### PR TITLE
[Test] Test glusterd set reset reserve limit

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -479,8 +479,8 @@ class VolumeOps(AbstractOps):
 
         return ret_dict
 
-    def get_volume_options(self, node: str = None, volname: str = 'all',
-                           option: str = 'all') -> dict:
+    def get_volume_options(self, volname: str = 'all', option: str = 'all',
+                           node: str = None) -> dict:
         """
         Gets the option values for a given volume.
         Args:
@@ -523,9 +523,10 @@ class VolumeOps(AbstractOps):
             option_value = option_i['Value']
             ret_dict[option_name] = option_value
 
-        return volume_options
+        return ret_dict
 
-    def set_volume_options(self, volname: str, options: str, node: str = None):
+    def set_volume_options(self, volname: str, options: dict,
+                           node: str = None):
         """
         Sets the option values for the given volume.
         Args:
@@ -554,6 +555,23 @@ class VolumeOps(AbstractOps):
                    f"{volume_options[option]} --mode=script --xml")
 
             self.execute_abstract_op_node(cmd, node)
+
+    def validate_volume_option(self, volname: str, options: dict,
+                               node: str = None):
+        """
+        Validate the volume options
+        Args:
+            node (str) : Node on which cmd has to be executed
+            volname (str) : volume name
+            option (dict) : dictionary of options which are to be validated.
+        Returns:
+            No value if success or else ValueError will be raised.
+        """
+        for (opt, val) in options.items():
+            ret_val = self.get_volume_options(volname, opt, node)
+            if ret_val[opt] != val:
+                raise ValueError
+        return
 
     def reset_volume_option(self, volname: str, option: str,
                             node: str = None, force: bool = False):

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -570,7 +570,8 @@ class VolumeOps(AbstractOps):
         for (opt, val) in options.items():
             ret_val = self.get_volume_options(volname, opt, node)
             if ret_val[opt] != val:
-                raise ValueError
+                raise Exception(f"Option {opt} has value {ret_val[opt]}"
+                                f" not {val}")
 
     def reset_volume_option(self, volname: str, option: str,
                             node: str = None, force: bool = False):

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -571,7 +571,6 @@ class VolumeOps(AbstractOps):
             ret_val = self.get_volume_options(volname, opt, node)
             if ret_val[opt] != val:
                 raise ValueError
-        return
 
     def reset_volume_option(self, volname: str, option: str,
                             node: str = None, force: bool = False):

--- a/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
+++ b/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
@@ -23,6 +23,7 @@ Description:
 
 from tests.abstract_test import AbstractTest
 
+
 class TestCase(AbstractTest):
     """ Testing set and reset of Reserve limit in GlusterD """
 

--- a/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
+++ b/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
@@ -77,7 +77,11 @@ class TestGlusterDSetResetReserveLimit(GlusterBaseClass):
         self.assertEqual(ret, 0, "Failed to reset the storage.reserve limit")
 
         # Validate that the storage.reserve option is reset
-        self.validate_vol_option('storage.reserve', '1 (DEFAULT)')
+        ret = get_volume_options(self.mnode, self.volname, 'storage.reserve')
+        if ret['storage.reserve'] == '1':
+            self.validate_vol_option('storage.reserve', '1')
+        else:
+            self.validate_vol_option('storage.reserve', '1 (DEFAULT)')
 
     def tearDown(self):
         """tear Down Callback"""

