### PR TITLE
[Lib] Adding random execution handling in Rexe.

### DIFF
--- a/core/parsing/params_handler.py
+++ b/core/parsing/params_handler.py
@@ -30,10 +30,9 @@ class ParamsHandler:
         Gives the list of all server ip
         Returns:
             list: list of all server ip address
-        """ 
+        """
         server_ip_list = list(cls.config_hashmap['servers_info'].keys())
         return server_ip_list
-        
 
     @classmethod
     def get_client_ip_list(cls) -> list:
@@ -49,18 +48,18 @@ class ParamsHandler:
     def get_config_hashmap(cls) -> dict:
         """
         Returns the config hashmap which is parsed from
-        the config file 
+        the config file
         Returns:
             dict: dictionary consisting of servers info,
-                  clients info and volume types info. 
-            format of dictionary:
+                  clients info and volume types info.
+                  format of dictionary:
             {
                 servers_info: {
                                 "10.4.28.93": {
                                     "user" : root
                                     "passwd" : redhat
                                 },
-                                "23.43.12.87": { 
+                                "23.43.12.87": {
                                     "user" : root
                                     "passwd" : redhat
                                 }
@@ -112,10 +111,10 @@ class ParamsHandler:
                                     "transport": "tcp"
                                 }
                }
-               
+
             }
-        """   
-        
+        """
+
         return cls.config_hashmap
 
     @classmethod

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -13,6 +13,7 @@ from test_runner import TestRunner
 from result_handler import ResultHandler
 import time
 
+
 def pars_args():
     """
     Function to handle command line parsing for the redant.
@@ -85,7 +86,6 @@ def main():
     print(f"\nTotal time taken by the framework: {time.time()-start} sec")
 
     ResultHandler.handle_results(all_test_results, args.result_path)
-
 
 
 if __name__ == '__main__':

--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -8,6 +8,7 @@ framework
 from prettytable import PrettyTable
 from colorama import Fore, Style
 
+
 class ResultHandler:
 
     @classmethod
@@ -31,12 +32,15 @@ class ResultHandler:
                 cls.result += (Style.RESET_ALL+"\n")
             else:
                 cls.result += (item+'\n')
-            
-            table = PrettyTable(['Volume Type','Test Result','Time taken (sec)'])
+
+            table = PrettyTable(
+                ['Volume Type', 'Test Result', 'Time taken (sec)'])
             for each_vol_test in test_results[item]:
-                
-                table.add_row([each_vol_test['volType'], each_vol_test['testResult'],each_vol_test['timeTaken']])
-            
+
+                table.add_row(
+                    [each_vol_test['volType'], each_vol_test['testResult'],
+                     each_vol_test['timeTaken']])
+
             cls.result += (str(table)+"\n")
 
     @classmethod
@@ -53,7 +57,7 @@ class ResultHandler:
         print(cls.result)
 
     @classmethod
-    def _store_results(cls, test_results:dict, result_path: str):
+    def _store_results(cls, test_results: dict, result_path: str):
         """
         This function stores the test results
         in the form of tables in a file.
@@ -80,7 +84,7 @@ class ResultHandler:
         test_results: all the tests results
         result_path: path of the result file
         """
-        if result_path == None:
+        if result_path is None:
             cls._display_test_results(test_results)
         else:
             cls._store_results(test_results, result_path)

--- a/core/runner_thread.py
+++ b/core/runner_thread.py
@@ -2,6 +2,7 @@
 The thread runner is responsible for the execution of a given TC.
 """
 
+
 class RunnerThread:
     """
     Runner thread will be encapsulating the functionalities for generically
@@ -10,14 +11,14 @@ class RunnerThread:
     """
 
     def __init__(self, mname: str, tc_class, config_hashmap: dict,
-                 volume_type: str, log_path: str,log_level: str):
+                 volume_type: str, log_path: str, log_level: str):
         # Creating the test case object from the test case.
         self.tc_obj = tc_class(mname, config_hashmap, volume_type,
                                log_path, log_level)
         self.run_test_func = getattr(self.tc_obj, "parent_run_test")
         self.terminate_test_func = getattr(self.tc_obj, "terminate")
         self.test_stats = {
-            'timeTaken':0,
+            'timeTaken': 0,
             'volType': volume_type
         }
 

--- a/core/test_list_builder.py
+++ b/core/test_list_builder.py
@@ -29,7 +29,7 @@ class TestListBuilder:
                                  "example": set([])}
 
     @classmethod
-    def create_test_dict(cls, path: str, single_tc: bool=False) -> tuple:
+    def create_test_dict(cls, path: str, single_tc: bool = False) -> tuple:
         """
         This method creates a dict of TCs wrt the given directory
         path.
@@ -226,7 +226,7 @@ class TestListBuilder:
         """
         flags = str(extract_comments(tc_path, mime="text/x-python")[0])
         tc_flags = {}
-        tc_flags["tcNature"] = flags.split(';')[0]
+        tc_flags["tcNature"] = flags.split(';')[0].strip()
         tc_flags["volType"] = flags.split(';')[1].split(',')
         if tc_flags["volType"] == ['']:
             tc_flags["volType"] = ["Generic"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pylint==2.7.2
 comment-parser==1.2.3
 colorama==0.4.4
 prettytable==2.1.0
+multipledispatch==0.6.0

--- a/support/ops/gluster_ops/gluster_ops.py
+++ b/support/ops/gluster_ops/gluster_ops.py
@@ -4,13 +4,14 @@ operations on the glusterd service on the server
 or the client.
 """
 
+
 class GlusterOps:
     """
     GlusterOps class provides APIs to start and stop
     the glusterd service on either the client or the sever.
     """
 
