### PR TITLE
Make logging API a little generic

### DIFF
--- a/redant_libs/support_libs/logging.md
+++ b/redant_libs/support_libs/logging.md
@@ -1,0 +1,41 @@
+# Redant Logging.
+
+Redant logging is achieved with the help of the `Logger` class which currently
+consists of three methods,
+1. set_logging_options
+2. rlog
+3. get_logger_handle
+
+Wherein the set_logging_options and get_logger_handle are static methods while
+rlog is a class method. The current design is a little convoluted as it exposes
+the logger object to the outside world which has to be rectified. If one looks
+into the class we have a `has a` relation between our logger object and the 
+logger class. ( I admit this isn't the best way. So, when you are reading this
+do see a big NEON light todo..)
+
+Following are certain design decisions taken,
+1. The default logging level be it during the intitialization or logging is Info
+as statistically speaking that is what would happen most of the time. Hence 
+whoever calls the methods, `set_logging_options` and `rlog` can skip the final
+parameter i.e. the log-level.
+2. The log levels to be used by the user while invoking the methods are as follows,
+
+	| Log level | Parameter |
+	|:---------:|:---------:|
+	|   Debug   |    'D'	|
+	|   Info    |    'I'	|
+	|   Error   |    'E'    |
+	|   Warning |    'W'    |
+        |   Critical |   'C'    |
+
+3. One important design consideration is the usage of the logger APIs. Now the usual 
+way is to invoke logger.debug or logger.info depending on the logging levels, but
+this seems to be a little less generic, so `rlog` was created to handle this.
+ A user using the logger function would just need to invoke `rlog(<log_message>, <log_level>)`
+ The internal mapping to the logger's API calls will be done by rlog with the help of
+a dictionary.
+
+# TODO:
+1. Making the logger more object oriented. Re-think the current design of how
+the class is.
+        

--- a/redant_libs/support_libs/relog.py
+++ b/redant_libs/support_libs/relog.py
@@ -3,10 +3,12 @@ import logging.handlers
 
 
 logger = logging.getLogger(__name__)
-class Logging:
+class Logger:
 
+    log_function_mapping = {'I' : logger.info, 'D' : logger.debug, 'W' : logger.warning,
+                            'E' : logger.error, 'C': logger.critical}
     @staticmethod
-    def set_logging_options(log_file_path="/tmp/redant.log", log_file_level="I"):
+    def set_logging_options(log_file_path: str="/tmp/redant.log", log_file_level: str="I"):
         """
         This function is for configuring the logger
         """
@@ -25,6 +27,10 @@ class Logging:
         log_file_handler.setFormatter(log_format)
         logger.addHandler(log_file_handler)
         return logger
+
+    @classmethod
+    def rlog(cls, log_message: str, log_level: str='I'):
+        cls.log_function_mapping[log_level](log_message)
 
     @staticmethod
     def get_logger_handle():

--- a/redant_libs/support_libs/rexe.py
+++ b/redant_libs/support_libs/rexe.py
@@ -3,7 +3,7 @@ import concurrent.futures
 import paramiko
 import yaml
 import xmltodict
-from redant_libs.support_libs.relog import logger  
+from redant_libs.support_libs.relog import Logger  
 
 def is_file_accessible(path, mode='rw+'):
     """
@@ -25,7 +25,7 @@ class Rexe:
         self.parse_conf_file()
         if command_file_path != "":
             self.parse_exec_file()
-        logger.debug(f"Conf file data : {self.conf_data}")
+        Logger.rlog(f"Conf file data : {self.conf_data}", 'D')
 
     def parse_conf_file(self):
         """
@@ -43,18 +43,18 @@ class Rexe:
         """
         Function to parse the exec file
         """
-        logger.debug("Parsing exec file")
+        Logger.rlog("Parsing exec file", 'D')
         self.exec_file_handle = open(self.command_file_path)
         self.exec_data = yaml.load(self.exec_file_handle, Loader=yaml.FullLoader)
         self.conf_file_handle.close()
-        logger.debug(f"Exec file data : {self.exec_data}")
+        Logger.rlog(f"Exec file data : {self.exec_data}", 'D')
 
     def establish_connection(self):
         """
         Function to establish connection with the given
         set of hosts.
         """
-        logger.debug("establish connection")
+        Logger.rlog("establish connection", 'D')
         self.node_dict = {}
         self.connect_flag = True
         
@@ -63,9 +63,9 @@ class Rexe:
             node_ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             try:
                 node_ssh_client.connect(hostname=node, username=self.host_user, password=self.host_passwd)
-                logger.debug(f"SSH connection to {node} is successful.")
+                Logger.rlog(f"SSH connection to {node} is successful.", 'D')
             except paramiko.ssh_exception.AuthenticationException:
-                logger.error("Authentication failure. Please check conf.")
+                Logger.rlog("Authentication failure. Please check conf.", 'E')
                 self.connect_flag = False
             self.node_dict[node] = node_ssh_client
 
@@ -95,7 +95,7 @@ class Rexe:
         ret_dict['cmd'] = cmd
         ret_dict['error_code'] = stdout.channel.recv_exit_status()
         
-        logger.debug(ret_dict)
+        Logger.rlog(ret_dict, 'D')
         return ret_dict
 
     def execute_command_multinode(self, node_list, cmd):
@@ -111,7 +111,7 @@ class Rexe:
                     ret_val.append(future_handle.result())
                 except Exception as exc:
                     print(f"Generated exception : {exc}")
-        logger.info(ret_val)
+        Logger.rlog(ret_val)
         return ret_val
 
     def execute_command_file(self):
@@ -123,7 +123,7 @@ class Rexe:
             return -1
         for command_node in self.exec_data:
             if command_node not in self.host_list and command_node not in self.host_generic:
-                logger.info(f"The command node {command_node} is not in host list.")
+                Logger.rlog(f"The command node {command_node} is not in host list.")
                 continue
             commands_list = self.exec_data[command_node]
             if command_node == 'allp':

--- a/thread_runner.py
+++ b/thread_runner.py
@@ -4,7 +4,7 @@ The thread runner is responsible for the execution of a given TC.
 import inspect
 import importlib
 import argparse
-from redant_libs.support_libs.relog import Logging
+from redant_libs.support_libs.relog import Logger
 from redant_libs.support_libs.rexe import Rexe
 
 if __name__ == "__main__":
@@ -21,10 +21,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Create the logger object.
-    logger = Logging.set_logging_options(args.log_path, args.log_level)
+    logger = Logger.set_logging_options(args.log_path, args.log_level)
 
     # Create remote connection with the servers and clients.
-    logger.debug("Creating the remote connection")
+    Logger.rlog("Creating the remote connection", 'D')
     remote_executor = Rexe(args.conf_path)
     remote_executor.establish_connection()
 


### PR DESCRIPTION
Changes:
1. Added a new method `rlog` to handle the generic way
of calls to logging. It takes two arguments of type string,
log_message and log_level wherein the default log_level is Info.
2. Modified the thread_runner and rexe with the logging changes.
3. Added logging.md to put out the design considerations.

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>