### PR TITLE
Logging re-structurized

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,22 @@ tests: holds the test cases. Add any new test cases here.<br>
 6. To run the sample TC, just run the below cmd after populating the
 config file with relevant values.
 `python3 redant_test_main.py -c parsing/config.yml -t tests/example/`
-7. Log files can be found at /tmp/redant.log [ default path ]. For more options, run `python3 redant_test_main.py --help`
+7. Log files can be found at /tmp/redant.log [ default path ].
+For more options, run `python3 redant_test_main.py --help`
+
+The logging is specific to a TC run. So when a user gives a specific base dir
+for logging when invoking `redant_test__main.py`, that directory will inturn
+contain the following dirs,
+ -> functional
+ -> performance
+ -> example
+
+Now, based on the invocation, directory of a component will be created inside
+the functional and performace dirs. And inside the component directory,
+the Test case specific directory will be created which inturn will contain
+volume specific log files.
+So for example to see the log files of a test case which is,
+`tests/functional/glusterd/test_sample_glusterd.py`
+one would have to go to the directory,
+`<base_log_dir>/functional/glusterd/test_sample_glusterd/`, which will inturn
+contain the log files specific to volume type.

--- a/redant_libs/support_libs/relog.py
+++ b/redant_libs/support_libs/relog.py
@@ -8,26 +8,18 @@ import logging
 import logging.handlers
 
 
-LOGGER = logging.getLogger(__name__)
-
-
-# pylint: disable=W0603
-class Logger:
+class Logger(logging.Logger):
     """
     The framework's logger class. It handles three levels of logging
-    Info, Debug and Error. Having a has-a relationship curently with the logger
-    object and wrapping it's functionalities.
+    Info, Debug and Error.
     """
-    log_function_mapping = {'I': LOGGER.info, 'D': LOGGER.debug,
-                            'E': LOGGER.error}
 
-    @staticmethod
-    def set_logging_options(log_file_path: str = "/tmp/redant.log",
-                            log_file_level: str = "I"):
+    def init_logger(self, mname: str, log_file_path: str,
+                 log_file_level: str = "I"):
         """
         This function is for configuring the logger
         """
-        global LOGGER
+        self.logger = logging.getLogger(mname)
         valid_log_level = ['I', 'D', 'E']
         log_level_dict = {'I': logging.INFO, 'D': logging.DEBUG,
                           'E': logging.ERROR}
@@ -37,25 +29,19 @@ class Logger:
         if log_file_level not in valid_log_level:
             print("Invalid log level given, Taking Log Level as Info.")
             log_file_level = 'I'
-        LOGGER.setLevel(log_level_dict[log_file_level])
+        self.logger.setLevel(log_level_dict[log_file_level])
         log_file_handler = logging.handlers.WatchedFileHandler(log_file_path)
         log_file_handler.setFormatter(log_format)
-        LOGGER.addHandler(log_file_handler)
-        return LOGGER
+        self.logger.addHandler(log_file_handler)
+        self.log_function_mapping = {'I': self.logger.info,
+                                     'D': self.logger.debug,
+                                     'E': self.logger.error}
 
-    @classmethod
-    def rlog(cls, log_message: str, log_level: str = 'I'):
+    def rlog(self, log_message: str, log_level: str = 'I'):
         """
         Logger function used across the framework for logging.
         Created in a way so that people only have to deal with one
         single logger function istead of multiple as is the default
         manner.
         """
-        cls.log_function_mapping[log_level](log_message)
-
-    @staticmethod
-    def get_logger_handle():
-        """
-        Getter function for logging.
-        """
-        return LOGGER
+        self.log_function_mapping[log_level](log_message)

--- a/redant_test_runner.py
+++ b/redant_test_runner.py
@@ -2,6 +2,8 @@
 The test runner is responsible for handling the list of TCs
 to be run and invoking them.
 """
+import uuid
+from colorama import Fore, Style
 from runner_thread import RunnerThread
 
 class TestRunner:
@@ -12,28 +14,46 @@ class TestRunner:
     """
 
     @classmethod
-    def init(cls, test_run_dict, mach_conn_dict, base_log_path="/tmp"):
+    def init(cls, test_run_dict: dict, mach_conn_dict: dict,
+             base_log_path: str, log_level: str):
         cls.test_run_dict = test_run_dict
         cls.mach_conn_dict = mach_conn_dict
+        cls.base_log_path = base_log_path
+        cls.log_level = log_level
 
     @classmethod
     def run_tests(cls):
-        # TODO add logic to parse the test_run_dict to run tests.
-        # Currently for testing the logical flow, hardcoding the calls
-        # Running non-disruptive cases first.
+        # TODO Concurrency to be added based on the test types.
         for test in cls.test_run_dict["nonDisruptive"]:
-            tc_class = cls.test_run_dict["nonDisruptive"][test]["testClass"]
-            runner_thread_obj = RunnerThread(tc_class,
-                                             cls.mach_conn_dict["clients"],
-                                             cls.mach_conn_dict["servers"],
-                                             "/tmp", 'I')
-            value = runner_thread_obj.run_thread()
-            print(value)
+            print(test)
+            tc_class = test["testClass"]
+            for volume in test["volType"]:
+                tc_log_path = cls.base_log_path+test["modulePath"][5:-3]+"/"+\
+                    test["moduleName"][:-3]+"-"+volume+".log"
+                runner_thread_obj = RunnerThread(str(uuid.uuid1().int), tc_class,
+                                                 cls.mach_conn_dict["clients"],
+                                                 cls.mach_conn_dict["servers"],
+                                                 volume, tc_log_path,
+                                                 cls.log_level)
+                value = runner_thread_obj.run_thread()
+                result_text = test["moduleName"][:-3]+"-"+volume
+                if value:
+                    result_text += " FAIL"
+                    print(Fore.RED + result_text)
+                    print(Style.RESET_ALL)
         for test in cls.test_run_dict["disruptive"]:
