### PR TITLE
remote_exec class variable changed to redant

### DIFF
--- a/tests/glusterd_start_stop_test.py
+++ b/tests/glusterd_start_stop_test.py
@@ -10,15 +10,17 @@ class TestCase:
     for glusterd service operations
     """
 
-    def __init__(self, remote_exec: object):
+    def __init__(self, redant: object):
         """
-        This init function initializes the remote_exec
+        This init function initializes the redant
         class variable which is mixin object passed as a
         reference by runner_thread.
         Args:
-            remote_exec (object): mixin object passed as reference.
+            redant (object): mixin object passed as reference.
+                             Point of contact for the redant
+                             framework.
         """
-        self.remote_exec = remote_exec
+        self.redant = redant
 
     def gluster_start_stop_test(self):
         """
@@ -28,8 +30,8 @@ class TestCase:
         """
         try:
             for _ in range(10):
-                self.remote_exec.gluster_start("10.70.43.63")
-                self.remote_exec.gluster_stop("10.70.43.63")
+                self.redant.gluster_start("10.70.43.63")
+                self.redant.gluster_stop("10.70.43.63")
             print("Test Passed")
 
         except Exception as error:

--- a/tests/sample_test.py
+++ b/tests/sample_test.py
@@ -1,0 +1,39 @@
+"""
+This file contains the format of a test case.
+It contains one class - TestCase wich would
+hold the functions to be run in the test case.
+"""
+
+
+class TestClass:
+
+    """
+    The TestCase class contains the functionsto be
+    run in the test case. Every function should contain
+    the flow of the function(APIs which are called) in
+    the form of steps.
+    """
+
+    def __init__(self, redant: object):
+        """
+        Initializer which provides a point of contact to the
+        redant framework.
+        Args:
+            redant (object): mixin object passed as reference.
+                             Point of contact for the redant
+                             framework.
+        """
+        self.redant = redant
+
+    @classmethod
+    def test_fn(cls):
+        """
+        Function calling required APIs for performing required test.
+        Steps:
+        1) calling API1
+        2) calling API2
+        """
+        try:
+            print("Hello world!")
+        except Exception as error:
+            print(f"Exception: {error}")

--- a/tests/test_sample_tc.py
+++ b/tests/test_sample_tc.py
@@ -1,8 +1,0 @@
-class test_class:
-
-    def __init__(self, remote_exec):
-        self.remote_exec = remote_exec
-
-    @classmethod
-    def test_fn(cls):
-        print("Hello world!")

--- a/tests/volume_create_delete_test.py
+++ b/tests/volume_create_delete_test.py
@@ -10,15 +10,17 @@ class TestCase:
     for volume creation and deletion
     """
 
-    def __init__(self, remote_exec: object):
+    def __init__(self, redant: object):
         """
-        This init function initializes the remote_exec
+        This init function initializes the redant
         class variable which is mixin object passed as a
         reference by runner_thread.
         Args:
-            remote_exec (object): mixin object passed as reference.
+            redant (object): mixin object passed as reference.
+                             Point of contact for the redant
+                             framework.
         """
-        self.remote_exec = remote_exec
+        self.redant = redant
 
     def volume_create_delete_test(self):
         """
@@ -30,14 +32,14 @@ class TestCase:
         """
         try:
 
-            self.remote_exec.gluster_start("10.70.43.63")
+            self.redant.gluster_start("10.70.43.63")
 
-            self.remote_exec.volume_create("10.70.43.63", "test-vol",
-                                           ["10.70.43.63:/brick1"],
-                                           force=True)
-            self.remote_exec.volume_delete("10.70.43.63", "test-vol")
+            self.redant.volume_create("10.70.43.63", "test-vol",
+                                      ["10.70.43.63:/brick1"],
+                                      force=True)
+            self.redant.volume_delete("10.70.43.63", "test-vol")
 
-            self.remote_exec.gluster_stop("10.70.43.63")
+            self.redant.gluster_stop("10.70.43.63")
             print("Test Passed")
 
         except Exception as error:


### PR DESCRIPTION
The remote_exec class variable has been changed to
redant which refers to the mixin object passed as reference
to the test case and forms a point of contact to the redant
framework from the test case.

Fixes: #106
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>