### PR TITLE
Volume creation in parent test and param handler changes

### DIFF
--- a/common/ops/abstract_ops.py
+++ b/common/ops/abstract_ops.py
@@ -26,7 +26,7 @@ class AbstractOps:
         """
         self.logger.info(f"Running {cmd} on {node}")
 
-        ret = self.execute_command(cmd,node)
+        ret = self.execute_command(cmd, node)
 
         if(ret['error_code']!=0):
             self.logger.error(ret['error_msg'])
@@ -53,7 +53,7 @@ class AbstractOps:
         """
         self.logger.info(f"Running {cmd} on {node}")
 
-        ret = self.execute_command_multinode(cmd,node)
+        ret = self.execute_command_multinode(cmd, node)
 
         if int(ret['msg']['opRet']) != 0:
             self.logger.error(ret['msg']['opErrstr'])

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -68,30 +68,19 @@ class VolumeOps(AbstractOps):
 
         return ret
 
-    def volume_create(self, volname: str, bricks_list: list,
-                      node: str = None, force: bool = False,
-                      **kwargs):
+    def volume_create(self, volname: str, node: str, conf_hash: dict,
+                      server_list: list, brick_root: list,
+                      force: bool = False):
         """
         Create the gluster volume with specified configuration
         Args:
-            node(str): server on which command has to be executed
             volname(str): volume name that has to be created
-            bricks_list (list): List of bricks to use for creating volume.
-
-        Kwargs:
+            node(str): server on which command has to be executed
+            conf_hash (dict): Config hash providing parameters for volume
+            creation.
             force (bool): If this option is set to True, then create volume
-                will get executed with force option. If it is set to False,
-                then create volume will get executed without force option
-            **kwargs
-                The keys, values in kwargs are:
-                    - replica_count : (int)|None
-                    - arbiter_count : (int)|None
-                    - stripe_count : (int)|None
-                    - disperse_count : (int)|None
-                    - disperse_data_count : (int)|None
-                    - redundancy_count : (int)|None
-                    - transport_type : tcp|rdma|tcp,rdma|None
-                    - ...
+            will get executed with force option.
+
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -102,42 +91,32 @@ class VolumeOps(AbstractOps):
                 - node : node on which the command got executed
 
         """
+        brick_cmd = ""
+        server_iter = 0
+        mul_fac = 0
+        cmd = ""
+        if "replica_count" in conf_hash:
+            mul_fac = conf_hash["replica_count"]
+            if "dist_count" in conf_hash:
+                mul_fac *= conf_hash["dist_count"]
+        elif "dist_count" in conf_hash:
+            mul_fac = conf_hash["dist_count"]
 
-        replica = arbiter = stripe = disperse = disperse_data = redundancy = ''
-        transport = ''
+        for iter in range(mul_fac):
+            if server_iter == len(server_list):
+                server_iter = 0
+            brick_cmd = (f"{brick_cmd} {server_list[server_iter]}:{brick_root[server_list[server_iter]]}/{volname}-{iter}")
 
-        if 'replica_count' in kwargs:
-            replica = f"replica {kwargs['replica_count']}"
-
-        if 'arbiter_count' in kwargs:
-            arbiter = f"arbiter {kwargs['arbiter_count']}"
-
-        if 'stripe_count' in kwargs:
-            stripe = f"stripe {kwargs['stripe_count']}"
-
-        if 'disperse_count' in kwargs:
-            disperse = f"disperse {kwargs['disperse_count']}"
-
-        if 'disperse_data_count' in kwargs:
-            disperse = f"disperse-data {kwargs['disperse_data_count']}"
-
-        if 'redundancy_count' in kwargs:
-            redundancy = f"redundancy {kwargs['redundancy_count']}"
-
-        if 'transport_type' in kwargs:
-            transport = f"transport {kwargs['transport_type']}"
-
-        cmd = (f"gluster volume create {volname} {replica} "
-               f"{arbiter} {stripe} {disperse} {disperse_data} "
-               f"{redundancy} {transport} {' '.join(bricks_list)} --xml "
-               "--mode=script")
-
+        if "replica_count" in conf_hash:
+            cmd = (f"gluster volume create {volname} replica {conf_hash['replica_count']}{brick_cmd}")
+        else:
+            cmd = (f"gluster volume create {volname}{brick_cmd}")
         if force:
-            cmd = cmd + " force"
+            cmd = (f"{cmd} force")
 
         ret = self.execute_abstract_op_node(cmd, node)
 