-    def start_glusterd(self, node=None, enable_retry: bool=True):
+    def start_glusterd(self, node=None, enable_retry: bool = True):
         """
         Starts the glusterd service on the specified node or nodes.
         Args:
@@ -32,7 +33,6 @@ class GlusterOps:
             node = [node]
 
         cmd = "pgrep glusterd || systemctl start glusterd"
-
 
         if node is None:
             ret = self.execute_command_multinode(cmd)
@@ -61,7 +61,7 @@ class GlusterOps:
 
         return ret
 
-    def restart_glusterd(self, node: str, enable_retry: bool=True):
+    def restart_glusterd(self, node: str, enable_retry: bool = True):
         """
         Restarts the glusterd service on the specified node or nodes.
         Args:
@@ -83,7 +83,6 @@ class GlusterOps:
             node = [node]
 
         cmd = "systemctl restart glusterd"
-
 
         self.logger.info(f"Running {cmd} on {node}")
         self.logger.info(f"Running {cmd} on {node}")
@@ -219,7 +218,7 @@ class GlusterOps:
         self.logger.info(f"Successfully ran {cmd1} on {node}")
         return is_active
 
-    def wait_for_glusterd_to_start(self, node=None, timeout: int=80):
+    def wait_for_glusterd_to_start(self, node=None, timeout: int = 80):
         """
         Checks if the glusterd has started already or waits for
         it till the timeout is reached.

--- a/support/ops/gluster_ops/gluster_ops.py
+++ b/support/ops/gluster_ops/gluster_ops.py
@@ -10,7 +10,7 @@ class GlusterOps:
     the glusterd service on either the client or the sever.
     """
 
-    def start_glusterd(self, node, enable_retry: bool=True):
+    def start_glusterd(self, node=None, enable_retry: bool=True):
         """
         Starts the glusterd service on the specified node or nodes.
         Args:
@@ -28,14 +28,18 @@ class GlusterOps:
         """
         cmd_fail = False
         error_msg = ""
-        if not isinstance(node, list):
+        if not isinstance(node, list) and node is not None:
             node = [node]
 
         cmd = "pgrep glusterd || systemctl start glusterd"
 
-        self.logger.info(f"Running {cmd} on {node}")
 
-        ret = self.execute_command_multinode(node, cmd)
+        if node is None:
+            ret = self.execute_command_multinode(cmd)
+            self.logger.info(f"Running {cmd} on all nodes.")
+        else:
+            ret = self.execute_command_multinode(cmd, node)
+            self.logger.info(f"Running {cmd} on {node}")
 
         for result_val in ret:
             if int(result_val['error_code']) != 0:
@@ -50,7 +54,10 @@ class GlusterOps:
         elif cmd_fail:
             raise Exception(error_msg)
 
-        self.logger.info(f"Successfully ran {cmd} on {node}")
+        if node is None:
+            self.logger.info(f"Successfully ran {cmd} on all nodes")
+        else:
+            self.logger.info(f"Successfully ran {cmd} on {node}")
 
         return ret
 
@@ -72,14 +79,16 @@ class GlusterOps:
         """
         cmd_fail = False
         error_msg = ""
-        if not isinstance(node, list):
+        if not isinstance(node, list) and node is not None:
             node = [node]
 
         cmd = "systemctl restart glusterd"
 
+
+        self.logger.info(f"Running {cmd} on {node}")
         self.logger.info(f"Running {cmd} on {node}")
 
-        ret = self.execute_command_multinode(node, cmd)
+        ret = self.execute_command_multinode(cmd, node)
 
         for result_val in ret:
             if int(result_val['error_code']) != 0:
@@ -94,11 +103,11 @@ class GlusterOps:
         elif cmd_fail:
             raise Exception(error_msg)
 
-        self.logger.info(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on {ret['node']}")
 
         return ret
 
-    def stop_glusterd(self, node):
+    def stop_glusterd(self, node=None):
         """
         Stops the glusterd service on the specified node(s).
         Args:
@@ -116,23 +125,29 @@ class GlusterOps:
         """
         cmd = "systemctl stop glusterd"
 
-        if not isinstance(node, list):
+        if not isinstance(node, list) and node is not None:
             node = [node]
 
-        self.logger.info(f"Running {cmd} on {node}")
-
-        ret = self.execute_command_multinode(node, cmd)
+        if node is None:
+            self.logger.info(f"Running {cmd} on all nodes")
+            ret = self.execute_command_multinode(cmd)
+        else:
+            self.logger.info(f"Running {cmd} on {node}")
+            ret = self.execute_command_multinode(cmd, node)
 
         for result_val in ret:
             if int(result_val['error_code']) != 0:
                 self.logger.error(result_val['error_msg'])
                 raise Exception(result_val['error_msg'])
 
-        self.logger.info(f"Successfully ran {cmd} on {node}")
+        if node is None:
+            self.logger.info(f"Successfully ran {cmd} on all nodes.")
+        else:
+            self.logger.info(f"Successfully ran {cmd} on {node}")
 
         return ret
 
-    def reset_failed_glusterd(self, node) -> bool:
+    def reset_failed_glusterd(self, node=None) -> bool:
         """
         Glusterd has a burst limit of 5 times, hence TCs will
         start failing after the TC breach this limit. Systemd has
