### PR TITLE
Gluster-ops enhancement

### DIFF
--- a/support/ops/gluster_ops/gluster_ops.py
+++ b/support/ops/gluster_ops/gluster_ops.py
@@ -3,7 +3,7 @@ This file contains one class - GlusterOps wich holds
 operations on the glusterd service on the server
 or the client.
 """
-
+from time import sleep
 
 class GlusterOps:
     """
@@ -11,45 +11,125 @@ class GlusterOps:
     the glusterd service on either the client or the sever.
     """
 
-    def glusterd_start(self, node: str):
+    def start_glusterd(self, node, enable_retry: bool=True):
         """
-        Starts the glusterd service on the specified node.
+        Starts the glusterd service on the specified node or nodes.
         Args:
-            node (str): The node on which the glusterd service
-                        is to be started.
+            node (str|list): The node(s) on which the glusterd service
+                             is to be started.
         """
-        cmd = "systemctl start glusterd"
+        cmd_fail = False
+        error_msg = ""
+        if not isinstance(node, list):
+            node = [node]
+
+        cmd = "pgrep glusterd || systemctl start glusterd"
 
         self.rlog(f"Running {cmd} on {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command_multinode(node, cmd)
 
-        if int(ret['error_code']) != 0:
-            self.rlog(ret['error_msg'], 'E')
-            raise Exception(ret['error_msg'])
+        for result_val in ret:
+            if int(result_val['error_code']) != 0:
+                error_msg = result_val['error_msg']
+                self.rlog(error_msg, 'E')
+                cmd_fail = True
+                break
+
+        if cmd_fail and enable_retry:
+            self.reset_failed_glusterd(node)
+            self.start_glusterd(node)
+        elif cmd_fail:
+            raise Exception(error_msg)
 
         self.rlog(f"Successfully ran {cmd} on {node}")
 
-    def glusterd_stop(self, node: str):
+    def restart_glusterd(self, node: str, enable_retry: bool=True):
         """
-        Stops the glusterd service on the specified node.
+        Restarts the glusterd service on the specified node or nodes.
         Args:
-            node (str): The node on which the glusterd service
+            node (str|list): The node(s) on which the glusterd service
+                             is to be restarted.
+        """
+        cmd_fail = False
+        error_msg = ""
+        if not isinstance(node, list):
+            node = [node]
+
+        cmd = "systemctl restart glusterd"
+
+        self.rlog(f"Running {cmd} on {node}")
+
+        ret = self.execute_command_multinode(node, cmd)
+
+        for result_val in ret:
+            if int(result_val['error_code']) != 0:
+                error_msg = result_val['error_msg']
+                self.rlog(error_msg, 'E')
+                cmd_fail = True
+                break
+
+        if cmd_fail and enable_retry:
+            self.reset_failed_glusterd(node)
+            self.restart_glusterd(node)
+        elif cmd_fail:
+            raise Exception(error_msg)
+
+        self.rlog(f"Successfully ran {cmd} on {node}")
+
+    def stop_glusterd(self, node):
+        """
+        Stops the glusterd service on the specified node(s).
+        Args:
+            node (str|list): The node on which the glusterd service
                         is to be stopped.
         """
         cmd = "systemctl stop glusterd"
 
+        if not isinstance(node, list):
+            node = [node]
+
         self.rlog(f"Running {cmd} on {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command_multinode(node, cmd)
 
-        if int(ret['error_code']) != 0:
-            self.rlog(ret['error_msg'], 'E')
-            raise Exception(ret['error_msg'])
+        for result_val in ret:
+            if int(result_val['error_code']) != 0:
+                self.rlog(result_val['error_msg'], 'E')
+                raise Exception(result_val['error_msg'])
 
         self.rlog(f"Successfully ran {cmd} on {node}")
 
-    def is_glusterd_active(self, node: str) -> bool:
+    def reset_failed_glusterd(self, node) -> bool:
+        """
+        Glusterd has a burst limit of 5 times, hence TCs will
+        start failing after the TC breach this limit. Systemd has
+        the feature to reset the limit which is of the form,
+        `systemctl reset-failed <daemon-process-name>`
+
+        Args:
+            node (str|list): A node or list of nodes on which glusterd
+            reset-failed has to be run.
+
+        Returns:
+            bool: True if successful on all servers or false.
+        """
+        if not isinstance(node, list):
+            node = [node]
+
+        cmd = "systemctl reset-failed glusterd"
+
+        self.rlog(f"Running {cmd} on {node}")
+
+        ret = self.execute_command_multinode(node, cmd)
+        for result_val in ret:
+            if int(result_val['error_code']) != 0:
+                self.rlog(result_val['error_msg'], 'E')
+                raise Exception(result_val['error_msg'])
+
+        self.rlog(f"Successfully ran {cmd} on {node}")
+
+    def is_glusterd_running(self, node: str) -> bool:
         """
         Checks the status of the glusterd service on the
         specified node.
