### PR TITLE
Gluster ops modified to use abstract ops functionalities

### DIFF
--- a/common/ops/abstract_ops.py
+++ b/common/ops/abstract_ops.py
@@ -24,7 +24,6 @@ class AbstractOps:
                         If the node is None then the rexe chooses the
                         node randomly and executes the command on it.
         """
-        self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command(cmd, node)
 
@@ -36,9 +35,14 @@ class AbstractOps:
                 self.logger.error(ret['msg']['opErrstr'])
                 raise Exception(ret['msg']['opErrstr'])
 
+<<<<<<< HEAD
+=======
+        self.logger.info(f"Successfully ran {cmd} on {ret['node']}")
+
+>>>>>>> 16b28c6... Gluster ops modified to use abstract ops functionalities
         return ret
         
-    def execute_abstract_op_multinode(self, cmd : str, node : str=None):
+    def execute_abstract_op_multinode(self, cmd : str, node : list=None):
         """
         Calls the function in the remote executioner to execute
         commands on the nodes. Logging is also performed along
@@ -49,14 +53,14 @@ class AbstractOps:
                         If the node is None then the rexe chooses the
                         node randomly and executes the command on it.
         """
-        self.logger.info(f"Running {cmd} on {node}")
-
         ret = self.execute_command_multinode(cmd, node)
+        for each_ret in ret:
+            if each_ret['error_code'] != 0:
+                self.logger.error(each_ret['msg']['opErrstr'])
+                raise Exception(each_ret['msg']['opErrstr'])
 
-        if int(ret['msg']['opRet']) != 0:
-            self.logger.error(ret['msg']['opErrstr'])
-            raise Exception(ret['msg']['opErrstr'])
-
+            self.logger.info(f"Successfully ran {cmd} on {each_ret['node']}")
+            
         return ret
         
         

--- a/common/ops/abstract_ops.py
+++ b/common/ops/abstract_ops.py
@@ -35,11 +35,8 @@ class AbstractOps:
                 self.logger.error(ret['msg']['opErrstr'])
                 raise Exception(ret['msg']['opErrstr'])
 
-<<<<<<< HEAD
-=======
         self.logger.info(f"Successfully ran {cmd} on {ret['node']}")
 
->>>>>>> 16b28c6... Gluster ops modified to use abstract ops functionalities
         return ret
         
     def execute_abstract_op_multinode(self, cmd : str, node : list=None):

--- a/common/ops/gluster_ops/gluster_ops.py
+++ b/common/ops/gluster_ops/gluster_ops.py
@@ -36,17 +36,6 @@ class GlusterOps(AbstractOps):
         cmd = "pgrep glusterd || systemctl start glusterd"
 
         ret = self.execute_abstract_op_multinode(cmd, node)
-    
-        for result_val in ret:
-            if int(result_val['error_code']) != 0:
-                cmd_fail = True
-                break
-
-        if cmd_fail and enable_retry:
-            self.reset_failed_glusterd(node)
-            self.start_glusterd(node)
-        elif cmd_fail:
-            raise Exception(error_msg)
 
         return ret
 

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -59,8 +59,8 @@ class Rexe:
                 (self.node_dict[node]).close()
         return
 
-    @dispatch(str)
-    def execute_command(self, cmd):
+    @dispatch(str, type(None))
+    def execute_command(self, cmd, node):
         """
         Module to handle random node execution.
         Returns:
@@ -72,6 +72,7 @@ class Rexe:
                 - cmd : command that got executed
                 - node : node on which the command got executed
         """
+        self.logger.info(f"Running {cmd} on a random node")
         return self.execute_command(cmd, self._random_node())
 
     @dispatch(str, str)
@@ -89,7 +90,7 @@ class Rexe:
 
         """
         ret_dict = {}
-
+        self.logger.info(f"Running {cmd} on {node}")
         if not self.connect_flag:
             ret_dict['Flag'] = False
             return ret_dict
@@ -131,6 +132,8 @@ class Rexe:
         ret_dict['error_code'] = stdout.channel.recv_exit_status()
 
         self.logger.debug(ret_dict)
+
+
         return ret_dict
 
     @dispatch(str)
@@ -250,12 +253,14 @@ class Rexe:
 
         return ret_dict
 
-    @dispatch(str)
-    def execute_command_multinode(self, cmd):
+
+    @dispatch(str, type(None))
+    def execute_command_multinode(self, cmd, node_list):
         """
         Function to execute command in multiple nodes parallely
         when node list isn't given.
         """
+        self.logger.info(f"Running {cmd} on random node list")
         return self.execute_command_multinode(cmd, list(self.node_dict.keys()))
 
     @dispatch(str, list)
@@ -265,7 +270,7 @@ class Rexe:
         parallely.
         """
         ret_val = []
-
+        self.logger.info(f"Running {cmd} on {node_list}")
         with concurrent.futures.ThreadPoolExecutor(
                 max_workers=len(node_list)) as executor:
 
@@ -277,4 +282,6 @@ class Rexe:
                 except Exception as exc:
                     print(f"Generated exception : {exc}")
         self.logger.info(ret_val)
+
+        self.logger.info(f"Successfully ran {cmd} on {node_list}")
         return ret_val


### PR DESCRIPTION
Replaced the redundant code in gluster ops with the abstract ops code.
Also the dispatcher was not able to recognise None type objects in case no node is passed. So added the `type(None)` in rexe in the dispatcher to handle the none case as well.
Fixes: #221

Signed-off-by: aujjwal-redhat <aujjwal@redhat.com>