@@ -153,20 +168,23 @@ class GlusterOps:
                 - node : node on which the command got executed
 
         """
-        if not isinstance(node, list):
+        if not isinstance(node, list) and node is not None:
             node = [node]
 
         cmd = "systemctl reset-failed glusterd"
 
-        self.logger.info(f"Running {cmd} on {node}")
-
-        ret = self.execute_command_multinode(node, cmd)
+        if node is None:
+            ret = self.execute_command_multinode(cmd)
+            self.logger.info(f"Running {cmd} on all nodes.")
+        else:
+            ret = self.execute_command_multinode(cmd, node)
+            self.logger.info(f"Running {cmd} on {node}")
         for result_val in ret:
             if int(result_val['error_code']) != 0:
                 self.logger.error(result_val['error_msg'])
                 raise Exception(result_val['error_msg'])
 
-        self.logger.info(f"Successfully ran {cmd} on {node}")
+        self.logger.info(f"Successfully ran {cmd} on said nodes.")
 
         return ret
 
@@ -188,12 +206,12 @@ class GlusterOps:
 
         self.logger.info(f"Running {cmd1} on {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd1)
+        ret = self.execute_command(cmd=cmd1, node=node)
 
         if int(ret['error_code']) != 0:
             is_active = 0
             self.logger.info(f"Running {cmd2} on {node}")
-            ret1 = self.execute_command(node=node, cmd=cmd2)
+            ret1 = self.execute_command(cmd=cmd2, node=node)
             if ret1['error_code'] == 0:
                 is_active = -1
                 self.logger.info(f"Successfully ran {cmd2} on {node}")
@@ -201,7 +219,7 @@ class GlusterOps:
         self.logger.info(f"Successfully ran {cmd1} on {node}")
         return is_active
 
-    def wait_for_glusterd_to_start(self, node, timeout: int=80):
+    def wait_for_glusterd_to_start(self, node=None, timeout: int=80):
         """
         Checks if the glusterd has started already or waits for
         it till the timeout is reached.
@@ -214,13 +232,16 @@ class GlusterOps:
         Returns:
             bool: True if glusterd is running on the node(s) or else False.
         """
-        if not isinstance(node, list):
+        if not isinstance(node, list) and node is not None:
             node = [node]
 
         count = 0
         from time import sleep
         while count <= timeout:
-            ret = self.is_glusterd_running(node)
+            if node is None:
+                ret = self.is_glusterd_running()
+            else:
+                ret = self.is_glusterd_running(node)
             if not ret:
                 return True
             sleep(1)
@@ -243,7 +264,7 @@ class GlusterOps:
         cmd = "gluster --version"
         self.logger.info(f"Running {cmd} on {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['error_code']) != 0:
             self.logger.error(ret['error_msg'])

--- a/support/ops/gluster_ops/peer_ops.py
+++ b/support/ops/gluster_ops/peer_ops.py
@@ -32,7 +32,7 @@ class PeerOps:
         cmd = f'gluster --xml peer probe {server}'
 
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -126,17 +126,17 @@ class PeerOps:
             raise Exception(ret['msg']['opErrstr'])
 
         peer_list = []
-        
+
         peers = ret['msg']['peerStatus']['peer']
-        if not isinstance(peers,list):
+        if not isinstance(peers, list):
             peers = [peers]
-            
+
         for peer in peers:
-            if peer['connected']=='1':
-                peer_list.append(peer['uuid'])    
-                     
+            if peer['connected'] == '1':
+                peer_list.append(peer['uuid'])
+
         self.logger.info(f"Successfully ran {cmd} on {node}")
-        
+
         return peer_list
 
     def nodes_from_pool_list(self, node: str) -> list:
@@ -186,7 +186,7 @@ class PeerOps:
         pool_list = peer_dict['peerStatus']['peer']
 
         return pool_list
-    
+
     def create_cluster(self, nodes: list) -> bool:
         """
         Creates a cluster by probing all the nodes in the list.
@@ -196,31 +196,31 @@ class PeerOps:
             True: If nodes are in cluster or number of nodes are 0 or 1.
             False: If cluster cannot be created.
         """
-        
+
         length = len(nodes)
-        if length==0 or length==1:
+        if length == 0 or length == 1:
             return True
-        
+
         peer_list = []
-        
+
         count = 0
-        
+
         for node in nodes:
             pool_list = self.pool_list(node)
-            if count==0:
+            if count == 0:
                 peer_list = pool_list
             else:
-                if len(peer_list)==len(pool_list):
+                if len(peer_list) == len(pool_list):
                     for peer in peer_list:
-                        if peer not in pool_list and len(peer_list)!=1:
+                        if peer not in pool_list and len(peer_list) != 1:
                             break
                 else:
                     break
             count += 1
-            
-        if count==len(nodes):
-            if len(peer_list)==1:
-                
+
+        if count == len(nodes):
+            if len(peer_list) == 1:
+
                 node = nodes[0]
                 self.logger.info("Creating cluster")
                 for server in nodes:

--- a/support/ops/gluster_ops/peer_ops.py
+++ b/support/ops/gluster_ops/peer_ops.py
@@ -32,7 +32,7 @@ class PeerOps:
         cmd = f'gluster --xml peer probe {server}'
 
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -68,7 +68,7 @@ class PeerOps:
         else:
             cmd = f"gluster --xml peer detach {server} --mode=script"
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(node, cmd)
+        ret = self.execute_command(cmd, node)
 
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -98,7 +98,7 @@ class PeerOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node, cmd)
+        ret = self.execute_command(cmd, node)
 
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -120,7 +120,7 @@ class PeerOps:
 
         cmd = 'gluster --xml pool list'
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(node, cmd)
+        ret = self.execute_command(cmd, node)
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
@@ -173,7 +173,7 @@ class PeerOps:
         cmd = 'gluster pool list --xml'
 
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(node, cmd)
+        ret = self.execute_command(cmd, node)
 
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -224,7 +224,7 @@ class PeerOps:
                 node = nodes[0]
                 self.logger.info("Creating cluster")
                 for server in nodes:
-                    self.peer_probe(server,node)
+                    self.peer_probe(server, node)
                 self.logger.info("Cluster created")
                 self.peer_status(nodes[0])
             return True

--- a/support/ops/gluster_ops/volume_ops.py
+++ b/support/ops/gluster_ops/volume_ops.py
@@ -13,7 +13,7 @@ class VolumeOps:
     """
 
     def volume_mount(self, server: str, volname: str,
-                     path: str, node: str=None):
+                     path: str, node: str = None):
         """
         Mounts the gluster volume to the client's filesystem.
         Args:
@@ -38,7 +38,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret["error_code"]) != 0:
             self.logger.error(ret["error_msg"])
@@ -47,8 +47,8 @@ class VolumeOps:
         self.logger.info(f"Successfully ran {cmd} on {node}")
 
         return ret
-        
-    def volume_unmount(self, path: str, node: str=None):
+
+    def volume_unmount(self, path: str, node: str = None):
         """
         Unmounts the gluster volume .
         Args:
@@ -57,7 +57,7 @@ class VolumeOps:
             server (str): Hostname or IP address
             volname (str): Name of volume to be mounted
             path (str): The path of the mount directory(mount point)
-        
+
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -68,23 +68,23 @@ class VolumeOps:
                 - node : node on which the command got executed
 
         """
-        
+
         cmd = f"umount {path}"
-        
+
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret["error_code"]) != 0:
             self.logger.error(ret["error_msg"])
             raise Exception(ret["error_msg"])
 
         self.logger.info(f"Successfully ran {cmd} on {node}")
-        
+
         return ret
 
     def volume_create(self, volname: str, bricks_list: list,
-                      node : str=None, force: bool = False,
+                      node: str = None, force: bool = False,
                       **kwargs):
         """
         Create the gluster volume with specified configuration
@@ -152,7 +152,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -162,7 +162,8 @@ class VolumeOps:
 
         return ret
 
-    def volume_start(self, volname: str, node : str=None, force: bool = False):
+    def volume_start(self, volname: str, node: str = None,
+                     force: bool = False):
         """
         Starts the gluster volume
         Args:
@@ -191,7 +192,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -201,7 +202,7 @@ class VolumeOps:
 
         return ret
 
-    def volume_stop(self, volname: str, node : str=None, force: bool = False):
+    def volume_stop(self, volname: str, node: str = None, force: bool = False):
         """
         Stops the gluster volume
         Args:
@@ -229,7 +230,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -238,7 +239,7 @@ class VolumeOps:
         self.logger.info(f"Successfully ran {cmd} on {node}")
         return ret
 
-    def volume_delete(self, volname: str,node : str=None):
+    def volume_delete(self, volname: str, node: str = None):
         """
         Deletes the gluster volume if given volume exists in
         gluster.
@@ -260,7 +261,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -270,7 +271,7 @@ class VolumeOps:
 
         return ret
 
-    def get_volume_info(self, node : str=None, volname: str = 'all') -> dict:
+    def get_volume_info(self, node: str = None, volname: str = 'all') -> dict:
         """
         Gives volume information
         Args:
@@ -290,7 +291,7 @@ class VolumeOps:
                                          'name': 'server-vm1:/brick1',
                                          'isArbiter': '0',
                                          '#text': 'server-vm1:/brick1'
-                                        }, 
+                                        },
                                         {'name': 'server-vm1:/brick3',
                                          'isArbiter': '0',
                                          '#text': 'server-vm1:/brick3'
@@ -322,14 +323,14 @@ class VolumeOps:
                                         }
                           }
             }
-            
+
         """
 
         cmd = f"gluster volume info {volname} --xml"
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
@@ -339,38 +340,38 @@ class VolumeOps:
         volume_info = ret['msg']['volInfo']['volumes']
         ret_dict = {}
         volume_list = volume_info['volume']
-        if not(isinstance(volume_list,list)):
+        if not(isinstance(volume_list, list)):
             volume_list = [volume_list]
         for volume in volume_list:
-            for key,val in volume.items():
-                if key=='name':
+            for key, val in volume.items():
+                if key == 'name':
                     volname = val
                     ret_dict[volname] = {}
-                elif key=='bricks':
+                elif key == 'bricks':
                     ret_dict[volname]['bricks'] = []
                     brick_list = val['brick']
-                    if not(isinstance(brick_list,list)):
+                    if not(isinstance(brick_list, list)):
                         brick_list = [brick_list]
                     for brick in brick_list:
                         brick_info = {}
-                        for b_key,b_val in brick.items():
+                        for b_key, b_val in brick.items():
                             brick_info[b_key] = b_val
-                        ret_dict[volname]['bricks'].append(brick_info)                   
-                elif key=='options':
+                        ret_dict[volname]['bricks'].append(brick_info)
+                elif key == 'options':
                     ret_dict[volname]['options'] = {}
                     for option in val['option']:
-                        for opt,opt_val in option.items():
-                            if opt=='name':
+                        for opt, opt_val in option.items():
+                            if opt == 'name':
                                 opt_name = opt_val
-                            elif opt=='value':
+                            elif opt == 'value':
                                 opt_value = opt_val
                         ret_dict[volname]['options'][opt_name] = opt_val
                 else:
                     ret_dict[volname][key] = val
 
         return ret_dict
-        
-    def get_volume_list(self, node : str=None) -> list:
+
+    def get_volume_list(self, node: str = None) -> list:
         """
         Fetches the volume names in the gluster.
         Uses xml output of volume list and parses it into to list
@@ -383,26 +384,26 @@ class VolumeOps:
             >>>['testvol1', 'testvol2']
         """
         cmd = "gluster volume list --xml"
-        
+
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
         self.logger.info(f"Successfully ran {cmd} on {node}")
-        
+
         volume_list_count = int(ret['msg']['volList']['count'])
         volume_list = []
-        if volume_list_count!=0:
+        if volume_list_count != 0:
             volume_list = ret['msg']['volList']['volume']
-        
+
         return volume_list
-        
-        
-    def volume_reset(self, volname: str, node : str=None, force : bool=False):
+
+    def volume_reset(self, volname: str, node: str = None,
+                     force: bool = False):
         """
         Resets the gluster volume of all the reconfigured options.
         Args:
