### PR TITLE
/tmp : wrong path for log file

### DIFF
--- a/redant_test_runner.py
+++ b/redant_test_runner.py
@@ -26,7 +26,7 @@ class TestRunner:
             runner_thread_obj = RunnerThread(tc_class,
                                              cls.mach_conn_dict["clients"],
                                              cls.mach_conn_dict["servers"],
-                                             "/tmp", 'I')
+                                             "/tmp/redant.log", 'I')
             value = runner_thread_obj.run_thread()
             print(value)
         for test in cls.test_run_dict["disruptive"]:


### PR DESCRIPTION
Updated the log path for nonDisruptive condition.
Was raising error:
```js
IsADirectoryError: [Errno 21] Is a directory
```
Fixes: #123
Signed-off-by: aujjwal-redhat <aujjwal@redhat.com>
