### PR TITLE
Converting threading to multiprocessing

### DIFF
--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -89,10 +89,10 @@ def main():
     # Environment cleanup. TBD.
 
     print(f"\nTotal time taken by the framework: {time.time()-start} sec")
-    while not all_test_results.empty():
-        print(all_test_results.get())
+    
+    ResultHandler.handle_results(all_test_results, args.result_path)
 
-#    ResultHandler.handle_results(all_test_results, args.result_path)
+
 
 
 if __name__ == '__main__':

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -90,7 +90,7 @@ def main():
 
     print(f"\nTotal time taken by the framework: {time.time()-start} sec")
     
-    ResultHandler.handle_results(result_queue, TestRunner.test_results,  args.result_path)
+    ResultHandler.handle_results(result_queue, args.result_path)
 
 
 

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -84,13 +84,13 @@ def main():
     # invoke the test_runner.
     TestRunner.init(test_cases_dict, param_obj, args.log_dir,
                     args.log_level, args.concur_count)
-    all_test_results = TestRunner.run_tests()
+    result_queue = TestRunner.run_tests()
 
     # Environment cleanup. TBD.
 
     print(f"\nTotal time taken by the framework: {time.time()-start} sec")
     
-    ResultHandler.handle_results(all_test_results, args.result_path)
+    ResultHandler.handle_results(result_queue, TestRunner.test_results,  args.result_path)
 
 
 

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -40,7 +40,7 @@ def pars_args():
                         dest="log_level", default="I", type=str)
     parser.add_argument("-cc", "--concurrency-count",
                         help="Number of concurrent test runs",
-                        dest="semaphore_count", default=4, type=int)
+                        dest="concur_count", default=4, type=int)
     parser.add_argument("-rf", "--result-file",
                         help="Result file. By default it will be None",
                         dest="result_path", default=None, type=str)
@@ -83,14 +83,16 @@ def main():
 
     # invoke the test_runner.
     TestRunner.init(test_cases_dict, param_obj, args.log_dir,
-                    args.log_level, args.semaphore_count)
+                    args.log_level, args.concur_count)
     all_test_results = TestRunner.run_tests()
 
     # Environment cleanup. TBD.
 
     print(f"\nTotal time taken by the framework: {time.time()-start} sec")
+    while not all_test_results.empty():
+        print(all_test_results.get())
 
-    ResultHandler.handle_results(all_test_results, args.result_path)
+#    ResultHandler.handle_results(all_test_results, args.result_path)
 
 
 if __name__ == '__main__':

--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -72,7 +72,7 @@ class ResultHandler:
         file.close()
 
     @classmethod
-    def handle_results(cls, test_results: dict, result_path: str):
+    def handle_results(cls, result_queue_non_dis, test_results_dis: dict, result_path: str):
         """
         This function handles the results
         for the framework. It checks
@@ -81,9 +81,23 @@ class ResultHandler:
         specified by the user
 
         Args:
-        test_results: all the tests results
+        test_results_dis: all the disruptive tests results
+        result_queue_non_dis : all the non-disruptive tests results
         result_path: path of the result file
         """
+        print(f"Test_results_dis:{test_results_dis}")
+        print(f"Non-disruptive queue:")
+        test_results = test_results_dis
+
+        while not result_queue_non_dis.empty():
+        
+            curr_item = result_queue_non_dis.get()
+            print(curr_item)
+            key = list(curr_item.keys())[0]
+            value = curr_item[key]
+            test_results[key].append(value)
+        
+
         if result_path is None:
             cls._display_test_results(test_results)
         else:

--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -72,7 +72,7 @@ class ResultHandler:
         file.close()
 
     @classmethod
-    def handle_results(cls, result_queue_non_dis, test_results_dis: dict, result_path: str):
+    def handle_results(cls, result_queue, result_path: str):
         """
         This function handles the results
         for the framework. It checks
@@ -81,20 +81,20 @@ class ResultHandler:
         specified by the user
 
         Args:
-        test_results_dis: all the disruptive tests results
-        result_queue_non_dis : all the non-disruptive tests results
+        result_queue: a queue of results
         result_path: path of the result file
         """
-        print(f"Test_results_dis:{test_results_dis}")
-        print(f"Non-disruptive queue:")
-        test_results = test_results_dis
+        test_results = {}
 
-        while not result_queue_non_dis.empty():
+        while not result_queue.empty():
         
-            curr_item = result_queue_non_dis.get()
-            print(curr_item)
+            curr_item = result_queue.get()
             key = list(curr_item.keys())[0]
             value = curr_item[key]
+
+            if key not in test_results.keys():
+                test_results[key] = []
+
             test_results[key].append(value)
         
 

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -59,17 +59,14 @@ class TestRunner:
                 proc.join()
 
         for test in cls.non_concur_test:
-            # cls.test_results[test['moduleName'][:-3]] = []
             cls._run_test(test)
 
         """
-        Because of the infinitesimal delay in the Queue
-        it was found that sometimes the
-        Queue was empty while the other times.
-        Although this is not the correct way
-        to handle it but can be considered for now.
+        Because of the infinitesimal delay in value being reflected in Queue
+        it was found that sometimes the Queue which was empty had been given
+        some value, it still showed itself as empty.
+        TODO: Handle it without sleep.
         """
-        # if not bool(cls.concur_count):
         while cls.job_result_queue.empty():
             time.sleep(1)
 
@@ -81,7 +78,6 @@ class TestRunner:
         This method creates the threadlist for non disruptive tests
         """
         for test in cls.concur_test:
-            # cls.test_results[test['moduleName'][:-3]] = []
             cls.nd_job_queue.put(test)
         
     @classmethod
@@ -115,7 +111,6 @@ class TestRunner:
             print(Fore.RED + result_text)
             print(Style.RESET_ALL)
 
-        # cls.test_results[test_dict["moduleName"][:-3]].append(test_stats)
         result_value = { test_dict["moduleName"][:-3] : test_stats }
         cls.job_result_queue.put(result_value)
 

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -55,19 +55,14 @@ class TestRunner:
                 else:
                    backoff_time += 1
 
-        while not cls.job_result_queue.empty():
-            curr_item = cls.job_result_queue.get()
-            key = list(curr_item.keys())[0]
-            value = curr_item[key]
-            cls.test_results[key].append(value)
+            for iter in range(cls.concur_count):
+                proc.join()
 
         for test in cls.non_concur_test:
             cls.test_results[test['moduleName'][:-3]] = []
             cls._run_test(test)
 
-
-
-        return cls.test_results
+        return cls.job_result_queue
 
     @classmethod
     def _prepare_thread_tests(cls):

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -20,7 +20,7 @@ class TestRunner:
     @classmethod
     def init(cls, test_run_dict: dict, param_obj: dict,
              base_log_path: str, log_level: str, multiprocess_count: int):
-        cls.test_results = {}
+        # cls.test_results = {}
         cls.param_obj = param_obj
         cls.concur_count = multiprocess_count
         cls.base_log_path = base_log_path
@@ -59,8 +59,19 @@ class TestRunner:
                 proc.join()
 
         for test in cls.non_concur_test:
-            cls.test_results[test['moduleName'][:-3]] = []
+            # cls.test_results[test['moduleName'][:-3]] = []
             cls._run_test(test)
+
+        """
+        Because of the infinitesimal delay in the Queue
+        it was found that sometimes the
+        Queue was empty while the other times.
+        Although this is not the correct way
+        to handle it but can be considered for now.
+        """
+        # if not bool(cls.concur_count):
+        while cls.job_result_queue.empty():
+            time.sleep(1)
 
         return cls.job_result_queue
 
@@ -70,7 +81,7 @@ class TestRunner:
         This method creates the threadlist for non disruptive tests
         """
         for test in cls.concur_test:
-            cls.test_results[test['moduleName'][:-3]] = []
+            # cls.test_results[test['moduleName'][:-3]] = []
             cls.nd_job_queue.put(test)
         
     @classmethod
@@ -104,7 +115,7 @@ class TestRunner:
             print(Fore.RED + result_text)
             print(Style.RESET_ALL)
 
-        cls.test_results[test_dict["moduleName"][:-3]].append(test_stats)
+        # cls.test_results[test_dict["moduleName"][:-3]].append(test_stats)
         result_value = { test_dict["moduleName"][:-3] : test_stats }
         cls.job_result_queue.put(result_value)
 

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -57,11 +57,10 @@ class TestRunner:
 
         while not cls.job_result_queue.empty():
             curr_item = cls.job_result_queue.get()
-            print(curr_item)
             key = list(curr_item.keys())[0]
             value = curr_item[key]
             cls.test_results[key].append(value)
-            
+
         for test in cls.non_concur_test:
             cls.test_results[test['moduleName'][:-3]] = []
             cls._run_test(test)

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -20,7 +20,6 @@ class TestRunner:
     @classmethod
     def init(cls, test_run_dict: dict, param_obj: dict,
              base_log_path: str, log_level: str, multiprocess_count: int):
-        # cls.test_results = {}
         cls.param_obj = param_obj
         cls.concur_count = multiprocess_count
         cls.base_log_path = base_log_path

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -5,7 +5,7 @@ to be run and invoking them.
 import uuid
 import time
 from datetime import datetime
