### PR TITLE
Added message to handle connection failure

### DIFF
--- a/common/rexe.py
+++ b/common/rexe.py
@@ -36,15 +36,14 @@ class Rexe:
                 node_ssh_client.connect(
                     hostname=node,
                     pkey=mykey,
+                    timeout=15,
                     )
 
                 self.logger.debug(f"SSH connection to {node} is successful.")
             except Exception as e:
                 self.logger.error(f"Connection failure. Exception : {e}")
                 self.connect_flag = False
-                print(f"Connection failed on {node}.\nTake a look in the main.log file for more details")
-                exit(0)
-                # raise e
+                raise e
             self.node_dict[node] = node_ssh_client
 
     def deconstruct_connection(self):

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -42,7 +42,9 @@ class Rexe:
             except Exception as e:
                 self.logger.error(f"Connection failure. Exception : {e}")
                 self.connect_flag = False
-                raise e
+                print(f"Connection failed on {node}.\nTake a look in the main.log file for more details")
+                exit(0)
+                # raise e
             self.node_dict[node] = node_ssh_client
 
     def deconstruct_connection(self):

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -18,7 +18,7 @@ class Rexe:
         """
         return random.choice(list(self.node_dict.keys()))
 
-    def establish_connection(self):
+    def establish_connection(self, timeout=15):
         """
         Function to establish connection with the given
         set of hosts.
@@ -36,7 +36,7 @@ class Rexe:
                 node_ssh_client.connect(
                     hostname=node,
                     pkey=mykey,
-                    timeout=15,
+                    timeout=timeout,
                     )
 
                 self.logger.debug(f"SSH connection to {node} is successful.")

--- a/core/environ.py
+++ b/core/environ.py
@@ -1,5 +1,7 @@
 import sys
 sys.path.insert(1, ".")
+import paramiko
+from socket import timeout
 from common.mixin import RedantMixin
 
 class environ:
@@ -15,7 +17,35 @@ class environ:
         """
         self.redant = RedantMixin(param_obj.get_server_config())
         self.redant.init_logger("environ", log_path, log_level)
-        self.redant.establish_connection()
+        try:
+            self.redant.establish_connection()
+        except paramiko.ssh_exception.NoValidConnectionsError as e:
+            print(f'''
+            It seems one of the nodes is down. 
+            Message: {e}.
+            Check and run again.
+            ''')
+            exit(0)
+        except paramiko.ssh_exception.AuthenticationException as e:
+            print(f"""
+            Authentication failed.
+            Message: {e}
+            Check and run again.
+            """)
+
+            exit(0)
+        except timeout as e:
+            print(f"""
+            Oops! There was a timeout connecting the servers.
+            Message:{e}
+            Check and run again.
+            """)
+
+            exit(0)
+        except Exception as e:
+            print(e)
+            exit(0)
+            
         self.server_list = param_obj.get_server_ip_list()
 
     def setup_env(self):

--- a/tests/functional/glusterd/test_glusterd_start_stop.py
+++ b/tests/functional/glusterd/test_glusterd_start_stop.py
@@ -17,7 +17,7 @@ class TestCase(ParentTest):
         """
         The following steps are undertaken in the testcase:
         1) glusterd service is started on the server.
-        4) glusterd service is stopped.
+        2) glusterd service is stopped.
         """
         for _ in range(5):
             redant.stop_glusterd(self.server_list)


### PR DESCRIPTION
Previously, on shutdown or connection failure a stact traceback was
displayed. Instead, a simple message is being displayed in its place
now.

Fixes: #236

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