-            tc_class = cls.test_run_dict["disruptive"][test]["testClass"]
-            runner_thread_obj = RunnerThread(tc_class,
-                                             cls.mach_conn_dict["clients"],
-                                             cls.mach_conn_dict["servers"],
-                                             "/tmp/redant.log", 'I')
-            value = runner_thread_obj.run_thread()
-            print(value)
+            tc_class = test["testClass"]
+            for volume in test["volType"]:
+                tc_log_path = cls.base_log_path + test["modulePath"][5:-3]+"/"+\
+                    test["moduleName"][:-3]+"-"+volume+".log"
+                runner_thread_obj = RunnerThread(str(uuid.uuid1().int), tc_class,
+                                                 cls.mach_conn_dict["clients"],
+                                                 cls.mach_conn_dict["servers"],
+                                                 volume, tc_log_path,
+                                                 cls.log_level)
+                value = runner_thread_obj.run_thread()
+                result_text = test["moduleName"][:-3]+"-"+volume
+                if value:
+                    result_text += " PASS"
+                    print(Fore.GREEN + result_text)
+                    print(Style.RESET_ALL)

--- a/redant_test_runner.py
+++ b/redant_test_runner.py
@@ -25,7 +25,6 @@ class TestRunner:
     def run_tests(cls):
         # TODO Concurrency to be added based on the test types.
         for test in cls.test_run_dict["nonDisruptive"]:
-            print(test)
             tc_class = test["testClass"]
             for volume in test["volType"]:
                 tc_log_path = cls.base_log_path+test["modulePath"][5:-3]+"/"+\
@@ -38,6 +37,10 @@ class TestRunner:
                 value = runner_thread_obj.run_thread()
                 result_text = test["moduleName"][:-3]+"-"+volume
                 if value:
+                    result_text += " PASS"
+                    print(Fore.GREEN + result_text)
+                    print(Style.RESET_ALL)
+                else:
                     result_text += " FAIL"
                     print(Fore.RED + result_text)
                     print(Style.RESET_ALL)
@@ -56,4 +59,8 @@ class TestRunner:
                 if value:
                     result_text += " PASS"
                     print(Fore.GREEN + result_text)
+                    print(Style.RESET_ALL)
+                else:
+                    result_text += " FAIL"
+                    print(Fore.RED + result_text)
                     print(Style.RESET_ALL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ flake8==3.9.0
 autopep8==1.5.5
 pylint==2.7.2
 comment-parser==1.2.3
+colorama==0.4.4

--- a/runner_thread.py
+++ b/runner_thread.py
@@ -8,10 +8,12 @@ class RunnerThread:
     invoking a TC, creating the TC object and then invoking the required
     functions for running it.
     """
-    def __init__(self, tc_class, client_list, server_list, log_path,
-                 log_level):
+    def __init__(self, mname: str, tc_class, client_list: list,
+                 server_list: list, volume_type: str, log_path: str,
+                 log_level: str):
         # Creating the test case object from the test case.
-        self.tc_obj = tc_class(client_list, server_list, log_path, log_level)
+        self.tc_obj = tc_class(mname, client_list, server_list, volume_type,
+                               log_path, log_level)
         self.run_test_func = getattr(self.tc_obj, "run_test")
         self.terminate_test_func = getattr(self.tc_obj, "terminate")
 

--- a/tests/example/sample_component/test_sample.py
+++ b/tests/example/sample_component/test_sample.py
@@ -17,7 +17,7 @@ class TestClass(ParentTest):
     the form of steps.
     """
 
-    def test_fn(self):
+    def run_test(self):
         """
         Function calling required APIs for performing required test.
         Steps:

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -10,7 +10,8 @@ class ParentTest:
 
     """
 
-    def __init__(self, client_list: list, server_list: list, log_path: str, log_level: str = 'I'):
+    def __init__(self, mname: str, client_list: list, server_list: list,
+                 volume_type: str, log_path: str, log_level: str = 'I'):
         """
         Creates volume
         And runs the specific component in the
@@ -20,12 +21,13 @@ class ParentTest:
         self.TEST_RES = True
         self.client_list = client_list
         self.server_list = server_list
-        self._configure(log_path, log_level)
+        self.volume_type = volume_type
+        self._configure(mname, log_path, log_level)
 
-    def _configure(self, log_path: str, log_level: str):
+    def _configure(self, mname: str, log_path: str, log_level: str):
         machines = self.client_list + self.server_list
         self.redant = RedantMixin(machines)
-        self.redant.set_logging_options(log_path, log_level)
+        self.redant.init_logger(mname, log_path, log_level)
         self.redant.establish_connection()
 
 


### PR DESCRIPTION
1. Logging class cleaned up.
2. Logging of TCs in their respective log files.
3. The logging dir structure resembles the TC
structure.
4. Added flag for specific test run but not
handled.
5. Test run based on multiple volume types
handled.
6. Output of redant_test_runner improved.

Fixes: #121
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in redant_libs/support_libs
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->