-        return ret
+        return 0
 
     def volume_start(self, volname: str, node: str = None,
                      force: bool = False):

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -4,7 +4,7 @@ holds volume related APIs which will be called
 from the test case.
 """
 from common.ops.abstract_ops import AbstractOps
-
+from multipledispatch import dispatch
 
 class VolumeOps(AbstractOps):
     """
@@ -117,7 +117,7 @@ class VolumeOps(AbstractOps):
 
         ret = self.execute_abstract_op_node(cmd, node)
 
-        return 0
+        return ret
 
     def volume_start(self, volname: str, node: str = None,
                      force: bool = False):
@@ -150,7 +150,7 @@ class VolumeOps(AbstractOps):
         ret = self.execute_abstract_op_node(cmd, node)
 
         return ret
-
+    
     def volume_stop(self, volname: str, node: str = None, force: bool = False):
         """
         Stops the gluster volume
@@ -354,7 +354,7 @@ class VolumeOps(AbstractOps):
 
         return ret
 
-    def get_volume_status(self, node: str = None, volname: str = 'all',
+    def get_volume_status(self, volname: str = 'all', node: str = None,
                           service: str = '', options: str = '') -> dict:
         """
         Gets the status of all or the specified volume

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -91,6 +91,7 @@ class VolumeOps(AbstractOps):
                 - node : node on which the command got executed
 
         """
+        #TODO adding vol create for disp, arb, dist-arb and dist-disp
         brick_cmd = ""
         server_iter = 0
         mul_fac = 0
@@ -201,7 +202,7 @@ class VolumeOps(AbstractOps):
         cmd = f"gluster volume delete {volname} --mode=script --xml"
 
         ret = self.execute_abstract_op_node(cmd, node)
-
+        #TODO cleanup of the brick dirs after the volume is deleted.
         return ret
 
     def get_volume_info(self, node: str = None, volname: str = 'all') -> dict:

--- a/core/environ.py
+++ b/core/environ.py
@@ -8,23 +8,22 @@ class environ:
     the setup and the complete cleanup.
     """
 
-    def __init__(self, config_hashm : dict, log_path : str, log_level : str):
+    def __init__(self, param_obj, log_path : str, log_level : str):
         """
         Redant mixin obj to be used for server setup and teardown operations
         has to be created.
         """
-        self.server_details = config_hashm['servers_info']
-        machine_details = {**self.server_details}
-        self.redant = RedantMixin(machine_details)
+        self.redant = RedantMixin(param_obj.get_server_config())
         self.redant.init_logger("environ", log_path, log_level)
         self.redant.establish_connection()
+        self.server_list = param_obj.get_server_ip_list()
 
     def setup_env(self):
         """
         Setting up of the environment before the TC execution begins.
         """
         self.redant.start_glusterd()
-        self.redant.create_cluster(list(self.server_details.keys()))
+        self.redant.create_cluster(self.server_list)
 
     def teardown_env(self):
         """

--- a/core/parsing/params_handler.py
+++ b/core/parsing/params_handler.py
@@ -12,40 +12,56 @@ class ParamsHandler:
     the values of all the configuration parameters.
     """
 
-    @classmethod
-    def set_config_hashmap(cls, filepath: str):
+    def __init__(self, filepath: str):
         """
-        Gets the configuration hashmap generated from the
-        api in Parser class and sets the reuired class variable.
-        The config_hashmap class variable can be accessed
-        throughout the class.
-        Args:
-            filepath (str): Path for config file
+        Parsing the config file.
         """
-        cls.config_hashmap = Parser.generate_config_hashmap(filepath)
+        self.config_hashmap = Parser.generate_config_hashmap(filepath)
+        self.server_config = self.config_hashmap['servers_info']
+        self.client_config = self.config_hashmap['clients_info']
+        self.volume_types = self.config_hashmap['volume_types']
 
-    @classmethod
-    def get_server_ip_list(cls) -> list:
+    def get_server_ip_list(self) -> list:
         """
         Gives the list of all server ip
         Returns:
             list: list of all server ip address
         """
-        server_ip_list = list(cls.config_hashmap['servers_info'].keys())
-        return server_ip_list
+        return list(self.server_config.keys())
 
-    @classmethod
-    def get_client_ip_list(cls) -> list:
+    def get_server_config(self) -> dict:
+        """
+        Getter for server config details.
+        Returns:
+            dict: Server config details.
+        """
+        return self.server_config
+
+    def get_client_config(self) -> dict:
+        """
+        Getter for client config details.
+        Returns:
+            dict: Client config details.
+        """
+        return self.client_config
+
+    def get_client_ip_list(self) -> list:
         """
         Gives the list of all client ip
         Returns:
             list: list of all client ip address
         """