@@ -423,16 +424,16 @@ class VolumeOps:
                 - error_code: error code returned
                 - cmd : command that got executed
                 - node : node on which the command got executed
-        
-        """  
+
+        """
         if force:
             cmd = f"gluster volume reset {volname} force --mode=script --xml"
         else:
             cmd = f"gluster volume reset {volname} --mode=script --xml"
-            
+
         self.logger.info(f"Running {cmd} on node {node}")
-        
-        ret = self.execute_command(cmd=cmd, node=node)
+
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -441,9 +442,9 @@ class VolumeOps:
         self.logger.info(f"Successfully ran {cmd} on {node}")
 
         return ret
-        
-    def get_volume_status(self,node : str=None,volname : str='all',
-                         service : str='',options : str='') -> dict:
+
+    def get_volume_status(self, node: str = None, volname: str = 'all',
+                          service: str = '', options: str = '') -> dict:
         """
         Gets the status of all or the specified volume
         Args:
@@ -459,7 +460,7 @@ class VolumeOps:
         Returns:
             dict: volume status in dict of dictionary format
         Example:
-            get_volume_status("test-vol1",server)    
+            get_volume_status("test-vol1",server)
          >>>{ 'test-vol1': {
                              'nodeCount': '2',
                              'node': [{
@@ -473,7 +474,7 @@ class VolumeOps:
                                                  },
                                         'pid': '669291'
                                       },
-                                      { 
+                                      {
                                         'hostname': 'server-vm1',
                                         'path': '/brick3',
                                         'status': '1',
@@ -488,52 +489,52 @@ class VolumeOps:
                            }
             }
         """
-        
+
         cmd = f"gluster volume status {volname} {service} {options} --xml"
-        
+
         self.logger.info(f"Running {cmd} on node {node}")
-            
-        ret = self.execute_command(cmd=cmd, node=node)
+
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
         self.logger.info(f"Successfully ran {cmd} on {node}")
-        
+
         volume_status = ret['msg']['volStatus']['volumes']
         ret_dict = {}
         volume_list = volume_status['volume']
-        if not(isinstance(volume_list,list)):
+        if not(isinstance(volume_list, list)):
             volume_list = [volume_list]
         for volume in volume_list:
-            for key,val in volume.items():
-                if key=='volName':
+            for key, val in volume.items():
+                if key == 'volName':
                     volname = val
                     ret_dict[volname] = {}
-                elif key=='node':
+                elif key == 'node':
                     ret_dict[volname]['node'] = []
                     node_list = val
-                    if not(isinstance(node_list,list)):
+                    if not(isinstance(node_list, list)):
                         node_list = [node_list]
                     for node in node_list:
                         node_info = {}
-                        for n_key,n_val in node.items():
-                            if n_key=='ports':
+                        for n_key, n_val in node.items():
+                            if n_key == 'ports':
                                 port_info = {}
-                                for p_key,p_val in n_val.items():
+                                for p_key, p_val in n_val.items():
                                     port_info[p_key] = p_val
                                 node_info[n_key] = port_info
-                            else:        
+                            else:
                                 node_info[n_key] = n_val
-                        ret_dict[volname]['node'].append(node_info)                   
+                        ret_dict[volname]['node'].append(node_info)
                 else:
                     ret_dict[volname][key] = val
-        
+
         return ret_dict
-        
-    def get_volume_options(self,node : str=None, volname : str='all',
-                            option : str='all') -> dict:
+
+    def get_volume_options(self, node: str = None, volname: str = 'all',
+                           option: str = 'all') -> dict:
         """
         Gets the option values for a given volume.
         Args:
@@ -560,34 +561,33 @@ class VolumeOps:
               'cluster.brick-graceful-cleanup': 'disable (DEFAULT)'
             }
         """
-        
+
         cmd = f"gluster volume get {volname} {option} --mode=script --xml"
-        
+
         self.logger.info(f"Running {cmd} on node {node}")
-            
-        ret = self.execute_command(cmd=cmd, node=node)
- 
+
+        ret = self.execute_command(cmd, node)
+
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
         self.logger.info(f"Successfully ran {cmd} on {node}")
-        
+
         volume_options = ret['msg']['volGetopts']
-        
-        
+
         ret_dict = {}
         option_list = volume_options['Opt']
-        if not(isinstance(option_list,list)):
+        if not(isinstance(option_list, list)):
             option_list = [option_list]
         for option in option_list:
             option_name = option['Option']
             option_value = option['Value']
             ret_dict[option_name] = option_value
-        
+
         return volume_options
-        
-    def set_volume_options(self, volname : str, options : str, node : str=None):
+
+    def set_volume_options(self, volname: str, options: str, node: str = None):
         """
         Sets the option values for the given volume.
         Args:
@@ -609,31 +609,30 @@ class VolumeOps:
             - node : node on which the command got executed
 
         """
-        
+
         volume_options = options
-        
+
         if 'group' in volume_options:
             group_options = volume_options.pop('group')
             if not isinstance(group_options, list):
                 group_options = [group_options]
             for group_option in group_options:
                 cmd = (f"gluster volume set {volname} group {group_option} "
-                        "--mode=script --xml")
+                       "--mode=script --xml")
                 self.logger.info(f"Running {cmd} on node {node}")
-                    
-                ret = self.execute_command(cmd=cmd, node=node)
+
+                ret = self.execute_command(cmd, node)
 
                 if int(ret['msg']['opRet']) != 0:
                     self.logger.error(ret['msg']['opErrstr'])
                     raise Exception(ret['msg']['opErrstr'])
-                    
 
         for option in volume_options:
             cmd = (f"gluster volume set {volname} {option} "
                    f"{volume_options[option]} --mode=script --xml")
             self.logger.info(f"Running {cmd} on node {node}")