@@ -79,3 +159,53 @@ class GlusterOps:
 
         self.rlog(f"Successfully ran {cmd1} on {node}")
         return is_active
+
+    def wait_for_glusterd_to_start(self, node, timeout: int=80):
+        """
+        Checks if the glusterd has started already or waits for
+        it till the timeout is reached.
+
+        Args:
+            node (str|list): A node or list of nodes wherein this is
+            to be executed.
+            timeout (int) : We cannot wait till eternity right :p
+
+        Returns:
+            bool: True if glusterd is running on the node(s) or else False.
+        """
+        if not isinstance(node, list):
+            node = [node]
+
+        count = 0
+        while count <= timeout:
+            ret = is_glusterd_running(node)
+            if not ret:
+                return True
+            sleep(1)
+            count += 1
+        return False
+
+    # TODO: Handle command execution in such a manner that this doesn't
+    # go under xml version.
+    def get_gluster_version(self, node: str) -> str:
+        """
+        Checks the glusterfs version on the node.
+
+        Args:
+            node (str): Node wherein the gluster version is
+            checked.
+
+        Returns:
+            str: The gluster version value.
+        """
+        cmd = "gluster --version"
+        self.rlog(f"Running {cmd} on {node}")
+
+        ret = self.execute_command(node=node, cmd=cmd)
+
+        if int(ret['error_code']) != 0:
+            self.rlog(ret['error_msg'], 'E')
+            raise Exception(ret['error_msg'])
+
+        self.rlog("Successfully ran {cmd} on {node}")
+        return ret['msg'].split(' ')[1]

--- a/support/ops/gluster_ops/gluster_ops.py
+++ b/support/ops/gluster_ops/gluster_ops.py
@@ -178,7 +178,7 @@ class GlusterOps:
 
         count = 0
         while count <= timeout:
-            ret = is_glusterd_running(node)
+            ret = self.is_glusterd_running(node)
             if not ret:
                 return True
             sleep(1)

--- a/tests/functional/glusterd/test_glusterd_start_stop.py
+++ b/tests/functional/glusterd/test_glusterd_start_stop.py
@@ -2,7 +2,7 @@
 This file contains a test-case which tests glusterd
 starting and stopping of glusterd service.
 """
-#nonDisruptive;dist,rep,arb,disp
+#nonDisruptive;dist
 
 from tests.parent_test import ParentTest
 
@@ -19,11 +19,10 @@ class TestCase(ParentTest):
         1) glusterd service is started on the server.
         4) glusterd service is stopped.
         """
-        server = self.server_list[0]
         try:
             for _ in range(10):
-                self.redant.glusterd_start(server)
-                self.redant.glusterd_stop(server)
+                self.redant.start_glusterd(self.server_list)
+                self.redant.stop_glusterd(self.server_list)
             print("Test Passed")
 
         except Exception as error:


### PR DESCRIPTION
Following code changes have been handled:
1. Addition of reset-failed feature to
handle burst limit issue in glusterd.
2. Gluster ops functions enhanced
to handle multi server operations.
3. Two new functions added
    3.1 wait_for_glusterd_to_start
    3.2 get_gluster_version

Fixes: #161, #163

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in ops/support_ops
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