-        client_ip_list = list(cls.config_hashmap['clients_info'].keys())
-        return client_ip_list
+        return list(self.client_config.keys())
 
-    @classmethod
-    def get_config_hashmap(cls) -> dict:
+    def get_volume_types(self) -> dict:
+        """
+        Getter for volume information.
+        Retuns:
+            Dict
+        """
+        return self.volume_types
+
+    def get_config_hashmap(self) -> dict:
         """
         Returns the config hashmap which is parsed from
         the config file
@@ -115,10 +131,9 @@ class ParamsHandler:
             }
         """
 
-        return cls.config_hashmap
+        return self.config_hashmap
 
-    @classmethod
-    def get_brick_root_list(cls, server_ip: str) -> list:
+    def get_brick_root_list(self, server_ip: str) -> list:
         """
         Returns the list of brick root given the server name
         Args:
@@ -129,6 +144,16 @@ class ParamsHandler:
         Example:
             get_brick_root_list("server-vm1")
         """
-        servers_info = cls.config_hashmap['servers_info']
-        brick_root_list = servers_info[server_ip]['brick_root']
-        return brick_root_list
+        return self.server_config[server_ip]['brick_root']
+
+    # TODO: Handling servers with multiple brick roots.
+    def get_brick_roots(self) -> dict:
+        """
+        Get the mapping of server ip to their brick roots
+        Returns:
+           Dict
+        """
+        brick_roots = {}
+        for server in self.server_config:
+            brick_roots[server] = self.server_config[server]['brick_root'][0]
+        return brick_roots

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -59,10 +59,7 @@ def main():
     start = time.time()
     args = pars_args()
 