-from threading import Thread, Semaphore
+from multiprocessing import Process, Queue
 from colorama import Fore, Style
 from runner_thread import RunnerThread
 
@@ -19,15 +19,16 @@ class TestRunner:
 
     @classmethod
     def init(cls, test_run_dict: dict, param_obj: dict,
-             base_log_path: str, log_level: str, semaphore_count: int):
+             base_log_path: str, log_level: str, multiprocess_count: int):
         cls.param_obj = param_obj
-        cls.semaphore = Semaphore(semaphore_count)
+        cls.concur_count = multiprocess_count
         cls.base_log_path = base_log_path
         cls.log_level = log_level
         cls.concur_test = test_run_dict["nonDisruptive"]
         cls.non_concur_test = test_run_dict["disruptive"]
         cls.threadList = []
-        cls.test_results = {}
+        cls.job_result_queue = Queue()
+        cls.nd_job_queue = Queue()
         cls._prepare_thread_tests()
 
     @classmethod
@@ -36,44 +37,43 @@ class TestRunner:
         The non-disruptive tests are invoked followed by the disruptive
         tests.
         """
-        for test_thread in cls.threadList:
-            test_thread.start()
+        jobs = []
+        if bool(cls.concur_count):
+            for iter in range(cls.concur_count):
+                proc = Process(target=cls._worker_process,
+                               args=(cls.nd_job_queue,))
+                jobs.append(proc)
+                proc.start()
 
-        for test_thread in cls.threadList:
-            test_thread.join()
-
-        thread_flag = False
+            # TODO replace incremental backup with a signalling and lock.
+            backoff_time = 0
+            while len(jobs) > 0:
+                jobs = [job for job in jobs if job.is_alive()]
+                if backoff_time == 20:
+                    time.sleep(backoff_time)
+                else:
+                   backoff_time += 1
 
         for test in cls.non_concur_test:
-            cls.test_results[test['moduleName'][:-3]] = []
+            cls._run_test(test)
 
-        for test in cls.non_concur_test:
-            cls._run_test(test, thread_flag)
-
-        return cls.test_results
+        return cls.job_result_queue
 
     @classmethod
     def _prepare_thread_tests(cls):
         """
         This method creates the threadlist for non disruptive tests
         """
-        thread_flag = True
-
         for test in cls.concur_test:
-            cls.test_results[test['moduleName'][:-3]] = []
-
-        for test in cls.concur_test:
-            cls.threadList.append(Thread(target=cls._run_test,
-                                         args=(test, thread_flag,)))
+            print(test)
+            cls.nd_job_queue.put(test)
 
     @classmethod
-    def _run_test(cls, test_dict: dict, thread_flag: bool):
+    def _run_test(cls, test_dict: dict, thread_flag: bool=False):
         """
         A generic method handling the run of both disruptive and non
         disruptive tests.
         """
-        if thread_flag:
-            cls.semaphore.acquire()
         tc_class = test_dict["testClass"]
         tc_log_path = cls.base_log_path+test_dict["modulePath"][5:-3]+"/" +\
             test_dict["volType"]+"/"+test_dict["moduleName"][:-3]+".log"
@@ -98,7 +98,16 @@ class TestRunner:
             test_stats['testResult'] = "FAIL"
             print(Fore.RED + result_text)
             print(Style.RESET_ALL)
-        if thread_flag:
-            cls.semaphore.release()
+        result_value = { test_dict["moduleName"][:-3] : test_stats }
+        cls.job_result_queue.put(result_value)
 
-        cls.test_results[test_dict['moduleName'][:-3]].append(test_stats)
+    @classmethod
+    def _worker_process(cls, nd_queue):
+        """
+        Worker process would be taking up new jobs from the queue
+        till the queue is empty. This queue will consist only non disruptive
+        test cases.
+        """
+        while not nd_queue.empty():
+            job_data = nd_queue.get()
+            cls._run_test(job_data, True)


### PR DESCRIPTION
The current implementation will have a bottleneck because of
the nature of how threads are executed in python, wherein threads
and the main process share the GIL even though the system might
boast of multiple processor cores.

To work around this bottleneck in python, multiprocessing module
can be used. Now one can argue that multiprocess will create a
separate process in the background and that this will be heavier than
a thread and also would consume more time than spinning up a new thread.

To solve this, we use the idea of worker processes taking up tasks from
a queue, hence processes are spun up once and are killed only when there
is no job in the queue.

One more point to note is that the multiprocessing requires some mechanism of
locking to prevent the main process form going ahead with its flow ( which in
our case would be the execution of the disruptive test cases ). Now for the time
being we have an incremental backoff system with sleep till all jobs are dead.

This will have to be replaced with a sophesticated locking and signalling mechanism.

Fixes: #229

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
