### PR TITLE
Migration of test_glusterd_logs_when_peer_detach

### DIFF
--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -16,8 +16,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
   Description:
-        No Errors should generate in glusterd.log while detaching
-        node from gluster
+        Check for error in glusterd logs when a peer is detached
 """
 
 import random
@@ -48,7 +47,7 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
                                               self.server_list[0])
 
         # Clearing the existing glusterd log file
-        ret = redant.execute_abstract_op_node('echo > /var/log/glusterfs/'
+        ret = redant.execute_abstract_op_node('> /var/log/glusterfs/'
                                               'glusterd.log',
                                               self.server_list[0])
 
@@ -61,5 +60,5 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
                                               "glusterd.log | wc -l",
                                               self.server_list[0])
         if int(ret['msg'][0]) != 0:
-            redant.logger.info("Found Error messages in glusterd log "
-                               "file after peer detach")
+            raise Exception("Found Error messages in glusterd "
+                            "log file after peer detach")

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -41,13 +41,16 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
         timestamp = ret['msg'][0].rstrip("\n")
 
         #  glusterd logs
-        ret = redant.execute_abstract_op_node('cp /var/log/glusterfs/glusterd.log /var/'
-                                    f'log/glusterfs/glusterd_{timestamp}.log',
-                                    self.server_list[0])
+        ret = redant.execute_abstract_op_node('cp /var/log/glusterfs/'
+                                              'glusterd.log /var/log/'
+                                              'glusterfs/'
+                                              f'glusterd_{timestamp}.log',
+                                              self.server_list[0])
 
         # Clearing the existing glusterd log file
-        ret = redant.execute_abstract_op_node('echo > /var/log/glusterfs/glusterd.log',
-                                    self.server_list[0])
+        ret = redant.execute_abstract_op_node('echo > /var/log/glusterfs/'
+                                              'glusterd.log',
+                                              self.server_list[0])
 
         # Performing peer detach
         random_server = random.choice(self.server_list[1:])
@@ -55,8 +58,8 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
 
         # Searching for error message in log
         ret = redant.execute_abstract_op_node("grep ' E ' /var/log/glusterfs/"
-                                    "glusterd.log | wc -l",
-                                    self.server_list[0])
+                                              "glusterd.log | wc -l",
+                                              self.server_list[0])
         if int(ret['msg'][0]) != 0:
             redant.logger.info("Found Error messages in glusterd log "
                                "file after peer detach")

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -1,52 +1,34 @@
-#  Copyright (C) 2018-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2018-2020  Red Hat, Inc. <http://www.redhat.com>
 
-""" Description:
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
         No Errors should generate in glusterd.log while detaching
         node from gluster
 """
 
 import random
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.peer_ops import (peer_detach_servers,
-                                         peer_probe_servers,
-                                         is_peer_connected)
+from tests.abstract_test import AbstractTest
+
+# disruptive;
 
 
-class GlusterdLogsWhilePeerDetach(GlusterBaseClass):
+class GlusterdLogsWhilePeerDetach(AbstractTest):
 
-    def tearDown(self):
-        """
-        tearDown for every test
-        """
-        # checking for peer status from every node
-        ret = is_peer_connected(self.mnode, self.servers)
-        if not ret:
-            ret = peer_probe_servers(self.mnode, self.random_server)
-            if not ret:
-                raise ExecutionError("Failed to peer probe failed in "
-                                     "servers %s" % self.random_server)
-        g.log.info("All peers are in connected state")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_logs_while_peer_detach(self):
+    def run_test(self, redant):
         '''
         -> Detach the node from peer
         -> Check that any error messages related to peer detach
@@ -55,38 +37,26 @@ class GlusterdLogsWhilePeerDetach(GlusterBaseClass):
         '''
 
         # Getting timestamp
-        _, timestamp, _ = g.run_local('date +%s')
-        timestamp = timestamp.strip()
+        ret = redant.execute_io_cmd('date +%s', self.server_list[0])
+        timestamp = ret['msg'][0].rstrip("\n")
 
         #  glusterd logs
-        ret, _, _ = g.run(self.mnode,
-                          'cp /var/log/glusterfs/glusterd.log '
-                          '/var/log/glusterfs/glusterd_%s.log' % timestamp)
-        if ret:
-            raise ExecutionError("Failed to copy glusterd logs")
+        ret = redant.execute_io_cmd('cp /var/log/glusterfs/glusterd.log /var/'
+                                    f'log/glusterfs/glusterd_{timestamp}.log',
+                                    self.server_list[0])
 
         # Clearing the existing glusterd log file
-        ret, _, _ = g.run(self.mnode, 'echo > /var/log/glusterfs/glusterd.log')
-        if ret:
-            raise ExecutionError("Failed to clear glusterd.log file on %s"
-                                 % self.mnode)
+        ret = redant.execute_io_cmd('echo > /var/log/glusterfs/glusterd.log',
+                                    self.server_list[0])
 
         # Performing peer detach
-        self.random_server = random.choice(self.servers[1:])
-        ret = peer_detach_servers(self.mnode, self.random_server)
-        self.assertTrue(ret, "Failed to detach peer %s"
-                        % self.random_server)
-        g.log.info("Peer detach successful for %s", self.random_server)
+        random_server = random.choice(self.server_list[1:])
+        ret = redant.peer_detach(random_server, self.server_list[0])
 
         # Searching for error message in log
-        ret, out, _ = g.run(
-            self.mnode,
-            "grep ' E ' /var/log/glusterfs/glusterd.log | wc -l")
-        self.assertEqual(ret, 0, "Failed to get error message count in "
-                                 "glusterd log file")
-        g.log.info("Successful getting error message count in log file")
-
-        self.assertEqual(int(out), 0, "Found Error messages in glusterd log "
-                                      "file after peer detach")
-        g.log.info("No error messages found in gluterd log file after peer "
-                   "detach")
+        ret = redant.execute_io_cmd("grep ' E ' /var/log/glusterfs/"
+                                    "glusterd.log | wc -l",
+                                    self.server_list[0])
+        if int(ret['msg'][0].rstrip("\n")) != 0:
+            redant.logger.info("Found Error messages in glusterd log "
+                               "file after peer detach")

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -40,7 +40,7 @@ class GlusterdLogsWhilePeerDetach(GlusterBaseClass):
         g.log.info("peer probe is successful for %s", self.random_server)
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_logs_while_peer_detach(self):
         '''

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -30,23 +30,23 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
 
     def run_test(self, redant):
         '''
-        -> Detach the node from peer
-        -> Check that any error messages related to peer detach
-        in glusterd log file
-        -> No errors should be there in glusterd log file
+            1) Detach the node from peer
+            2) Check that any error messages related to peer detach
+                in glusterd log file
+            3) No errors should be there in glusterd log file
         '''
 
         # Getting timestamp
-        ret = redant.execute_io_cmd('date +%s', self.server_list[0])
+        ret = redant.execute_abstract_op_node('date +%s', self.server_list[0])
         timestamp = ret['msg'][0].rstrip("\n")
 
         #  glusterd logs
-        ret = redant.execute_io_cmd('cp /var/log/glusterfs/glusterd.log /var/'
+        ret = redant.execute_abstract_op_node('cp /var/log/glusterfs/glusterd.log /var/'
                                     f'log/glusterfs/glusterd_{timestamp}.log',
                                     self.server_list[0])
 
         # Clearing the existing glusterd log file
-        ret = redant.execute_io_cmd('echo > /var/log/glusterfs/glusterd.log',
+        ret = redant.execute_abstract_op_node('echo > /var/log/glusterfs/glusterd.log',
                                     self.server_list[0])
 
         # Performing peer detach
@@ -54,9 +54,9 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
         ret = redant.peer_detach(random_server, self.server_list[0])
 
         # Searching for error message in log
-        ret = redant.execute_io_cmd("grep ' E ' /var/log/glusterfs/"
+        ret = redant.execute_abstract_op_node("grep ' E ' /var/log/glusterfs/"
                                     "glusterd.log | wc -l",
                                     self.server_list[0])
-        if int(ret['msg'][0].rstrip("\n")) != 0:
+        if int(ret['msg'][0]) != 0:
             redant.logger.info("Found Error messages in glusterd log "
                                "file after peer detach")

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2018-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,8 @@ from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass
 from glustolibs.gluster.peer_ops import (peer_detach_servers,
-                                         peer_probe_servers)
+                                         peer_probe_servers,
+                                         is_peer_connected)
 
 
 class GlusterdLogsWhilePeerDetach(GlusterBaseClass):
@@ -33,11 +34,14 @@ class GlusterdLogsWhilePeerDetach(GlusterBaseClass):
         """
         tearDown for every test
         """
-        # Peer probe detached server
-        ret = peer_probe_servers(self.mnode, self.random_server)
+        # checking for peer status from every node
+        ret = is_peer_connected(self.mnode, self.servers)
         if not ret:
-            raise ExecutionError(ret, "Failed to probe detached server")
-        g.log.info("peer probe is successful for %s", self.random_server)
+            ret = peer_probe_servers(self.mnode, self.random_server)
+            if not ret:
+                raise ExecutionError("Failed to peer probe failed in "
+                                     "servers %s" % self.random_server)
+        g.log.info("All peers are in connected state")
 
         # Calling GlusterBaseClass tearDown
         self.get_super_method(self, 'tearDown')()

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -1,0 +1,88 @@
+#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+        No Errors should generate in glusterd.log while detaching
+        node from gluster
+"""
+
+import random
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.peer_ops import (peer_detach_servers,
+                                         peer_probe_servers)
+
+
+class GlusterdLogsWhilePeerDetach(GlusterBaseClass):
+
+    def tearDown(self):
+        """
+        tearDown for every test
+        """
+        # Peer probe detached server
+        ret = peer_probe_servers(self.mnode, self.random_server)
+        if not ret:
+            raise ExecutionError(ret, "Failed to probe detached server")
+        g.log.info("peer probe is successful for %s", self.random_server)
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_logs_while_peer_detach(self):
+        '''
+        -> Detach the node from peer
+        -> Check that any error messages related to peer detach
+        in glusterd log file
+        -> No errors should be there in glusterd log file
+        '''
+
+        # Getting timestamp
+        _, timestamp, _ = g.run_local('date +%s')
+        timestamp = timestamp.strip()
+
+        #  glusterd logs
+        ret, _, _ = g.run(self.mnode,
+                          'cp /var/log/glusterfs/glusterd.log '
+                          '/var/log/glusterfs/glusterd_%s.log' % timestamp)
+        if ret:
+            raise ExecutionError("Failed to copy glusterd logs")
+
+        # Clearing the existing glusterd log file
+        ret, _, _ = g.run(self.mnode, 'echo > /var/log/glusterfs/glusterd.log')
+        if ret:
+            raise ExecutionError("Failed to clear glusterd.log file on %s"
+                                 % self.mnode)
+
+        # Performing peer detach
+        self.random_server = random.choice(self.servers[1:])
+        ret = peer_detach_servers(self.mnode, self.random_server)
+        self.assertTrue(ret, "Failed to detach peer %s"
+                        % self.random_server)
+        g.log.info("Peer detach successful for %s", self.random_server)
+
+        # Searching for error message in log
+        ret, out, _ = g.run(
+            self.mnode,
+            "grep ' E ' /var/log/glusterfs/glusterd.log | wc -l")
+        self.assertEqual(ret, 0, "Failed to get error message count in "
+                                 "glusterd log file")
+        g.log.info("Successful getting error message count in log file")
+
+        self.assertEqual(int(out), 0, "Found Error messages in glusterd log "
+                                      "file after peer detach")
+        g.log.info("No error messages found in gluterd log file after peer "
+                   "detach")

