### PR TITLE
Underscore is removed from hostname

### DIFF
--- a/parsing/CONFIG_README.md
+++ b/parsing/CONFIG_README.md
@@ -10,8 +10,8 @@ service and provide a storage environment to which the clients mount their
 filesystem.
 A single server in the config file has to be specified with a reference name 
 followed by ip address in the following way:<br>
-`&server_vm1 0.0.0.0`<br>
-server_vm1 is a reference to its ip address which can be used to refer to its 
+`&server-vm1 0.0.0.0`<br>
+server-vm1 is a reference to its ip address which can be used to refer to its 
 ip address in the further config file or in the test cases. 1 should be replaced
 by other integers in the increasing order while specifying further servers
 

--- a/parsing/config.yml
+++ b/parsing/config.yml
@@ -4,14 +4,14 @@ log_file: /var/log/tests/gluster_tests.log
 # This section has to be defined.
 # Below x denotes integer
 # server-vm[x] has to be replaced by ip-address
-# server_vm[x] can be used to refer to its ip-address in this file using
-# *server_vm[x] wherever required and can also be used in test cases using 
-# just "server_vm[x]"
+# server-vm[x] can be used to refer to its ip-address in this file using
+# *server-vm[x] wherever required and can also be used in test cases using 
+# just "server-vm[x]"
 servers:
-    - &server_vm1 server-vm1 #Example- &server_vm1 0.0.0.0
-    - &server_vm2 server-vm2
-    - &server_vm3 server-vm3
-    - &server_vm4 server-vm4
+    - &server-vm1 server-vm1 #Example- &server-vm1 0.0.0.0
+    - &server-vm2 server-vm2
+    - &server-vm3 server-vm3
+    - &server-vm4 server-vm4
 
 # 'clients' is list of Hostnames/IP's of clients in the cluster.
 # This section has to be defined.
@@ -31,19 +31,19 @@ clients:
 # This section has to be defined.
 
 servers_info:
-    *server_vm1: &server1
+    *server-vm1: &server1
         brick_root: ["/bricks"] #Example- brick_root: ["/bricks","/gluster"]
         user: "root"
         passwd: "redhat"
-    *server_vm2: &server2
+    *server-vm2: &server2
         brick_root: ["/bricks"]
         user: "root"
         passwd: "redhat"
-    *server_vm3: &server3
+    *server-vm3: &server3
         brick_root: ["/bricks"]
         user: "root"
         passwd: "redhat"
-    *server_vm4: &server4
+    *server-vm4: &server4
         brick_root: ["/bricks"]
         user: "root"
         passwd: "redhat"
@@ -144,12 +144,12 @@ gluster:
         - &vol1
             name: testvol
             voltype: *distributed_dispersed
-            servers: [ *server_vm1, *server_vm2, *server_vm3, *server_vm4 ]
+            servers: [ *server-vm1, *server-vm2, *server-vm3, *server-vm4 ]
 
     # 'extra_servers' - To be used in case of add new servers to the cluster
     #                   in case of add-brick, replace-brick, attach-tier etc.
-            #extra_servers: [ *server_vm9, *server_vm10,
-            #                 *server_vm11, *server_vm12 ]
+            #extra_servers: [ *server-vm9, *server-vm10,
+            #                 *server-vm11, *server-vm12 ]
 
     # 'tier' -  Tiering related info. set 'create_tier' to 'true' to attach
     #           tier during volume setup when the tests calls glusto-tests
@@ -219,7 +219,7 @@ gluster:
     mounts:
         - &mount1
             protocol: 'glusterfs'
-            server: *server_vm1
+            server: *server-vm1
             volname: testvol
             client:
                 host: *client_vm1
@@ -227,7 +227,7 @@ gluster:
             options: ''
         - &mount2
             protocol: 'nfs'
-            server: *server_vm1
+            server: *server-vm1
             volname: testvol
             client:
                 host: *client_vm2

--- a/parsing/redant_params_handler.py
+++ b/parsing/redant_params_handler.py
@@ -30,11 +30,11 @@ class ParamsHandler:
         Gives the server ip given the server name
         Args:
             server_name: name of the server as in config file.
-                         example: server_vm1
+                         example: server-vm1
         Returns:
             str: ip address of the given server
         Example:
-            get_server_ip("server_vm1")
+            get_server_ip("server-vm1")
         """
         index = server_name[9:]
         server_ip = cls.config_hashmap['servers'][int(index)-1]
@@ -86,13 +86,13 @@ class ParamsHandler:
         {
             servers: [
                         {
-                            "hostname" : server_vm1
+                            "hostname" : server-vm1
                             "ip" : 10.4.28.93
                             "user" : root
                             "passwd" : redhat
                         },
                         {
-                            "hostname" : server_vm2
+                            "hostname" : server-vm2
                             "ip" : 23.43.12.87
                             "user" : root
                             "passwd" : redhat
@@ -128,7 +128,7 @@ class ParamsHandler:
 
         for i, ip in enumerate(servers_ip_list):
             servers_info = {}
-            servers_info["hostname"] = f"server_vm{i+1}"
+            servers_info["hostname"] = f"server-vm{i+1}"
             servers_info["ip"] = ip
             servers_info["user"] = s_info[ip]["user"]
             servers_info["passwd"] = s_info[ip]["passwd"]
@@ -152,11 +152,11 @@ class ParamsHandler:
         Returns the list of brick root given the server name
         Args:
             server_name (str): name of the server as in config file.
-                         example: server_vm1
+                         example: server-vm1
         Returns:
             list: list of brick root of the given server
         Example:
-            get_brick_root_list("server_vm1")
+            get_brick_root_list("server-vm1")
         """
         server_ip = cls.get_server_ip(server_name)
         servers_info = cls.config_hashmap['servers_info']


### PR DESCRIPTION
Underscore is replaced by hiphen in hostname

Fixes: #132
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>