### PR TITLE
Migrated test_lower_gluster_op_version

### DIFF
--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -32,7 +32,7 @@ class LowerGlusterOpVersion(GlusterBaseClass):
     def setUp(self):
 
         # calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         # Creating Volume
         g.log.info("Started creating volume")
         ret = self.setup_volume()
@@ -43,7 +43,7 @@ class LowerGlusterOpVersion(GlusterBaseClass):
     def tearDown(self):
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
         # stopping the volume and Cleaning up the volume
         ret = cleanup_volume(self.mnode, self.volname)
         if not ret:

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -16,8 +16,8 @@
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  Description:
-        Test Cases in this module related to Glusterd volume reset validation
-        with bitd, scrub and snapd daemons running or not
+        Test Cases in this module related to setting
+        valid and invalid op-version values.
 """
 
 # nonDisruptive;rep
@@ -48,13 +48,19 @@ class LowerGlusterOpVersion(AbstractTest):
         invalid_op_version_dict = {'cluster.op-version': invalid_op_version}
 
         # Set the volume option with lower op-version
-        ret = redant.set_volume_options('all', lower_op_version_dict,
-                                        self.server_list[0])
+        try:
+            ret = redant.set_volume_options('all', lower_op_version_dict,
+                                            self.server_list[0])
+        except Exception as error:
+            redant.logger.info(error)
+            redant.logger.info("Failed: setting lower"
+                               " op-version.")
+
         # Setting invalid opversion
         try:
             ret = redant.set_volume_options('all', invalid_op_version_dict,
                                             self.server_list[0])
         except Exception as error:
+            redant.logger.info(error)
             redant.logger.info("Successfully tested setting invalid"
                                " op-version.")
-            redant.logger.info(error)

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -34,9 +34,10 @@ class LowerGlusterOpVersion(AbstractTest):
         - Set the invalid op-version
         """
         # Get the volume op-version
