### PR TITLE
Logger doesn't reflect proper module and line number

### DIFF
--- a/support/ops/gluster_ops/gluster_ops.py
+++ b/support/ops/gluster_ops/gluster_ops.py
@@ -3,7 +3,6 @@ This file contains one class - GlusterOps wich holds
 operations on the glusterd service on the server
 or the client.
 """
-from time import sleep
 
 class GlusterOps:
     """
@@ -25,14 +24,14 @@ class GlusterOps:
 
         cmd = "pgrep glusterd || systemctl start glusterd"
 
-        self.rlog(f"Running {cmd} on {node}")
+        self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command_multinode(node, cmd)
 
         for result_val in ret:
             if int(result_val['error_code']) != 0:
                 error_msg = result_val['error_msg']
-                self.rlog(error_msg, 'E')
+                self.logger.error(error_msg)
                 cmd_fail = True
                 break
 
@@ -42,7 +41,7 @@ class GlusterOps:
         elif cmd_fail:
             raise Exception(error_msg)
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def restart_glusterd(self, node: str, enable_retry: bool=True):
         """
@@ -58,14 +57,14 @@ class GlusterOps:
 
         cmd = "systemctl restart glusterd"
 
-        self.rlog(f"Running {cmd} on {node}")
+        self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command_multinode(node, cmd)
 
         for result_val in ret:
             if int(result_val['error_code']) != 0:
                 error_msg = result_val['error_msg']
-                self.rlog(error_msg, 'E')
+                self.logger.error(error_msg)
                 cmd_fail = True
                 break
 
@@ -75,7 +74,7 @@ class GlusterOps:
         elif cmd_fail:
             raise Exception(error_msg)
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def stop_glusterd(self, node):
         """
@@ -89,16 +88,16 @@ class GlusterOps:
         if not isinstance(node, list):
             node = [node]
 
-        self.rlog(f"Running {cmd} on {node}")
+        self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command_multinode(node, cmd)
 
         for result_val in ret:
             if int(result_val['error_code']) != 0:
-                self.rlog(result_val['error_msg'], 'E')
+                self.logger.error(result_val['error_msg'])
                 raise Exception(result_val['error_msg'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def reset_failed_glusterd(self, node) -> bool:
         """
@@ -119,15 +118,15 @@ class GlusterOps:
 
         cmd = "systemctl reset-failed glusterd"
 
-        self.rlog(f"Running {cmd} on {node}")
+        self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command_multinode(node, cmd)
         for result_val in ret:
             if int(result_val['error_code']) != 0:
-                self.rlog(result_val['error_msg'], 'E')
+                self.logger.error(result_val['error_msg'])
                 raise Exception(result_val['error_msg'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def is_glusterd_running(self, node: str) -> bool:
         """
@@ -145,19 +144,19 @@ class GlusterOps:
         cmd1 = "systemctl status glusterd"
         cmd2 = "pidof glusterd"
 
-        self.rlog(f"Running {cmd1} on {node}")
+        self.logger.info(f"Running {cmd1} on {node}")
 
         ret = self.execute_command(node=node, cmd=cmd1)
 
         if int(ret['error_code']) != 0:
             is_active = 0
-            self.rlog(f"Running {cmd2} on {node}")
+            self.logger.info(f"Running {cmd2} on {node}")
             ret1 = self.execute_command(node=node, cmd=cmd2)
             if ret1['error_code'] == 0:
                 is_active = -1
-                self.rlog(f"Successfully ran {cmd2} on {node}")
+                self.logger.info(f"Successfully ran {cmd2} on {node}")
 
-        self.rlog(f"Successfully ran {cmd1} on {node}")
+        self.logger.info(f"Successfully ran {cmd1} on {node}")
         return is_active
 
     def wait_for_glusterd_to_start(self, node, timeout: int=80):
@@ -177,6 +176,7 @@ class GlusterOps:
             node = [node]
 
         count = 0
+        from time import sleep
         while count <= timeout:
             ret = self.is_glusterd_running(node)
             if not ret:
@@ -199,13 +199,13 @@ class GlusterOps:
             str: The gluster version value.
         """
         cmd = "gluster --version"
-        self.rlog(f"Running {cmd} on {node}")
+        self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['error_code']) != 0:
-            self.rlog(ret['error_msg'], 'E')
+            self.logger.error(ret['error_msg'])
             raise Exception(ret['error_msg'])
 
-        self.rlog("Successfully ran {cmd} on {node}")
+        self.logger.info("Successfully ran {cmd} on {node}")
         return ret['msg'].split(' ')[1]

--- a/support/ops/gluster_ops/peer_ops.py
+++ b/support/ops/gluster_ops/peer_ops.py
@@ -36,14 +36,14 @@ class peer_ops:
 
         cmd = f'gluster --xml peer probe {server}'
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
         ret = self.execute_command(node=node, cmd=cmd)
 
         if ret['error_code'] != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         return ret
 
     def peer_detach(self, node: str, server: str, force: bool = False):
@@ -75,14 +75,14 @@ class peer_ops:
             cmd = f"gluster --xml peer detach {server} force --mode=script"
         else:
             cmd = f"gluster --xml peer detach {server} --mode=script"
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
         ret = self.execute_command(node, cmd)
 
         if ret['error_code'] != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         return ret
 
     def peer_status(self, node: str):
@@ -108,15 +108,15 @@ class peer_ops:
 
         cmd = 'gluster --xml peer status'
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node, cmd)
 
         if ret['error_code'] != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         return ret
 
     def pool_list(self, node: str):
@@ -141,14 +141,14 @@ class peer_ops:
         """
 
         cmd = 'gluster --xml pool list'
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
         ret = self.execute_command(node, cmd)
 
         if ret['error_code'] != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         return ret
 
     def nodes_from_pool_list(self, node: str):
@@ -164,7 +164,7 @@ class peer_ops:
         pool_list_data = self.get_pool_list(node)
 
         if pool_list_data is None:
-            self.rlog("Unable to get Nodes")
+            self.logger.info("Unable to get Nodes")
 
         nodes = []
         for item in pool_list_data:
@@ -184,14 +184,14 @@ class peer_ops:
 
         cmd = 'gluster pool list --xml'
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
         ret = self.execute_command(node, cmd)
 
         if ret['error_code'] != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
         peer_dict = ret['msg']
 

--- a/support/ops/gluster_ops/volume_ops.py
+++ b/support/ops/gluster_ops/volume_ops.py
@@ -26,15 +26,15 @@ class VolumeOps:
 
         cmd = f"mount -t glusterfs {server}:/{volname} {path}"
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret["error_code"]) != 0:
-            self.rlog(ret["error_msg"], 'E')
+            self.logger.error(ret["error_msg"])
             raise Exception(ret["error_msg"])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         
     def volume_unmount(self, path: str, node: str=None):
         """
@@ -49,15 +49,15 @@ class VolumeOps:
         
         cmd = f"umount {path}"
         
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret["error_code"]) != 0:
-            self.rlog(ret["error_msg"], 'E')
+            self.logger.error(ret["error_msg"])
             raise Exception(ret["error_msg"])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         
 
     def volume_create(self, volname: str, bricks_list: list,
@@ -118,15 +118,15 @@ class VolumeOps:
         if force:
             cmd = cmd + " force"
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def volume_start(self, volname: str, node : str=None, force: bool = False):
         """
@@ -145,15 +145,15 @@ class VolumeOps:
         else:
             cmd = f"gluster volume start {volname} --mode=script --xml"
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def volume_stop(self, volname: str, node : str=None, force: bool = False):
         """
@@ -172,15 +172,15 @@ class VolumeOps:
         else:
             cmd = f"gluster volume stop {volname} --mode=script --xml"
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def volume_delete(self, volname: str,node : str=None):
         """
@@ -193,15 +193,15 @@ class VolumeOps:
 
         cmd = f"gluster volume delete {volname} --mode=script --xml"
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
     def get_volume_info(self, node : str=None, volname: str = 'all') -> dict:
         """
@@ -260,14 +260,14 @@ class VolumeOps:
 
         cmd = f"gluster volume info {volname} --xml"
 
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
 
         volume_info = ret['msg']['volInfo']['volumes']
         ret_dict = {}
@@ -317,15 +317,15 @@ class VolumeOps:
         """
         cmd = "gluster volume list --xml"
         
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
 
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         
         volume_list_count = int(ret['msg']['volList']['count'])
         volume_list = []
@@ -354,15 +354,15 @@ class VolumeOps:
         else:
             cmd = f"gluster volume reset {volname} --mode=script --xml"
             
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
         
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         
     def get_volume_status(self,node : str=None,volname : str='all',
                          service : str='',options : str='') -> dict:
@@ -413,15 +413,15 @@ class VolumeOps:
         
         cmd = f"gluster volume status {volname} {service} {options} --xml"
         
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
             
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         
         volume_status = ret['msg']['volStatus']['volumes']
         ret_dict = {}
@@ -485,15 +485,15 @@ class VolumeOps:
         
         cmd = f"gluster volume get {volname} {option} --mode=script --xml"
         
-        self.rlog(f"Running {cmd} on node {node}")
+        self.logger.info(f"Running {cmd} on node {node}")
             
         ret = self.execute_command(node=node, cmd=cmd)
  
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
         
         volume_options = ret['msg']['volGetopts']
         
@@ -531,27 +531,27 @@ class VolumeOps:
             for group_option in group_options:
                 cmd = (f"gluster volume set {volname} group {group_option} "
                         "--mode=script --xml")
-                self.rlog(f"Running {cmd} on node {node}")
+                self.logger.info(f"Running {cmd} on node {node}")
                     
                 ret = self.execute_command(node=node, cmd=cmd)
 
                 if int(ret['msg']['opRet']) != 0:
-                    self.rlog(ret['msg']['opErrstr'], 'E')
+                    self.logger.error(ret['msg']['opErrstr'])
                     raise Exception(ret['msg']['opErrstr'])
                     
 
         for option in volume_options:
             cmd = (f"gluster volume set {volname} {option} "
                    f"{volume_options[option]} --mode=script --xml")
-            self.rlog(f"Running {cmd} on node {node}")
+            self.logger.info(f"Running {cmd} on node {node}")
                 
             ret = self.execute_command(node=node, cmd=cmd)
 
             if int(ret['msg']['opRet']) != 0:
-                self.rlog(ret['msg']['opErrstr'], 'E')
+                self.logger.error(ret['msg']['opErrstr'])
                 raise Exception(ret['msg']['opErrstr'])
 
-            self.rlog(f"Successfully ran {cmd} on {node}")
+            self.logger.info(f"Successfully ran {cmd} on {node}")
         
     def reset_volume_option(self, volname : str, option : str,
                             node : str=None, force : bool=False):
@@ -574,13 +574,14 @@ class VolumeOps:
                    "--mode=script --xml")
         else:
             cmd = f"gluster volume reset {volname} {option} --mode=script --xml"
