### PR TITLE
Fixed test_add_remove_brick issue

### DIFF
--- a/tests/functional/glusterd/test_add_remove_brick.py
+++ b/tests/functional/glusterd/test_add_remove_brick.py
@@ -18,15 +18,11 @@ class TestAddBrick(AbstractTest):
         Bricks are added
         Bricks are removed
         """
-        try:
-            vol_dict = self.conv_dict[self.volume_type]
-            redant.add_brick(self.vol_name, self.server_list[0],
-                             self.vol_type_inf[vol_dict],
-                             self.server_list, self.brick_roots, True)
+        vol_dict = self.conv_dict[self.volume_type]
+        redant.add_brick(self.vol_name, self.server_list[0],
+                         self.vol_type_inf[vol_dict],
+                         self.server_list, self.brick_roots, True)
 
-            redant.remove_brick(self.server_list[0], self.vol_name,
-                                self.vol_type_inf[vol_dict],
-                                self.server_list, self.brick_roots, 'force')
-
-        except Exception:
-            self.TEST_RES = False
+        redant.remove_brick(self.server_list[0], self.vol_name,
+                            self.vol_type_inf[vol_dict],
+                            self.server_list, self.brick_roots, 'force')


### PR DESCRIPTION
In the test_add_remove_brick, try and except clause was explicitly been
called and hence there was no traceback getting generated in the logs if
the test was failing. This is handled now by removing the try except
from the test.

Fixes: #342

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
