### PR TITLE
[Testfix] Test failing with erraneous function calls.

### DIFF
--- a/support/ops/support_ops/rexe.py
+++ b/support/ops/support_ops/rexe.py
@@ -96,5 +96,5 @@ class Rexe:
                     ret_val.append(future_handle.result())
                 except Exception as exc:
                     print(f"Generated exception : {exc}")
-        self.rlog(ret_val)
+        self.logger.info(ret_val)
         return ret_val

--- a/tests/functional/glusterd/test_peer_probe_detach.py
+++ b/tests/functional/glusterd/test_peer_probe_detach.py
@@ -25,7 +25,7 @@ class TestCase(ParentTest):
             server1 = self.server_list[0]
             server2 = self.server_list[1]
 
-            self.redant.glusterd_start(server1)
+            self.redant.start_glusterd(server1)
 
             self.redant.peer_probe(server2, server1)
 
@@ -33,7 +33,7 @@ class TestCase(ParentTest):
 
             self.redant.peer_detach(server1, server2)
 
-            self.redant.glusterd_stop(server1)
+            self.redant.stop_glusterd(server1)
 
         except Exception as e:
             self.TEST_RES = False

--- a/tests/functional/glusterd/test_volume_create_delete.py
+++ b/tests/functional/glusterd/test_volume_create_delete.py
@@ -24,14 +24,14 @@ class TestCase(ParentTest):
         try:
             server = self.server_list[0]
 
-            self.redant.glusterd_start(server)
+            self.redant.start_glusterd(server)
 
             self.redant.volume_create(server, "test-vol",
                                       [f"{server}:/brick1"],
                                       force=True)
             self.redant.volume_delete(server, "test-vol")
 
-            self.redant.glusterd_stop(server)
+            self.redant.stop_glusterd(server)
             print("Test Passed")
 
         except Exception as error:


### PR DESCRIPTION
The test cases are failing because the latest changes
in the framework have not been incorporated in them.
Especially with start_glusterd and stop_glusterd.

Fixes: #169
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in ops/support_ops
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