--- a/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
+++ b/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py
@@ -40,20 +40,18 @@ class GlusterdLogsWhilePeerDetach(AbstractTest):
         timestamp = ret['msg'][0].rstrip("\n")
 
         #  glusterd logs
-        ret = redant.execute_abstract_op_node('cp /var/log/glusterfs/'
-                                              'glusterd.log /var/log/'
-                                              'glusterfs/'
-                                              f'glusterd_{timestamp}.log',
-                                              self.server_list[0])
+        redant.execute_abstract_op_node('cp /var/log/glusterfs/glusterd.log '
+                                        '/var/log/glusterfs/'
+                                        f'glusterd_{timestamp}.log',
+                                        self.server_list[0])
 
         # Clearing the existing glusterd log file
-        ret = redant.execute_abstract_op_node('> /var/log/glusterfs/'
-                                              'glusterd.log',
-                                              self.server_list[0])
+        redant.execute_abstract_op_node('> /var/log/glusterfs/glusterd.log',
+                                        self.server_list[0])
 
         # Performing peer detach
         random_server = random.choice(self.server_list[1:])
-        ret = redant.peer_detach(random_server, self.server_list[0])
+        redant.peer_detach(random_server, self.server_list[0])
 
         # Searching for error message in log
         ret = redant.execute_abstract_op_node("grep ' E ' /var/log/glusterfs/"


### PR DESCRIPTION
[test_glusterd_logs_when_peer_detach.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_glusterd_logs_when_peer_detach.py) is migrated to redant

Updates: #292
Fixes: #317  
Signed-off-by: Nishith Vihar Sakinala nsakinal@redhat.com