### PR TITLE
Handle non volume TCs.

### DIFF
--- a/core/test_list_builder.py
+++ b/core/test_list_builder.py
@@ -228,7 +228,8 @@ class TestListBuilder:
         tc_flags = {}
         tc_flags["tcNature"] = flags.split(';')[0]
         tc_flags["volType"] = flags.split(';')[1].split(',')
-
+        if tc_flags["volType"] == ['']:
+            tc_flags["volType"] = ["Generic"]
         return tc_flags
 
     @classmethod


### PR DESCRIPTION
Now one, user can even push non volume TCs, i.e.
TC won't require to be linked to any particular
volume type. This leads to two scenarios,
1. A TC which doesn't even create volumes.
2. A TC which might go one to deal with
volumes of multiple times at a time.

Fixes: #162
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in ops/support_ops
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