-                
-            ret = self.execute_command(cmd=cmd, node=node)
+
+            ret = self.execute_command(cmd, node)
 
             if int(ret['msg']['opRet']) != 0:
                 self.logger.error(ret['msg']['opErrstr'])
@@ -642,9 +641,9 @@ class VolumeOps:
             self.logger.info(f"Successfully ran {cmd} on {node}")
 
         return ret
-        
-    def reset_volume_option(self, volname : str, option : str,
-                            node : str=None, force : bool=False):
+
+    def reset_volume_option(self, volname: str, option: str,
+                            node: str = None, force: bool = False):
         """
         Resets the volume option
         Args:
@@ -657,7 +656,7 @@ class VolumeOps:
                 then reset volume will get executed without force option
         Example:
             reset_volume_option("test-vol1", "option", server)
-        
+
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -668,24 +667,24 @@ class VolumeOps:
                 - node : node on which the command got executed
 
         """
-        
+
         if force:
-            cmd = (f"gluster volume reset {volname} {option} force" 
+            cmd = (f"gluster volume reset {volname} {option} force"
                    "--mode=script --xml")
         else:
-            cmd = f"gluster volume reset {volname} {option} --mode=script --xml"
+            cmd = f"gluster vol reset {volname} {option} --mode=script --xml"
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command( cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
         self.logger.info(f"Successfully ran {cmd} on {node}")
-        
+
         return ret
 
-    def volume_sync(self, hostname : str, node: str, volname : str='all'):
+    def volume_sync(self, hostname: str, node: str, volname: str = 'all'):
         """
         Sync the volume to the specified host
         Args:
@@ -695,7 +694,7 @@ class VolumeOps:
             volname (str): volume name. Defaults to 'all'.
         Example:
             volume_sync(volname="testvol",server)
-        
+
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -706,11 +705,11 @@ class VolumeOps:
                 - node : node on which the command got executed
 
         """
-        
+
         cmd = f"gluster volume sync {hostname} {volname} --mode=script --xml"
-        
+
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(cmd=cmd, node=node)
+        ret = self.execute_command(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])

--- a/support/ops/gluster_ops/volume_ops.py
+++ b/support/ops/gluster_ops/volume_ops.py
@@ -38,7 +38,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret["error_code"]) != 0:
             self.logger.error(ret["error_msg"])
@@ -73,7 +73,7 @@ class VolumeOps:
         
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret["error_code"]) != 0:
             self.logger.error(ret["error_msg"])
@@ -152,7 +152,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -191,7 +191,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -229,7 +229,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -260,7 +260,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -329,7 +329,7 @@ class VolumeOps:
 
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
@@ -386,7 +386,7 @@ class VolumeOps:
         
         self.logger.info(f"Running {cmd} on node {node}")
 
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -432,7 +432,7 @@ class VolumeOps:
             
         self.logger.info(f"Running {cmd} on node {node}")
         
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -493,7 +493,7 @@ class VolumeOps:
         
         self.logger.info(f"Running {cmd} on node {node}")
             
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -565,7 +565,7 @@ class VolumeOps:
         
         self.logger.info(f"Running {cmd} on node {node}")
             
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
  
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -621,7 +621,7 @@ class VolumeOps:
                         "--mode=script --xml")
                 self.logger.info(f"Running {cmd} on node {node}")
                     
-                ret = self.execute_command(node=node, cmd=cmd)
+                ret = self.execute_command(cmd=cmd, node=node)
 
                 if int(ret['msg']['opRet']) != 0:
                     self.logger.error(ret['msg']['opErrstr'])
@@ -633,7 +633,7 @@ class VolumeOps:
                    f"{volume_options[option]} --mode=script --xml")
             self.logger.info(f"Running {cmd} on node {node}")
                 
-            ret = self.execute_command(node=node, cmd=cmd)
+            ret = self.execute_command(cmd=cmd, node=node)
 
             if int(ret['msg']['opRet']) != 0:
                 self.logger.error(ret['msg']['opErrstr'])
@@ -675,7 +675,7 @@ class VolumeOps:
         else:
             cmd = f"gluster volume reset {volname} {option} --mode=script --xml"
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command( cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])
@@ -710,7 +710,7 @@ class VolumeOps:
         cmd = f"gluster volume sync {hostname} {volname} --mode=script --xml"
         
         self.logger.info(f"Running {cmd} on node {node}")
-        ret = self.execute_command(node=node, cmd=cmd)
+        ret = self.execute_command(cmd=cmd, node=node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])

--- a/support/ops/support_ops/io_ops.py
+++ b/support/ops/support_ops/io_ops.py
@@ -10,14 +10,14 @@ class IoOps:
     all the IO commands.
     """
 
-    def execute_io_cmd(self, cmd: str, host: str=None):
+    def execute_io_cmd(self, cmd: str, host: str = None):
         '''
         Used for all the IO commands
 
         Args:
             cmd (str): The IO command which is to be run
             host (str): The node in the cluster where the command is to be run
-        
+
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed

--- a/support/ops/support_ops/io_ops.py
+++ b/support/ops/support_ops/io_ops.py
@@ -10,7 +10,7 @@ class IoOps:
     all the IO commands.
     """
 
-    def execute_io_cmd(self, cmd: str, host: str = None):
+    def execute_io_cmd(self, cmd: str, host: str=None):
         '''
         Used for all the IO commands
 
@@ -30,12 +30,15 @@ class IoOps:
         '''
 
         self.logger.info(f"Running {cmd} on node {host}")
-        ret = self.execute_command(host, cmd)
+        if host is None:
+            ret = self.execute_command(cmd)
+        else:
+            ret = self.execute_command(cmd, host)
 
         if ret['error_code'] != 0:
             self.logger.error(ret['msg']['opErrstr'])
             raise Exception(ret['msg']['opErrstr'])
 