-    ParamsHandler.set_config_hashmap(args.config_file)
-
-    # Obtain the client and server dict.
-    config_hashmap = ParamsHandler.get_config_hashmap()
+    param_obj = ParamsHandler(args.config_file)
 
     # Building the test list and obtaining the TC details.
     test_cases_tuple = TestListBuilder.create_test_dict(args.test_dir,
@@ -81,11 +78,11 @@ def main():
     test_cases_dict = TestListBuilder.pre_test_run_list_modify(test_cases_dict)
 
     # Environment setup.
-    env_obj = environ(config_hashmap, args.log_dir+"/main.log", args.log_level)
+    env_obj = environ(param_obj, args.log_dir+"/main.log", args.log_level)
     env_obj.setup_env()
 
     # invoke the test_runner.
-    TestRunner.init(test_cases_dict, config_hashmap, args.log_dir,
+    TestRunner.init(test_cases_dict, param_obj, args.log_dir,
                     args.log_level, args.semaphore_count)
     all_test_results = TestRunner.run_tests()
 

--- a/core/runner_thread.py
+++ b/core/runner_thread.py
@@ -10,11 +10,11 @@ class RunnerThread:
     functions for running it.
     """
 
-    def __init__(self, mname: str, tc_class, config_hashmap: dict,
+    def __init__(self, tc_class, param_obj, mname: str,
                  volume_type: str, log_path: str, log_level: str,
                  thread_flag : bool):
         # Creating the test case object from the test case.
-        self.tc_obj = tc_class(mname, config_hashmap, volume_type,
+        self.tc_obj = tc_class(mname, param_obj, volume_type,
                                thread_flag, log_path, log_level)
         self.run_test_func = getattr(self.tc_obj, "parent_run_test")
         self.terminate_test_func = getattr(self.tc_obj, "terminate")

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -18,9 +18,9 @@ class TestRunner:
     """
 
     @classmethod
-    def init(cls, test_run_dict: dict, config_hashmap: dict,
+    def init(cls, test_run_dict: dict, param_obj: dict,
              base_log_path: str, log_level: str, semaphore_count: int):
-        cls.config_hashmap = config_hashmap
+        cls.param_obj = param_obj
         cls.semaphore = Semaphore(semaphore_count)
         cls.base_log_path = base_log_path
         cls.log_level = log_level
@@ -80,8 +80,8 @@ class TestRunner:
 
         # to calculate time spent to execute the test
         start = time.time()
-        runner_thread_obj = RunnerThread(str(uuid.uuid1().int), tc_class,
-                                         cls.config_hashmap,
+        runner_thread_obj = RunnerThread(tc_class, cls.param_obj,
+                                         test_dict["moduleName"][:-3],
                                          test_dict["volType"], tc_log_path,
                                          cls.log_level, thread_flag)
         test_stats = runner_thread_obj.run_thread()

--- a/tests/example/sample_component/test_file_creation.py
+++ b/tests/example/sample_component/test_file_creation.py
@@ -3,7 +3,7 @@ This file contains a test-case which tests
 the creation of different types of files and
 some operations on it.
 """
-# disruptive;
+# nonDisruptive;rep,dist,dist-rep
 
 from tests.parent_test import ParentTest
 

--- a/tests/example/sample_component/test_sample.py
+++ b/tests/example/sample_component/test_sample.py
@@ -29,39 +29,19 @@ class TestCase(ParentTest):
         servera = self.server_list[0]
         serverb = self.server_list[1]
         serverc = self.server_list[2]
-        redant.peer_probe(servera, serverb)
-        redant.peer_probe(serverc, serverb)
-        redant.peer_status(serverb)
-
-        volname = "dist"
-        mountpoint = "/mnt/dist"
 
         redant.execute_io_cmd("ls -l /root", servera)
-        redant.volume_create(volname,
-                             [f"{servera}:/glusterfs/brick/brick1",
-                              f"{serverb}:/glusterfs/brick/brick2",
-                              f"{serverc}:/glusterfs/brick//brick3"],
-                             serverb, force=True)
-        redant.volume_start(volname, serverc)
-        volume_status = redant.get_volume_status(serverb, volname)
+        volume_status = redant.get_volume_status(self.vol_name, servera)
         redant.logger.info(volume_status)
-        redant.execute_io_cmd(f"mkdir -p {mountpoint}", serverb)
-        redant.volume_mount(servera, volname, mountpoint, serverb)
-        redant.execute_io_cmd(f"cd {mountpoint} && touch " + "{1..100}",
-                              serverb)
-        redant.execute_io_cmd(f"ls -l {mountpoint}", serverb)
-        redant.execute_io_cmd(f"cd {mountpoint} && rm -rf ./*", serverb)
-        redant.execute_io_cmd(f"ls -l {mountpoint}", serverb)
+        redant.execute_io_cmd(f"cd {self.mountpoint} && touch " + "{1..100}",
+                              self.client_list[0])
+        redant.execute_io_cmd(f"ls -l {self.mountpoint}", self.client_list[0])
+        redant.execute_io_cmd(f"cd {self.mountpoint} && rm -rf ./*",
+                              self.client_list[0])
+        redant.execute_io_cmd(f"ls -l {self.mountpoint}", self.client_list[0])
 
         try:
             redant.execute_io_cmd("ls -l /non-exsisting-path", servera)
         except Exception as error:
             redant.logger.error(error)
             pass
-
-        redant.volume_stop(volname, servera)
-        redant.volume_delete(volname, servera)
-        redant.volume_unmount(mountpoint, serverb)
-        redant.execute_io_cmd(f"cd /mnt && rm -rf {mountpoint}", serverb)
-        redant.peer_detach(serverc, serverb)
-        redant.peer_detach(servera, serverb)

--- a/tests/example/sample_component/test_vol_creation.py
+++ b/tests/example/sample_component/test_vol_creation.py
@@ -1,0 +1,21 @@
+"""
+This file contains a test-case which tests
+the creation of different volume types.
+"""
+# nonDisruptive;rep,dist,dist-rep
+
+from tests.parent_test import ParentTest
+
+
+class TestCase(ParentTest):
+    """
+    The test case contains one function to test
+    for the creation of different types of files and
+    some operations on it.
+    """
+
+    def run_test(self, redant):
+        """
+        In the testcase:
+        """
+        pass

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -52,6 +52,12 @@ class ParentTest(metaclass=abc.ABCMeta):
             self.redant.volume_create(self.vol_name, self.server_list[0],
                                       self.volume_types_info[self.conv_dict[volume_type]],
                                       self.server_list, self.brick_roots, True)
+            self.redant.volume_start(self.vol_name, self.server_list[0])
+            self.mountpoint = (f"/mnt/{self.vol_name}")
+            self.redant.execute_io_cmd(f"mkdir -p {self.mountpoint}",
+                                       self.client_list[0])
+            self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                     self.mountpoint, self.client_list[0])
 
     def _configure(self, mname: str, server_details: dict,
                    client_details: dict, log_path: str, log_level: str):
@@ -93,6 +99,9 @@ class ParentTest(metaclass=abc.ABCMeta):
         Closes connection for now.
         """
         if self.volume_type != 'Generic':
+            self.redant.volume_unmount(self.mountpoint, self.client_list[0])
+            self.redant.execute_io_cmd(f"rm -rf {self.mountpoint}",
+                                       self.client_list[0])
             self.redant.volume_stop(self.vol_name, self.server_list[0], True)
             self.redant.volume_delete(self.vol_name, self.server_list[0])
         self.redant.deconstruct_connection()

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -14,7 +14,16 @@ class ParentTest(metaclass=abc.ABCMeta):
 
     """
 
-    def __init__(self, mname: str, config_hashmap: dict, volume_type: str,
+    conv_dict = {
+                    "dist" : "distributed",
+                    "rep" : "replicated",
+                    "dist-rep" : "distributed-replicated",
+                    "disp" : "dispersed",
+                    "dist-disp" : "distributed-dispersed",
+                    "arb" : "arbiter",
+                    "dist-arb" : "distributed-arbiter"
+                }
+    def __init__(self, mname: str, param_obj, volume_type: str,
                  thread_flag: bool, log_path: str, log_level: str = 'I'):
         """
         Creates volume
@@ -22,18 +31,23 @@ class ParentTest(metaclass=abc.ABCMeta):
         test case
         """
 
-        server_details = config_hashmap['servers_info']
-        client_details = config_hashmap['clients_info']
+        server_details = param_obj.get_server_config()
+        client_details = param_obj.get_client_config()
 
         self.TEST_RES = True
         self.volume_type = volume_type
-        self.server_list = []
-        self.client_list = []
-        self.volume_types_info = config_hashmap['volume_types']
-        self._configure(mname, server_details, client_details, log_path,
-                        log_level)
-        self.server_list = list(server_details.keys())
-        self.client_list = list(client_details.keys())
+        self.volume_types_info = param_obj.get_volume_types()
+        self._configure(f"{mname}-{volume_type}", server_details,
+                        client_details, log_path, log_level)
+        self.server_list = param_obj.get_server_ip_list()
+        self.client_list = param_obj.get_client_ip_list()
+        self.brick_roots = param_obj.get_brick_roots()
+
+        if self.volume_type != "Generic":
+            self.vol_name = (f"{mname}-{volume_type}")
+            self.redant.volume_create(self.vol_name, self.server_list[0],
+                                      self.volume_types_info[self.conv_dict[volume_type]],
+                                      self.server_list, self.brick_roots, True)
 
         if not thread_flag:
             self.redant.start_glusterd()
@@ -45,7 +59,7 @@ class ParentTest(metaclass=abc.ABCMeta):
         self.redant = RedantMixin(machine_detail)
         self.redant.init_logger(mname, log_path, log_level)
         self.redant.establish_connection()
-        self.test_name = log_path.split('/')[-1:][0][:-4]
+        self.test_name = mname
 
     @abc.abstractmethod
     def run_test(self):
@@ -78,4 +92,7 @@ class ParentTest(metaclass=abc.ABCMeta):
         """
         Closes connection for now.
         """
+        if self.volume_type != 'Generic':
+            self.redant.volume_stop(self.vol_name, self.server_list[0], True)
+            self.redant.volume_delete(self.vol_name, self.server_list[0])
         self.redant.deconstruct_connection()

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -43,15 +43,15 @@ class ParentTest(metaclass=abc.ABCMeta):
         self.client_list = param_obj.get_client_ip_list()
         self.brick_roots = param_obj.get_brick_roots()
 
+        if not thread_flag:
+            self.redant.start_glusterd()
+            self.redant.create_cluster(self.server_list)
+
         if self.volume_type != "Generic":
             self.vol_name = (f"{mname}-{volume_type}")
             self.redant.volume_create(self.vol_name, self.server_list[0],
                                       self.volume_types_info[self.conv_dict[volume_type]],
                                       self.server_list, self.brick_roots, True)
-
-        if not thread_flag:
-            self.redant.start_glusterd()
-            self.redant.create_cluster(self.server_list)
 
     def _configure(self, mname: str, server_details: dict,
                    client_details: dict, log_path: str, log_level: str):


### PR DESCRIPTION
Multiple code changes:
1. Volume creation method modified to handle replica,
distributed and distributed-replica volume with servers
having single brick root.
2. Param handler methods converted from class methods to
regular methods so that gc doesn't do a cleanup after
object goes out of scope.

Fixes: #209
Updates: #186

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
