### PR TITLE
Changed parent test to abstract test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ test_list_builder, test_runner, runner_thread and redant_main.<br>
 common: consists of the libs and ops that will help in running the
 test cases and the mixin class.<br>
 tests: holds the test cases as performace and functional tests and includes
-parent test. Add any new test cases here.<br>
+abstract test. Add any new test cases here.<br>
 
 ## Set up
 

--- a/docs/RP/HLD.md
+++ b/docs/RP/HLD.md
@@ -60,7 +60,7 @@ understood if one were to divide it into three components,
      +----------------------+               | Performance | Component2 TCs |
      |       MIXIN          |               |             | Component3 TCs |
      +----------------------+               +------------------------------+
-                                            |       Parent Test            |
+                                            |       Abstract Test            |
                                             +------------------------------+
    
    
@@ -91,5 +91,5 @@ most interactions a user might have is with the tests component ( and ops if new
 and performance tests ( I guess the names are self explanatory ). And within these are sub-components which are usually the gluster specific classifications
 such as 'Glusterd', 'Geo-replication', 'Snapshot', etc. Each sub-component will contain the test cases catering to different scenarios wherein the said
 component figures in. All these test components are dependent upon the Common. Also, every test case derives some basic operational capability from a common
-parent test which lifts much of the repeated tasks usually done when a test case run begins and ends.
+abstract test which lifts much of the repeated tasks usually done when a test case run begins and ends.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -108,11 +108,11 @@ Non-disruptive: `#nonDisruptive`
 |  dist-disp | Distributed-disp |
 
 
-4. Now, import [ParentTest](https://github.com/srijan-sivakumar/redant/blob/main/tests/parent_test.py). Two questions that must come to your mind:
-- What is this Parent Test?
+4. Now, import [AbstractTest](https://github.com/srijan-sivakumar/redant/blob/main/tests/abstract_test.py). Two questions that must come to your mind:
+- What is this Abstract Test?
 - Why to import it in every test? :space_invader:
 
-[ParentTest](https://github.com/srijan-sivakumar/redant/blob/main/tests/parent_test.py), from the name itself it's almost clear that this test is parent to all the tests or is the superclass for all other tests. It has the standard functions that the tests inherit and might even override.
+[AbstractTest](https://github.com/srijan-sivakumar/redant/blob/main/tests/abstract_test.py), from the name itself it's almost clear that this test is abstract to all the tests or is the superclass for all other tests. It has the standard functions that the tests inherit and might even override.
 
 The functions that it has:
 * \_\_init\_\_() : This function not just acts as a constructor but also an initiator for each test case.
@@ -121,15 +121,15 @@ The functions that it has:
 * terminate() : This function takes care of the tasks that need to be done in the end of each test case like closing the connections etc.
 
 ```js
-from tests.parent_test import ParentTest
+from tests.abstract_test import AbstractTest
 ```
 
-5. Create a class that extends the `ParentTest`. This is important as we already know that all the tests need to follow a certain set of functionalities to be performed and rules to be followed to run them and these are all in the ParentTest. Without this statement, you cannot override the run_test() function in your test.
+5. Create a class that extends the `AbstractTest`. This is important as we already know that all the tests need to follow a certain set of functionalities to be performed and rules to be followed to run them and these are all in the AbstractTest. Without this statement, you cannot override the run_test() function in your test.
 ```js
-class TestCase(ParentTest):
+class TestCase(AbstractTest):
 ```
 
-6. Make a function `run_test`. This function basically overrides the run_test() function(as mentioned earlier) from the [ParentTest](https://github.com/srijan-sivakumar/redant/blob/main/tests/parent_test.py). Whatever, operation you want to perform needs to be a part of this function. You don't need to take care of the exception handling part as this is already taken care of by the ParentTest -> parent_run_test() function and hence all you need is call the ops and execute the functionalities. Moreover, remember to add `redant` as one of the arguments as it won't be able to override the run_test() function and you won't be able to call the ops without the redant object.
+6. Make a function `run_test`. This function basically overrides the run_test() function(as mentioned earlier) from the [AbstractTest](https://github.com/srijan-sivakumar/redant/blob/main/tests/abstract_test.py). Whatever, operation you want to perform needs to be a part of this function. You don't need to take care of the exception handling part as this is already taken care of by the AbstractTest -> parent_run_test() function and hence all you need is call the ops and execute the functionalities. Moreover, remember to add `redant` as one of the arguments as it won't be able to override the run_test() function and you won't be able to call the ops without the redant object.
 
 ```js
 def run_test(self, redant):

--- a/tests/abstract_test.py
+++ b/tests/abstract_test.py
@@ -3,7 +3,7 @@ import abc
 from common.mixin import RedantMixin
 
 
-class ParentTest(metaclass=abc.ABCMeta):
+class AbstractTest(metaclass=abc.ABCMeta):
 
     """
     This class contains the standard info and methods which are needed by

--- a/tests/example/sample_component/test_sample.py
+++ b/tests/example/sample_component/test_sample.py
@@ -5,10 +5,10 @@ service operations
 """
 # nonDisruptive;dist,rep,dist-rep,arb,dist-arb,disp,dist-disp
 
-from tests.parent_test import ParentTest
+from tests.abstract_test import AbstractTest
 
 
-class TestCase(ParentTest):
+class TestCase(AbstractTest):
     """
     The test case contains one function to test
     for glusterd service operations

--- a/tests/example/sample_component/test_vol_creation.py
+++ b/tests/example/sample_component/test_vol_creation.py
@@ -4,10 +4,10 @@ the creation of different volume types.
 """
 # nonDisruptive;rep,dist,dist-rep,arb,dist-arb,disp,dist-disp
 
-from tests.parent_test import ParentTest
+from tests.abstract_test import AbstractTest
 
 
-class TestCase(ParentTest):
+class TestCase(AbstractTest):
     """
     The test case contains one function to test
     for the creation of different types of files and

--- a/tests/functional/glusterd/test_glusterd_start_stop.py
+++ b/tests/functional/glusterd/test_glusterd_start_stop.py
@@ -4,10 +4,10 @@ starting and stopping of glusterd service.
 """
 # disruptive;
 
-from tests.parent_test import ParentTest
+from tests.abstract_test import AbstractTest
 
 
-class TestCase(ParentTest):
+class TestCase(AbstractTest):
     """
     The test case contains one function to test
     for glusterd service operations


### PR DESCRIPTION
The name parent test was very misleading as it was not exactly parent
but actually all the tests are abstracting the Parent test. Hence, this
confusion needs to be removed with a better nomenclature and the name
came upon with is Abstrat Test as it desccribes the class
straightforward.

Updates: #286

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
