### PR TITLE
Gluster Operations shifted from parent test constructor to parent_test_run

### DIFF
--- a/core/runner_thread.py
+++ b/core/runner_thread.py
@@ -10,12 +10,10 @@ class RunnerThread:
     functions for running it.
     """
 
-    def __init__(self, tc_class, param_obj, mname: str,
-                 volume_type: str, log_path: str, log_level: str,
-                 thread_flag : bool):
+    def __init__(self, tc_class, param_obj, volume_type: str,
+                 mname: str, log_path: str, log_level: str):
         # Creating the test case object from the test case.
-        self.tc_obj = tc_class(mname, param_obj, volume_type,
-                               thread_flag, log_path, log_level)
+        self.tc_obj = tc_class(mname, param_obj, volume_type, log_path, log_level)
         self.run_test_func = getattr(self.tc_obj, "parent_run_test")
         self.terminate_test_func = getattr(self.tc_obj, "terminate")
         self.test_stats = {
@@ -23,11 +21,11 @@ class RunnerThread:
             'volType': volume_type
         }
 
-    def run_thread(self):
+    def run_thread(self, mname: str, volume_type: str, thread_flag: bool):
         """
         Method to trigger the run test and the terminate test functions.
         """
-        self.run_test_func()
+        self.run_test_func(mname, volume_type, thread_flag)
         self.terminate_test_func()
         self.test_stats['testResult'] = self.tc_obj.TEST_RES
         return self.test_stats

--- a/core/test_runner.py
+++ b/core/test_runner.py
@@ -78,7 +78,7 @@ class TestRunner:
         """
         for test in cls.concur_test:
             cls.nd_job_queue.put(test)
-        
+
     @classmethod
     def _run_test(cls, test_dict: dict, thread_flag: bool=False):
         """
@@ -86,16 +86,18 @@ class TestRunner:
         disruptive tests.
         """
         tc_class = test_dict["testClass"]
+        volume_type = test_dict["volType"]
+        mname = test_dict["moduleName"][:-3]
+
         tc_log_path = cls.base_log_path+test_dict["modulePath"][5:-3]+"/" +\
-            test_dict["volType"]+"/"+test_dict["moduleName"][:-3]+".log"
+            volume_type+"/"+mname+".log"
 
         # to calculate time spent to execute the test
         start = time.time()
-        runner_thread_obj = RunnerThread(tc_class, cls.param_obj,
-                                         test_dict["moduleName"][:-3],
-                                         test_dict["volType"], tc_log_path,
-                                         cls.log_level, thread_flag)
-        test_stats = runner_thread_obj.run_thread()
+
+        runner_thread_obj = RunnerThread(tc_class, cls.param_obj, volume_type,
+                                         mname, tc_log_path, cls.log_level)
+        test_stats = runner_thread_obj.run_thread(mname, volume_type, thread_flag)
 
         test_stats['timeTaken'] = time.time() - start
         result_text = test_dict["moduleName"][:-3]+"-"+test_dict["volType"]

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -1,7 +1,7 @@
 import traceback
 import abc
-from common.mixin import RedantMixin
 from datetime import datetime
+from common.mixin import RedantMixin
 
 
 class ParentTest(metaclass=abc.ABCMeta):
@@ -82,6 +82,13 @@ class ParentTest(metaclass=abc.ABCMeta):
                 self.redant.volume_mount(self.server_list[0], self.vol_name,
                                         self.mountpoint, self.client_list[0])
             self.run_test(self.redant)
+
+            if self.volume_type != 'Generic':
+                self.redant.volume_unmount(self.mountpoint, self.client_list[0])
+                self.redant.execute_io_cmd(f"rm -rf {self.mountpoint}",
+                                        self.client_list[0])
+                self.redant.volume_stop(self.vol_name, self.server_list[0], True)
+                self.redant.volume_delete(self.vol_name, self.server_list[0])
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)
@@ -97,10 +104,4 @@ class ParentTest(metaclass=abc.ABCMeta):
         """
         Closes connection for now.
         """
-        if self.volume_type != 'Generic':
-            self.redant.volume_unmount(self.mountpoint, self.client_list[0])
-            self.redant.execute_io_cmd(f"rm -rf {self.mountpoint}",
-                                       self.client_list[0])
-            self.redant.volume_stop(self.vol_name, self.server_list[0], True)
-            self.redant.volume_delete(self.vol_name, self.server_list[0])
         self.redant.deconstruct_connection()

--- a/tests/parent_test.py
+++ b/tests/parent_test.py
@@ -24,7 +24,7 @@ class ParentTest(metaclass=abc.ABCMeta):
                     "dist-arb" : "distributed-arbiter"
                 }
     def __init__(self, mname: str, param_obj, volume_type: str,
-                 thread_flag: bool, log_path: str, log_level: str = 'I'):
+                 log_path: str, log_level: str = 'I'):
         """
         Creates volume
         And runs the specific component in the
@@ -43,22 +43,6 @@ class ParentTest(metaclass=abc.ABCMeta):
         self.client_list = param_obj.get_client_ip_list()
         self.brick_roots = param_obj.get_brick_roots()
 
-        if not thread_flag:
-            self.redant.start_glusterd()
-            self.redant.create_cluster(self.server_list)
-
-        if self.volume_type != "Generic":
-            self.vol_name = (f"{mname}-{volume_type}")
-            self.redant.volume_create(self.vol_name, self.server_list[0],
-                                      self.volume_types_info[self.conv_dict[volume_type]],
-                                      self.server_list, self.brick_roots, True)
-            self.redant.volume_start(self.vol_name, self.server_list[0])
-            self.mountpoint = (f"/mnt/{self.vol_name}")
-            self.redant.execute_io_cmd(f"mkdir -p {self.mountpoint}",
-                                       self.client_list[0])
-            self.redant.volume_mount(self.server_list[0], self.vol_name,
-                                     self.mountpoint, self.client_list[0])
-
     def _configure(self, mname: str, server_details: dict,
                    client_details: dict, log_path: str, log_level: str):
         machine_detail = {**client_details, **server_details}
@@ -71,7 +55,7 @@ class ParentTest(metaclass=abc.ABCMeta):
     def run_test(self):
         pass
 
-    def parent_run_test(self):
+    def parent_run_test(self, mname: str, volume_type: str, thread_flag: bool):
         """
         Function to handle the exception logic and invokes the run_test
         which is overridden by every TC.
@@ -82,6 +66,21 @@ class ParentTest(metaclass=abc.ABCMeta):
         ============================================================
         ''')
         try:
+            if not thread_flag:
+                self.redant.start_glusterd()
+                self.redant.create_cluster(self.server_list)
+
+            if self.volume_type != "Generic":
+                self.vol_name = (f"{mname}-{volume_type}")
+                self.redant.volume_create(self.vol_name, self.server_list[0],
+                                        self.volume_types_info[self.conv_dict[volume_type]],
+                                        self.server_list, self.brick_roots, True)
+                self.redant.volume_start(self.vol_name, self.server_list[0])
+                self.mountpoint = (f"/mnt/{self.vol_name}")
+                self.redant.execute_io_cmd(f"mkdir -p {self.mountpoint}",
+                                        self.client_list[0])
+                self.redant.volume_mount(self.server_list[0], self.vol_name,
+                                        self.mountpoint, self.client_list[0])
             self.run_test(self.redant)
         except Exception as error:
             tb = traceback.format_exc()


### PR DESCRIPTION
Gluster Operations are shifted from constructor of parent test to
parent_test_run under the try-except clause

Fixes: #239
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>