+        self.logger.info(f"Running {cmd} on node {node}")
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")
             
     def volume_sync(self, hostname : str, node: str, volname : str='all'):
         """
@@ -596,10 +597,11 @@ class VolumeOps:
         
         cmd = f"gluster volume sync {hostname} {volname} --mode=script --xml"
         
+        self.logger.info(f"Running {cmd} on node {node}")
         ret = self.execute_command(node=node, cmd=cmd)
 
         if int(ret['msg']['opRet']) != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {node}")

--- a/support/ops/support_ops/io_ops.py
+++ b/support/ops/support_ops/io_ops.py
@@ -19,11 +19,11 @@ class io_ops:
             host (str): The node in the cluster where the command is to be run
         '''
 
-        self.rlog(f"Running {cmd} on node {host}")
+        self.logger.info(f"Running {cmd} on node {host}")
         ret = self.execute_command(host, cmd)
 
         if ret['error_code'] != 0:
-            self.rlog(ret['msg']['opErrstr'], 'E')
+            self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.rlog(f"Successfully ran {cmd} on {host}")
+        self.logger.info(f"Successfully ran {cmd} on {host}")

--- a/support/ops/support_ops/relog.py
+++ b/support/ops/support_ops/relog.py
@@ -34,18 +34,6 @@ class Logger(logging.Logger):
         log_file_handler = logging.handlers.WatchedFileHandler(log_file_path)
         log_file_handler.setFormatter(log_format)
         self.logger.addHandler(log_file_handler)
-        self.log_function_mapping = {'I': self.logger.info,
-                                     'D': self.logger.debug,
-                                     'E': self.logger.error}
-
-    def rlog(self, log_message: str, log_level: str = 'I'):
-        """
-        Logger function used across the framework for logging.
-        Created in a way so that people only have to deal with one
-        single logger function istead of multiple as is the default
-        manner.
-        """
-        self.log_function_mapping[log_level](log_message)
 
     @classmethod
     def log_dir_creation(cls, path: str, component_dict: dict,

--- a/support/ops/support_ops/rexe.py
+++ b/support/ops/support_ops/rexe.py
@@ -18,7 +18,7 @@ class Rexe:
         Function to establish connection with the given
         set of hosts.
         """