-        ret = redant.get_volume_options(node=self.server_list[0])
-        cluster_op = ret['cluster.op-version']
-
+        ret = (redant.
+               get_volume_options(node=self.server_list[0])
+               ['cluster.op-version'])
+        redant.logger.info(f"Op-verion: {ret}")
         redant.logger.info("Successfully got the op-version")
 
         # Lowest opversion is 30000

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -1,68 +1,45 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 
-""" Description:
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
         Test Cases in this module related to Glusterd volume reset validation
         with bitd, scrub and snapd daemons running or not
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_libs import cleanup_volume
-from glustolibs.gluster.volume_ops import (get_volume_options,
-                                           set_volume_options)
+
+# nonDisruptive;rep
+from tests.abstract_test import AbstractTest
 
 
-@runs_on([['replicated'], ['glusterfs']])
-class LowerGlusterOpVersion(GlusterBaseClass):
+class LowerGlusterOpVersion(AbstractTest):
 
-    def setUp(self):
-
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-        # Creating Volume
-        g.log.info("Started creating volume")
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Volume creation failed")
-        g.log.info("Volume created successfully : %s", self.volname)
-
-    def tearDown(self):
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-        # stopping the volume and Cleaning up the volume
-        ret = cleanup_volume(self.mnode, self.volname)
-        if not ret:
-            raise ExecutionError("Failed Cleanup the Volume")
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-    def test_lower_gluster_op_version(self):
+    def run_test(self, redant):
         """
         - Create volume
         - Get the volume op-version
         - Set the valid lower op-version
         - Set the invalid op-version
         """
-
         # Get the volume op-version
-        ret = get_volume_options(self.mnode, self.volname,
-                                 'cluster.op-version')
-        self.assertIsNotNone(ret, "Failed to get the op-version")
-        g.log.info("Successfully get the op-version")
+        ret = redant.get_volume_options(node=self.server_list[0])
+        cluster_op = ret['cluster.op-version']
+
+        if cluster_op is None:
+            raise Exception("Failed to get the op-version")
+        redant.logger.info("Successfully got the op-version")
 
         # Lowest opversion is 30000
         lowest_op_version = 30000
@@ -71,19 +48,13 @@ class LowerGlusterOpVersion(GlusterBaseClass):
         invalid_op_version_dict = {'cluster.op-version': invalid_op_version}
 
         # Set the volume option with lower op-version
-        ret = set_volume_options(self.mnode, 'all',
-                                 lower_op_version_dict)
-        self.assertFalse(ret, "Expected: Should not be able to set lower "
-                         "op-version \n Actual: Successfully set the lower"
-                         " op-version")
-        g.log.info("Failed to set op-version %s as "
-                   "expected", lowest_op_version)
-
+        ret = redant.set_volume_options('all', lower_op_version_dict,
+                                        self.server_list[0])
         # Setting invalid opversion
-        ret = set_volume_options(self.mnode, 'all',
-                                 invalid_op_version_dict)
-        self.assertFalse(ret, "Expected: Should not be able to set invalid "
-                         "op-version \n Actual: Successfully set the invalid"
-                         " op-version")
-        g.log.info("Failed to set op-version %s as "
-                   "expected", invalid_op_version)
+        try:
+            ret = redant.set_volume_options('all', invalid_op_version_dict,
+                                            self.server_list[0])
+        except Exception as error:
+            redant.logger.info("Successfully tested setting invalid"
+                               " op-version.")
+            redant.logger.info(error)

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -22,8 +22,8 @@ from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.volume_libs import cleanup_volume
-from glustolibs.gluster.volume_libs import (get_volume_options,
-                                            set_volume_options)
+from glustolibs.gluster.volume_ops import (get_volume_options,
+                                           set_volume_options)
 
 
 @runs_on([['replicated'], ['glusterfs']])

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -48,8 +48,8 @@ class LowerGlusterOpVersion(AbstractTest):
 
         # Set the volume option with lower op-version
         try:
-            ret = redant.set_volume_options('all', lower_op_version_dict,
-                                            self.server_list[0])
+            redant.set_volume_options('all', lower_op_version_dict,
+                                      self.server_list[0])
         except Exception as error:
             redant.logger.info(error)
             redant.logger.info("Failed: setting lower"
@@ -57,8 +57,8 @@ class LowerGlusterOpVersion(AbstractTest):
 
         # Setting invalid opversion
         try:
-            ret = redant.set_volume_options('all', invalid_op_version_dict,
-                                            self.server_list[0])
+            redant.set_volume_options('all', invalid_op_version_dict,
+                                      self.server_list[0])
         except Exception as error:
             redant.logger.info(error)
             redant.logger.info("Successfully tested setting invalid"

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -1,0 +1,89 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+        Test Cases in this module related to Glusterd volume reset validation
+        with bitd, scrub and snapd daemons running or not
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_libs import cleanup_volume
+from glustolibs.gluster.volume_libs import (get_volume_options,
+                                            set_volume_options)
+
+
+@runs_on([['replicated'], ['glusterfs']])
+class LowerGlusterOpVersion(GlusterBaseClass):
+
+    def setUp(self):
+
+        # calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+        # Creating Volume
+        g.log.info("Started creating volume")
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Volume creation failed")
+        g.log.info("Volume created successfully : %s", self.volname)
+
+    def tearDown(self):
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+        # stopping the volume and Cleaning up the volume
+        ret = cleanup_volume(self.mnode, self.volname)
+        if not ret:
+            raise ExecutionError("Failed Cleanup the Volume")
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+    def test_lower_gluster_op_version(self):
+        """
+        - Create volume
+        - Get the volume op-version
+        - Set the valid lower op-version
+        - Set the invalid op-version
+        """
+
+        # Get the volume op-version
+        ret = get_volume_options(self.mnode, self.volname,
+                                 'cluster.op-version')
+        self.assertIsNotNone(ret, "Failed to get the op-version")
+        g.log.info("Successfully get the op-version")
+
+        # Lowest opversion is 30000
+        lowest_op_version = 30000
+        invalid_op_version = "abc"
+        lower_op_version_dict = {'cluster.op-version': lowest_op_version}
+        invalid_op_version_dict = {'cluster.op-version': invalid_op_version}
+
+        # Set the volume option with lower op-version
+        ret = set_volume_options(self.mnode, 'all',
+                                 lower_op_version_dict)
+        self.assertFalse(ret, "Expected: Should not be able to set lower "
+                         "op-version \n Actual: Successfully set the lower"
+                         " op-version")
+        g.log.info("Failed to set op-version %s as "
+                   "expected", lowest_op_version)
+
+        # Setting invalid opversion
+        ret = set_volume_options(self.mnode, 'all',
+                                 invalid_op_version_dict)
+        self.assertFalse(ret, "Expected: Should not be able to set invalid "
+                         "op-version \n Actual: Successfully set the invalid"
+                         " op-version")
+        g.log.info("Failed to set op-version %s as "
+                   "expected", invalid_op_version)

--- a/tests/functional/glusterd/test_lower_gluster_op_version.py
+++ b/tests/functional/glusterd/test_lower_gluster_op_version.py
@@ -37,8 +37,6 @@ class LowerGlusterOpVersion(AbstractTest):
         ret = redant.get_volume_options(node=self.server_list[0])
         cluster_op = ret['cluster.op-version']
 
-        if cluster_op is None:
-            raise Exception("Failed to get the op-version")
         redant.logger.info("Successfully got the op-version")
 
         # Lowest opversion is 30000


### PR DESCRIPTION
Migrated the [test
case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_lower_gluster_op_version.py).
Modified it as per the ops in redant.

Updates: #292
Fixes: #339

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>