### PR TITLE
Added arbiter option in volume create

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -105,11 +105,12 @@ class VolumeOps(AbstractOps):
         if "replica_count" in conf_hash:
             mul_fac = conf_hash["replica_count"]
 
+            if "arbiter_count" in conf_hash:
+                mul_fac += conf_hash["arbiter_count"]
+                
             if "dist_count" in conf_hash:
                 mul_fac *= conf_hash["dist_count"]
 
-            if "arbiter_count" in conf_hash:
-                mul_fac += conf_hash["arbiter_count"]
 
         elif "dist_count" in conf_hash:
             mul_fac = conf_hash["dist_count"]

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -108,7 +108,7 @@ class VolumeOps(AbstractOps):
             if "dist_count" in conf_hash:
                 mul_fac *= conf_hash["dist_count"]
 
-            if "arbiter_count" in conf_hash["arbiter_count"]:
+            if "arbiter_count" in conf_hash:
                 mul_fac += conf_hash["arbiter_count"]
 
         elif "dist_count" in conf_hash:

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -104,8 +104,13 @@ class VolumeOps(AbstractOps):
         cmd = ""
         if "replica_count" in conf_hash:
             mul_fac = conf_hash["replica_count"]
+
             if "dist_count" in conf_hash:
                 mul_fac *= conf_hash["dist_count"]
+
+            if "arbiter_count" in conf_hash["arbiter_count"]:
+                mul_fac += conf_hash["arbiter_count"]
+
         elif "dist_count" in conf_hash:
             mul_fac = conf_hash["dist_count"]
 
@@ -124,7 +129,11 @@ class VolumeOps(AbstractOps):
             server_iter += 1
 
         if "replica_count" in conf_hash:
-            cmd = (f"gluster volume create {volname} replica {conf_hash['replica_count']}{brick_cmd}")
+            if "arbiter_count" in conf_hash:
+                cmd = (f"gluster volume create {volname} replica {conf_hash['replica_count']} arbiter {conf_hash['arbiter_count']}{brick_cmd}")
+
+            else:
+                cmd = (f"gluster volume create {volname} replica {conf_hash['replica_count']}{brick_cmd}")
         else:
             cmd = (f"gluster volume create {volname}{brick_cmd}")
         if force:

--- a/config/config.yml
+++ b/config/config.yml
@@ -46,6 +46,6 @@ volume_types:
         transport: tcp
     distributed-arbiter:
         dist_count: 2
-        replica_count: 3
+        replica_count: 2
         arbiter_count: 1
         transport: tcp

--- a/config/config.yml
+++ b/config/config.yml
@@ -41,7 +41,7 @@ volume_types:
         redundancy_count: 2
         transport: tcp
     arbiter:
-        replica_count: 3
+        replica_count: 2
         arbiter_count: 1
         transport: tcp
     distributed-arbiter:

--- a/tests/example/sample_component/test_vol_creation.py
+++ b/tests/example/sample_component/test_vol_creation.py
@@ -2,7 +2,7 @@
 This file contains a test-case which tests
 the creation of different volume types.
 """
-# nonDisruptive;rep,dist,dist-rep
+# nonDisruptive;rep,dist,dist-rep,arb,dist-arb
 
 from tests.parent_test import ParentTest
 


### PR DESCRIPTION
In volume ops, inside volume create added arbiter option to take care of
arbiter volume types.

Fixes: #260

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>