-        self.rlog("establish connection", 'D')
+        self.logger.debug("establish connection")
         self.node_dict = {}
         self.connect_flag = True
 
@@ -31,9 +31,9 @@ class Rexe:
                     hostname=self.host_dict[node]['ip'],
                     username=self.host_dict[node]['user'],
                     password=self.host_dict[node]['passwd'])
-                self.rlog(f"SSH connection to {node} is successful.", 'D')
+                self.loger.debug(f"SSH connection to {node} is successful.")
             except Exception as e:
-                self.rlog(f"Connection failure. Exception : {e}", 'E')
+                self.logger.error(f"Connection failure. Exception : {e}")
                 self.connect_flag = False
             self.node_dict[node] = node_ssh_client
 
@@ -57,10 +57,10 @@ class Rexe:
                     hostname=self.host_dict[node]['ip'],
                     username=self.host_dict[node]['user'],
                     password=self.host_dict[node]['passwd'])
-                self.rlog(f"SSH connection to {node} is successful.", 'D')
+                self.logger.debug(f"SSH connection to {node} is successful.")
                 self.node_dict[node] = node_ssh_client
             except Exception as e:
-                self.rlog(f"Connection failure. Exception {e}", 'E')
+                self.logger.error(f"Connection failure. Exception {e}")
         if stdout.channel.recv_exit_status() != 0:
             ret_dict['Flag'] = False
             ret_dict['msg'] = stdout.readlines()
@@ -77,7 +77,7 @@ class Rexe:
         ret_dict['cmd'] = cmd
         ret_dict['error_code'] = stdout.channel.recv_exit_status()
 
-        self.rlog(ret_dict, 'D')
+        self.logger.debug(ret_dict)
         return ret_dict
 
     def execute_command_multinode(self, node_list, cmd):


### PR DESCRIPTION
This seems to be related to the fact that the logger
takes in the function and line number values from
where it is being executed and hence we cannot
delegate and generalize the logger functions by
calling them from a common location.

This might be something which works in languages
which go through a good level of compilation steps
but the same is not done in python. Hence reverting back
to the pythonic way of logging.

Fixes: #167
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in ops/support_ops
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