--- a/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
+++ b/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
@@ -1,95 +1,45 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
+  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 Description:
     Test set and reset of storage reserve limit in glusterd
 """
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import (
-    set_volume_options,
-    reset_volume_option,
-    get_volume_options)
+# nonDisruptive;rep,dist,arb,disp,dist-rep,dist-arb,dist-disp
 
+from tests.abstract_test import AbstractTest
 
-@runs_on([['distributed', 'distributed-replicated', 'distributed-arbiter',
-           'distributed-dispersed', 'replicated', 'arbiter', 'dispersed'],
-          ['glusterfs']])
-class TestGlusterDSetResetReserveLimit(GlusterBaseClass):
+class TestCase(AbstractTest):
     """ Testing set and reset of Reserve limit in GlusterD """
 
-    def setUp(self):
-        """Setup Volume"""
-        # Calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        # Setup and mount the volume
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to setup volume and mount it")
-
-    def validate_vol_option(self, option_name, value_expected):
-        """ Function for validating volume options """
-        # Get the volume option.
-        ret = get_volume_options(self.mnode, self.volname, option_name)
-        self.assertIsNotNone(ret, "The %s option is not present" % option_name)
-        self.assertEqual(ret[option_name], value_expected,
-                         ("Volume option for %s is not equal to %s"
-                          % (option_name, value_expected)))
-        g.log.info("Volume option %s is equal to the expected value %s",
-                   option_name, value_expected)
-
-    def test_glusterd_set_reset_reserve_limit(self):
+    def run_test(self, redant):
         """
         Test set and reset of reserve limit on glusterd
         1. Create a volume and start it.
         2. Set storage.reserve limit on the created volume and verify it.
         3. Reset storage.reserve limit on the created volume and verify it.
         """
-        # Setting storage.reserve to 50
-        ret = set_volume_options(self.mnode, self.volname,
-                                 {'storage.reserve': '50'})
-        self.assertTrue(ret, "Failed to set storage reserve on %s"
-                        % self.mnode)
-
-        # Validate storage.reserve option set to 50
-        self.validate_vol_option('storage.reserve', '50')
-
-        # Reseting the storage.reserve limit
-        ret, _, _ = reset_volume_option(self.mnode, self.volname,
-                                        'storage.reserve')
-        self.assertEqual(ret, 0, "Failed to reset the storage.reserve limit")
-
-        # Validate that the storage.reserve option is reset
-        ret = get_volume_options(self.mnode, self.volname, 'storage.reserve')
-        if ret['storage.reserve'] == '1':
-            self.validate_vol_option('storage.reserve', '1')
-        else:
-            self.validate_vol_option('storage.reserve', '1 (DEFAULT)')
-
-    def tearDown(self):
-        """tear Down Callback"""
-        # Unmount volume and cleanup.
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to unmount and cleanup volume")
-        g.log.info("Successful in unmount and cleanup of volume")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        redant.set_volume_options(self.vol_name, {'storage.reserve': '50'},
+                                  self.server_list[0])
+        redant.validate_volume_option(self.vol_name,
+                                      {'storage.reserve': '50'},
+                                      self.server_list[0])
+        redant.reset_volume_option(self.vol_name, 'storage.reserve',
+                                   self.server_list[0])
+        redant.validate_volume_option(self.vol_name,
+                                      {'storage.reserve': '1 (DEFAULT)'},
+                                      self.server_list[0])

--- a/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
+++ b/tests/functional/glusterd/test_glusterd_set_reset_reserve_limit.py
@@ -1,0 +1,91 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+    Test set and reset of storage reserve limit in glusterd
+"""
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import (
+    set_volume_options,
+    reset_volume_option,
+    get_volume_options)
+
+
+@runs_on([['distributed', 'distributed-replicated', 'distributed-arbiter',
+           'distributed-dispersed', 'replicated', 'arbiter', 'dispersed'],
+          ['glusterfs']])
+class TestGlusterDSetResetReserveLimit(GlusterBaseClass):
+    """ Testing set and reset of Reserve limit in GlusterD """
+
+    def setUp(self):
+        """Setup Volume"""
+        # Calling GlusterBaseClass setUp
+        self.get_super_method(self, 'setUp')()
+
+        # Setup and mount the volume
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume and mount it")
+
+    def validate_vol_option(self, option_name, value_expected):
+        """ Function for validating volume options """
+        # Get the volume option.
+        ret = get_volume_options(self.mnode, self.volname, option_name)
+        self.assertIsNotNone(ret, "The %s option is not present" % option_name)
+        self.assertEqual(ret[option_name], value_expected,
+                         ("Volume option for %s is not equal to %s"
+                          % (option_name, value_expected)))
+        g.log.info("Volume option %s is equal to the expected value %s",
+                   option_name, value_expected)
+
+    def test_glusterd_set_reset_reserve_limit(self):
+        """
+        Test set and reset of reserve limit on glusterd
+        1. Create a volume and start it.
+        2. Set storage.reserve limit on the created volume and verify it.
+        3. Reset storage.reserve limit on the created volume and verify it.
+        """
+        # Setting storage.reserve to 50
+        ret = set_volume_options(self.mnode, self.volname,
+                                 {'storage.reserve': '50'})
+        self.assertTrue(ret, "Failed to set storage reserve on %s"
+                        % self.mnode)
+
+        # Validate storage.reserve option set to 50
+        self.validate_vol_option('storage.reserve', '50')
+
+        # Reseting the storage.reserve limit
+        ret, _, _ = reset_volume_option(self.mnode, self.volname,
+                                        'storage.reserve')
+        self.assertEqual(ret, 0, "Failed to reset the storage.reserve limit")
+
+        # Validate that the storage.reserve option is reset
+        self.validate_vol_option('storage.reserve', '1 (DEFAULT)')
+
+    def tearDown(self):
+        """tear Down Callback"""
+        # Unmount volume and cleanup.
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to unmount and cleanup volume")
+        g.log.info("Successful in unmount and cleanup of volume")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()


### PR DESCRIPTION
The test case is concerned with reserve limit option in a volume.
Following set of operations are performed,
1. Set storage reserve limit to some value
2. validate it
3. Reset it
4. Validate if it is reset properly.

#Updates: #292
Signed-off-by: srijan-sivakumar ssivakum@redhat.com
<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