-        self.logger.info(f"Successfully ran {cmd} on {host}")
+        self.logger.info(f"Successfully ran {cmd} on {ret['node']}")
 
         return ret

--- a/support/relog.py
+++ b/support/relog.py
@@ -38,9 +38,7 @@ class Logger(logging.Logger):
         test_name = log_file_path.split('/')[-1:][0][:-4]
         self.logger.info(f'''
          ============================================================
-                                         
-           {test_name} started running: {datetime.now()}       
-                                         
+           {test_name} started running: {datetime.now()}
          ============================================================
         ''')
 
@@ -93,19 +91,19 @@ class Logger(logging.Logger):
         """
         if not os.path.isdir(path):
             os.makedirs(path)
-        
+
         # Component wise directory creation.
         for test_type in component_dict:
             test_type_path = path+"/"+test_type
-        
+
         if not os.path.isdir(test_type_path):
             os.makedirs(test_type_path)
-        
+
         components = component_dict[test_type]
         for component in components:
             if not os.path.isdir(test_type_path+"/"+component):
                 os.makedirs(test_type_path+"/"+component)
-        
+
         # TC wise directory creation.
         for test in test_dict["disruptive"]:
             test_case_dir = path+"/"+test["modulePath"][5:-3]
@@ -115,7 +113,7 @@ class Logger(logging.Logger):
                 voltype_dir = test_case_dir+"/"+vol
                 if not os.path.isdir(voltype_dir):
                     os.makedirs(voltype_dir)
-            
+
         for test in test_dict["nonDisruptive"]:
             test_case_dir = path+"/"+test["modulePath"][5:-3]
             if not os.path.isdir(test_case_dir):

--- a/support/rexe.py
+++ b/support/rexe.py
@@ -51,7 +51,7 @@ class Rexe:
         for node in self.host_dict:
             if self.node_dict[node]:
                 (self.node_dict[node]).close()
-        return    
+        return
 
     @dispatch(str)
     def execute_command(self, cmd):
@@ -103,7 +103,7 @@ class Rexe:
                 self.logger.debug(f"SSH connection to {node} is successful.")
                 self.node_dict[node] = node_ssh_client
             except Exception as e:
-                self.logger.error(f"Connection failure. Exception {e}")
+                self.logger.error(f"Connection failure. Exceptions {e}.")
             # On rebooting the node
             _, stdout, stderr = self.node_dict[node].exec_command(cmd)
 
@@ -111,6 +111,8 @@ class Rexe:
             ret_dict['Flag'] = False
             ret_dict['msg'] = stdout.readlines()
             ret_dict['error_msg'] = stderr.readlines()
+            if isinstance(ret_dict['error_msg'], list):
+                ret_dict['error_msg'] = "".join(ret_dict['error_msg'])
         else:
             if cmd.find("--xml") != -1:
                 stdout_xml_string = "".join(stdout.readlines())

--- a/tests/example/sample_component/test_file_creation.py
+++ b/tests/example/sample_component/test_file_creation.py
@@ -29,7 +29,7 @@ class TestCase(ParentTest):
         host = self.server_list[0]
         regfile_name = "file1"
         mountpoint = "/mnt/test_dir"
-        redant.execute_io_cmd(f"mkdir -p {mountpoint}", host)
+        """redant.execute_io_cmd(f"mkdir -p {mountpoint}", host)
         redant.execute_io_cmd(
             f"cd {mountpoint} && touch {mountpoint}/{regfile_name}", host)
 
@@ -50,5 +50,6 @@ class TestCase(ParentTest):
                 f"echo '{str_to_add}' >> {path}", host)
 
         redant.execute_io_cmd(f"cat {path}", host)
-        redant.execute_io_cmd(f"ls -lR {mountpoint}", host)
-        redant.execute_io_cmd(f"rm -rf {mountpoint}", host)
+        redant.execute_io_cmd(f"ls -lR {mountpoint}", host)"""
+        redant.execute_io_cmd(f"ls -l /")
+        #redant.execute_io_cmd(f"rm -rf {mountpoint}", host)

--- a/tests/example/sample_component/test_file_creation.py
+++ b/tests/example/sample_component/test_file_creation.py
@@ -3,7 +3,7 @@ This file contains a test-case which tests
 the creation of different types of files and
 some operations on it.
 """
-#disruptive;
+# disruptive;
 
 from tests.parent_test import ParentTest
 
@@ -29,13 +29,13 @@ class TestCase(ParentTest):
         host = self.server_list[0]
         regfile_name = "file1"
         mountpoint = "/mnt/test_dir"
-        """redant.execute_io_cmd(f"mkdir -p {mountpoint}", host)
+        redant.execute_io_cmd(f"mkdir -p {mountpoint}", host)
         redant.execute_io_cmd(
             f"cd {mountpoint} && touch {mountpoint}/{regfile_name}", host)
 
         for (file_name, parameter) in [
                 ("blockfile", "b"), ("charfile", "c")]:
-                redant.execute_io_cmd(
+            redant.execute_io_cmd(
                 f"mknod {mountpoint}/{file_name} {parameter} 1 5", host)
 
         redant.execute_io_cmd(f"mkfifo {mountpoint}/pipefile", host)
@@ -43,13 +43,13 @@ class TestCase(ParentTest):
         for (file_name, data_str) in [
             ("regfile", "regular"),
             ("charfile", "character special"),
-            ("blockfile", "block special")]:
+                ("blockfile", "block special")]:
             str_to_add = f"This is a {data_str} file."
             path = f"{mountpoint}/{regfile_name}"
             redant.execute_io_cmd(
                 f"echo '{str_to_add}' >> {path}", host)
 
         redant.execute_io_cmd(f"cat {path}", host)
-        redant.execute_io_cmd(f"ls -lR {mountpoint}", host)"""
-        redant.execute_io_cmd(f"ls -l /")
-        #redant.execute_io_cmd(f"rm -rf {mountpoint}", host)
+        redant.execute_io_cmd(f"ls -lR {mountpoint}", host)
+        redant.execute_io_cmd("ls -l /")
+        redant.execute_io_cmd(f"rm -rf {mountpoint}", host)

