### PR TITLE
User credentials are removed from config file

### DIFF
--- a/config/CONFIG_README.md
+++ b/config/CONFIG_README.md
@@ -6,39 +6,28 @@ The components of the config.yml file are as follows:
 
 <h3>1. servers_info</h3>
 'servers_info' is info about each server in the cluster.<br>
-Each server is defined by its ip address.
-Each server should contain 4 attributes:<br>
-1) ip(key representing server): ip address of the server.<br>
-2) brick_root: the list of directories where bricks have to be created.<br>
-3) user: the username of the server for ssh connection.<br>
-4) passwd: the password of the server for ssh connection.<br>
-All the above attributes have to defined by the user.<br>
+Each server is defined by its ip address which acts as a key representing the server.<br>
+Each server should contain 1 attributes:<br>
+1) brick_root: the list of directories where bricks have to be created.<br>
+The above attribute has to be defined by the user.<br>
 If a new server has to added, then it has to follow the convention of the
-previous servers
+previous servers.
 
 Example format of one server:<br>
 
 ip:<br>
     &nbsp;&nbsp;&nbsp;&nbsp; brick_root: ["/bricks","/gluster"]<br>
-    &nbsp;&nbsp;&nbsp;&nbsp; user: "root"<br>
-    &nbsp;&nbsp;&nbsp;&nbsp; passwd: "redhat"<br>
 
 <h3>2. clients_info</h3>
 'clients_info' is info about each client in the cluster.<br>
-Each client is defined by its ip address.
-Each client should contain 3 attributes:<br>
-1) ip: ip address of the client.<br>
-2) user: the username of the client for ssh connection.<br>
-3) passwd: the password of the client for ssh connection.<br>
-All the above attributes have to defined by the user.<br>
+Each client is defined by its ip address which acts as a key representing the client.<br>
+The client does not take any attribute values.<br>
 If a new client has to added, then it has to follow the convention of the
-previous clients 
+previous clients. 
 
 Example format of one client:<br>
 
 ip:<br>
-   &nbsp;&nbsp;&nbsp;&nbsp; user: "root"<br>
-   &nbsp;&nbsp;&nbsp;&nbsp; passwd: "redhat"<br>
 
 <h3>3. volume_types</h3>
 'volume_types' defines different volume types that we can create in

--- a/config/CONFIG_README.md
+++ b/config/CONFIG_README.md
@@ -7,7 +7,7 @@ The components of the config.yml file are as follows:
 <h3>1. servers_info</h3>
 'servers_info' is info about each server in the cluster.<br>
 Each server is defined by its ip address which acts as a key representing the server.<br>
-Each server should contain 1 attributes:<br>
+Each server should contain 1 attribute:<br>
 1) brick_root: the list of directories where bricks have to be created.<br>
 The above attribute has to be defined by the user.<br>
 If a new server has to added, then it has to follow the convention of the

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,29 +6,17 @@
 servers_info:
     "1.1.1.1":
         brick_root: ["/bricks"]
-        user: "root"
-        passwd: "redhat"
     "2.2.2.2":
         brick_root: ["/bricks"]
-        user: "root"
-        passwd: "redhat"
     "3.3.3.3":
         brick_root: ["/bricks"]
-        user: "root"
-        passwd: "redhat"
     "4.4.4.4":
         brick_root: ["/bricks"]
-        user: "root"
-        passwd: "redhat"
         
 #clients_info - All the relevant information about the clients
 clients_info:
     "5.5.5.5":
-        user: "root"
-        passwd: "redhat"
     "6.6.6.6":
-        user: 'root'
-        passwd: "redhat"
 
 #volume_types - Indivudual volume type information and minimum servers for
 #               each volume type


### PR DESCRIPTION
username and password for the nodes are removed from the config file
as they are redundant after incorporating passwordless ssh into the
test framework.

Fixes: #240
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>