### PR TITLE
execute_io_cmd is removed

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -14,29 +14,6 @@ class IoOps(AbstractOps):
     the other the io_ops which execute on mountpoints.
     """
 
-    def execute_io_cmd(self, cmd: str, host: str = None):
-        '''
-        Used for all the IO commands
-
-        Args:
-            cmd (str): The IO command which is to be run
-            host (str): The node in the cluster where the command is to be run
-
-        Returns:
-            ret: A dictionary consisting
-                - Flag : Flag to check if connection failed
-                - msg : message
-                - error_msg: error message
-                - error_code: error code returned
-                - cmd : command that got executed
-                - node : node on which the command got executed
-
-        '''
-
-        ret = self.execute_abstract_op_node(cmd, host)
-
-        return ret
-
     def create_file(self, path: str, filename: str, node: str):
         """
         Creates a file in the specified specified path

--- a/tests/abstract_test.py
+++ b/tests/abstract_test.py
@@ -73,7 +73,7 @@ class AbstractTest(metaclass=abc.ABCMeta):
                     self.server_list, self.brick_roots, True)
                 self.redant.volume_start(self.vol_name, self.server_list[0])
                 self.mountpoint = (f"/mnt/{self.vol_name}")
-                self.redant.execute_io_cmd(f"mkdir -p {self.mountpoint}",
+                self.redant.execute_abstract_op_node(f"mkdir -p {self.mountpoint}",
                                            self.client_list[0])
                 self.redant.volume_mount(self.server_list[0], self.vol_name,
                                          self.mountpoint, self.client_list[0])
@@ -82,7 +82,7 @@ class AbstractTest(metaclass=abc.ABCMeta):
             if self.volume_type != 'Generic':
                 self.redant.volume_unmount(self.vol_name, self.mountpoint,
                                            self.client_list[0])
-                self.redant.execute_io_cmd(f"rm -rf {self.mountpoint}",
+                self.redant.execute_abstract_op_node(f"rm -rf {self.mountpoint}",
                                            self.client_list[0])
                 self.redant.volume_stop(
                     self.vol_name, self.server_list[0], True)

--- a/tests/abstract_test.py
+++ b/tests/abstract_test.py
@@ -73,8 +73,9 @@ class AbstractTest(metaclass=abc.ABCMeta):
                     self.server_list, self.brick_roots, True)
                 self.redant.volume_start(self.vol_name, self.server_list[0])
                 self.mountpoint = (f"/mnt/{self.vol_name}")
-                self.redant.execute_abstract_op_node(f"mkdir -p {self.mountpoint}",
-                                           self.client_list[0])
+                self.redant.execute_abstract_op_node(f"mkdir -p "
+                                                     f"{self.mountpoint}",
+                                                     self.client_list[0])
                 self.redant.volume_mount(self.server_list[0], self.vol_name,
                                          self.mountpoint, self.client_list[0])
             self.run_test(self.redant)
@@ -82,8 +83,9 @@ class AbstractTest(metaclass=abc.ABCMeta):
             if self.volume_type != 'Generic':
                 self.redant.volume_unmount(self.vol_name, self.mountpoint,
                                            self.client_list[0])
-                self.redant.execute_abstract_op_node(f"rm -rf {self.mountpoint}",
-                                           self.client_list[0])
+                self.redant.execute_abstract_op_node(f"rm -rf "
+                                                     f"{self.mountpoint}",
+                                                     self.client_list[0])
                 self.redant.volume_stop(
                     self.vol_name, self.server_list[0], True)
                 self.redant.volume_delete(self.vol_name, self.server_list[0])

--- a/tests/example/sample_component/test_sample.py
+++ b/tests/example/sample_component/test_sample.py
@@ -28,17 +28,17 @@ class TestCase(AbstractTest):
         """
         servera = self.server_list[0]
 
-        redant.execute_io_cmd("ls -l /root", servera)
+        redant.execute_abstract_op_node("ls -l /root", servera)
         volume_status = redant.get_volume_status(self.vol_name, servera)
         redant.logger.info(volume_status)
-        redant.execute_io_cmd(f"cd {self.mountpoint} && touch " + "{1..100}",
+        redant.execute_abstract_op_node(f"cd {self.mountpoint} && touch " + "{1..100}",
                               self.client_list[0])
-        redant.execute_io_cmd(f"ls -l {self.mountpoint}", self.client_list[0])
-        redant.execute_io_cmd(f"cd {self.mountpoint} && rm -rf ./*",
+        redant.execute_abstract_op_node(f"ls -l {self.mountpoint}", self.client_list[0])
+        redant.execute_abstract_op_node(f"cd {self.mountpoint} && rm -rf ./*",
                               self.client_list[0])
-        redant.execute_io_cmd(f"ls -l {self.mountpoint}", self.client_list[0])
+        redant.execute_abstract_op_node(f"ls -l {self.mountpoint}", self.client_list[0])
 
         try:
-            redant.execute_io_cmd("ls -l /non-exsisting-path", servera)
+            redant.execute_abstract_op_node("ls -l /non-exsisting-path", servera)
         except Exception as error:
             redant.logger.error(error)

--- a/tests/example/sample_component/test_sample.py
+++ b/tests/example/sample_component/test_sample.py
@@ -31,14 +31,18 @@ class TestCase(AbstractTest):
         redant.execute_abstract_op_node("ls -l /root", servera)
         volume_status = redant.get_volume_status(self.vol_name, servera)
         redant.logger.info(volume_status)
-        redant.execute_abstract_op_node(f"cd {self.mountpoint} && touch " + "{1..100}",
-                              self.client_list[0])
-        redant.execute_abstract_op_node(f"ls -l {self.mountpoint}", self.client_list[0])
+        redant.execute_abstract_op_node(f"cd {self.mountpoint} "
+                                        "&& touch " + "{1..100}",
+                                        self.client_list[0])
+        redant.execute_abstract_op_node(
+            f"ls -l {self.mountpoint}", self.client_list[0])
         redant.execute_abstract_op_node(f"cd {self.mountpoint} && rm -rf ./*",
-                              self.client_list[0])
-        redant.execute_abstract_op_node(f"ls -l {self.mountpoint}", self.client_list[0])
+                                        self.client_list[0])
+        redant.execute_abstract_op_node(
+            f"ls -l {self.mountpoint}", self.client_list[0])
 
         try:
-            redant.execute_abstract_op_node("ls -l /non-exsisting-path", servera)
+            redant.execute_abstract_op_node(
+                "ls -l /non-exsisting-path", servera)
         except Exception as error:
             redant.logger.error(error)

--- a/tests/functional/glusterd/test_io.py
+++ b/tests/functional/glusterd/test_io.py
@@ -53,5 +53,7 @@ class TestCase(AbstractTest):
         redant.volume_unmount(volumes[0], "/root/mount1", self.server_list[0])
         redant.volume_unmount(volumes[0], "/root/mount2", self.server_list[0])
         redant.cleanup_mounts(mountpoints)
-        redant.execute_abstract_op_node("rm -rf /root/mount1", self.server_list[0])
-        redant.execute_abstract_op_node("rm -rf /root/mount2", self.server_list[0])
+        redant.execute_abstract_op_node(
+            "rm -rf /root/mount1", self.server_list[0])
+        redant.execute_abstract_op_node(
+            "rm -rf /root/mount2", self.server_list[0])

--- a/tests/functional/glusterd/test_io.py
+++ b/tests/functional/glusterd/test_io.py
@@ -53,5 +53,5 @@ class TestCase(AbstractTest):
         redant.volume_unmount(volumes[0], "/root/mount1", self.server_list[0])
         redant.volume_unmount(volumes[0], "/root/mount2", self.server_list[0])
         redant.cleanup_mounts(mountpoints)
-        redant.execute_io_cmd("rm -rf /root/mount1", self.server_list[0])
-        redant.execute_io_cmd("rm -rf /root/mount2", self.server_list[0])
+        redant.execute_abstract_op_node("rm -rf /root/mount1", self.server_list[0])
+        redant.execute_abstract_op_node("rm -rf /root/mount2", self.server_list[0])


### PR DESCRIPTION
execute_io_cmd from io_ops is removed and all the function calls
are replaced by execute_abstract_op_node.

Fixes: #340
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>