--- a/tests/example/sample_component/test_sample.py
+++ b/tests/example/sample_component/test_sample.py
@@ -3,7 +3,7 @@
 This file contains a test-case which tests glusterd
 service operations
 """
-#disruptive;dist
+# disruptive;dist
 
 from tests.parent_test import ParentTest
 
@@ -41,9 +41,10 @@ class TestCase(ParentTest):
                              [f"{servera}:/glusterfs/brick/brick1",
                               f"{serverb}:/glusterfs/brick/brick2",
                               f"{serverc}:/glusterfs/brick//brick3"],
-                              serverb, force=True)
-        redant.volume_start(volname,serverc)
-        volume_status = redant.get_volume_status(serverb,volname)
+                             serverb, force=True)
+        redant.volume_start(volname, serverc)
+        volume_status = redant.get_volume_status(serverb, volname)
+        redant.logger.info(volume_status)
         redant.execute_io_cmd(f"mkdir -p {mountpoint}", serverb)
         redant.volume_mount(servera, volname, mountpoint, serverb)
         redant.execute_io_cmd(f"cd {mountpoint} && touch " + "{1..100}",
@@ -55,11 +56,12 @@ class TestCase(ParentTest):
         try:
             redant.execute_io_cmd("ls -l /non-exsisting-path", servera)
         except Exception as error:
+            redant.logger.error(error)
             pass
 
         redant.volume_stop(volname, servera)
         redant.volume_delete(volname, servera)
-        redant.volume_unmount(mountpoint,serverb)
+        redant.volume_unmount(mountpoint, serverb)
         redant.execute_io_cmd(f"cd /mnt && rm -rf {mountpoint}", serverb)
         redant.peer_detach(serverb, serverc)
         redant.peer_detach(serverb, servera)

--- a/tests/functional/glusterd/test_glusterd_start_stop.py
+++ b/tests/functional/glusterd/test_glusterd_start_stop.py
@@ -2,7 +2,7 @@
 This file contains a test-case which tests glusterd
 starting and stopping of glusterd service.
 """
-#disruptive;
+# disruptive;
 
 from tests.parent_test import ParentTest
 

--- a/tests/functional/glusterd/test_peer_probe_detach.py
+++ b/tests/functional/glusterd/test_peer_probe_detach.py
@@ -2,7 +2,7 @@
 This component has a test-case for testing
 peer related operations
 """
-#disruptive;
+# disruptive;
 
 from tests.parent_test import ParentTest
 

--- a/tests/functional/glusterd/test_volume_create_delete.py
+++ b/tests/functional/glusterd/test_volume_create_delete.py
@@ -2,7 +2,7 @@
 This file contains a test-case which tests
 volume related operations.
 """
-#disruptive;dist
+# disruptive;dist
 
 from tests.parent_test import ParentTest
 
@@ -41,7 +41,9 @@ class TestCase(ParentTest):
                              serverb, force=True)
         redant.volume_start(volname, serverc)
         volume_status1 = redant.get_volume_status(serverb, volname)
+        redant.logger.info(volume_status1)
         volume_status2 = redant.get_volume_status(serverc, volname)
+        redant.logger.info(volume_status2)
         redant.execute_io_cmd(f"mkdir -p {mountpoint}", serverb)
         redant.volume_mount(servera, volname, mountpoint, serverb)
         redant.execute_io_cmd(f"cd {mountpoint} && touch " + "{1..100}",

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -34,7 +34,7 @@ class ParentTest(metaclass=abc.ABCMeta):
         self.server_list = list(server_details.keys())
         self.client_list = list(client_details.keys())
 
-        self.redant.start_glusterd(self.server_list)
+        self.redant.start_glusterd()
 
     def _configure(self, mname: str, server_details: dict,
                    client_details: dict, log_path: str, log_level: str):

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -3,6 +3,7 @@ import abc
 from support.mixin import RedantMixin
 from datetime import datetime
 
+
 class ParentTest(metaclass=abc.ABCMeta):
 
     """
@@ -38,7 +39,7 @@ class ParentTest(metaclass=abc.ABCMeta):
 
     def _configure(self, mname: str, server_details: dict,
                    client_details: dict, log_path: str, log_level: str):
-        machine_detail = {**client_details , **server_details}
+        machine_detail = {**client_details, **server_details}
         self.redant = RedantMixin(machine_detail)
         self.redant.init_logger(mname, log_path, log_level)
         self.redant.establish_connection()
@@ -57,14 +58,13 @@ class ParentTest(metaclass=abc.ABCMeta):
             self.run_test(self.redant)
         except Exception as error:
             tb = traceback.format_exc()
+            self.redant.logger.error(error)
             self.redant.logger.error(tb)
             self.TEST_RES = False
         self.redant.logger.info(f'''
-         ============================================================
-                                         
-           {self.test_name} finished running: {datetime.now()}       
-                                         
-         ============================================================
+        ============================================================
+           {self.test_name} finished running: {datetime.now()}
+        ============================================================
         ''')
 
     def terminate(self):


### PR DESCRIPTION
Ops libraries can now run commands on any of the
connected nodes when the node list or node isn't
provided.

Multipledispatch has been added to dependency
to handle function overloading in Rexe.

Also, the execute command and multinode functions
have inverted order of parameter. The first param
being `cmd` and the second being `node` ( For
functions which take node ).

Fixes: #144

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in ops/support_ops
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
