### PR TITLE
Migrated test_setting_volume_level_option_to_cluster

### DIFF
--- a/common/ops/gluster_ops/gluster_ops.py
+++ b/common/ops/gluster_ops/gluster_ops.py
@@ -217,7 +217,7 @@ class GlusterOps(AbstractOps):
             timeout (int) : We cannot wait till eternity right :p
 
         Returns:
-            bool: True if glusterd is running on the node(s) or else False.
+            bool: True if glusterd is running on the node or else False.
         """
         count = 0
         while count <= timeout:

--- a/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
@@ -39,10 +39,9 @@ class TestSettingVolumeLevelOptionToCluster(AbstractTest):
 
         # Set transport.listen-backlog to 128 for all volumes.(Should fail!)
         try:
-            ret = (redant.
-                   set_volume_options('all',
+            redant.set_volume_options('all',
                                       {'transport.listen-backlog': '128'},
-                                      self.server_list[0]))
+                                      self.server_list[0])
         except Exception as error:
             redant.logger.info(error)
             redant.logger.info("Successfully tested"

--- a/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
@@ -1,0 +1,72 @@
+#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.peer_ops import is_peer_connected
+from glustolibs.gluster.gluster_init import is_glusterd_running
+from glustolibs.gluster.volume_ops import set_volume_options
+
+
+class TestSettingVolumeLevelOptionToCluster(GlusterBaseClass):
+
+    def test_setting_volume_level_option_to_cluster(self):
+        # pylint: disable=too-many-statements
+        """
+        Test Case:
+        1) Create a cluster.
+        2) Try to set volume level options to cluster level.
+           (These should fail!)
+        eg: gluster v set all transport.listen-backlog 128
+            gluster v set all performance.parallel-readdir on
+        3) Check if glusterd has crashed or not.(Should not crash!)
+        """
+
+        # Set transport.listen-backlog to 128 for all volumes.(Should fail!)
+        ret = set_volume_options(self.mnode, 'all',
+                                 {'transport.listen-backlog': '128'})
+        self.assertFalse(ret, "Error: Able to set transport.listen-backlog "
+                         "to 128 for all volumes.")
+        g.log.info("EXPECTED: Failed to set transport.listen-backlog to 128"
+                   " for all volumes.")
+
+        # Checking if glusterd is running on all the nodes.
+        ret = is_glusterd_running(self.servers)
+        self.assertEqual(ret, 0, "glusterd has crashed.")
+        g.log.info("glusterd is running on all servers.")
+
+        # Checking if all the peers are in connected state or not.
+        ret = is_peer_connected(self.mnode, self.servers)
+        self.assertTrue(ret, "All peers are not in connected state.")
+        g.log.info("All peers are in connected state.")
+
+        # Set performance.parallel-readdir to on for all volumes.(Should fail!)
+        ret = set_volume_options(self.mnode, 'all',
+                                 {'performance.parallel-readdir': 'on'})
+        self.assertFalse(ret, "Error: Able to set performance.parallel"
+                         "-readdir to ON for all volumes.")
+        g.log.info("EXPECTED: Failed to set parallel-readdir to"
+                   " ON for all volumes.")
+
+        # Checking if glusterd is running on all the nodes
+        ret = is_glusterd_running(self.servers)
+        self.assertEqual(ret, 0, "glusterd has crashed.")
+        g.log.info("glusterd is running on all servers.")
+
+        # Checking if all the peers are in connected state or not.
+        ret = is_peer_connected(self.mnode, self.servers)
+        self.assertTrue(ret, "All peers are not in connected state.")
+        g.log.info("All peers are in connected state.")

--- a/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
@@ -1,29 +1,33 @@
-#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.peer_ops import is_peer_connected
-from glustolibs.gluster.gluster_init import is_glusterd_running
-from glustolibs.gluster.volume_ops import set_volume_options
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along`
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+
+ In this test we are testing the volume level option to cluster
+ """
+
+# nonDisruptive;
+
+from tests.abstract_test import AbstractTest
 
 
-class TestSettingVolumeLevelOptionToCluster(GlusterBaseClass):
+class TestSettingVolumeLevelOptionToCluster(AbstractTest):
 
-    def test_setting_volume_level_option_to_cluster(self):
+    def run_test(self, redant):
         # pylint: disable=too-many-statements
         """
         Test Case:
@@ -36,37 +40,47 @@ class TestSettingVolumeLevelOptionToCluster(GlusterBaseClass):
         """
 
         # Set transport.listen-backlog to 128 for all volumes.(Should fail!)
-        ret = set_volume_options(self.mnode, 'all',
-                                 {'transport.listen-backlog': '128'})
-        self.assertFalse(ret, "Error: Able to set transport.listen-backlog "
-                         "to 128 for all volumes.")
-        g.log.info("EXPECTED: Failed to set transport.listen-backlog to 128"
-                   " for all volumes.")
+        try:
+            ret = redant.set_volume_options(
+                'all', {'transport.listen-backlog': '128'},
+                self.server_list[0])
+        except Exception as error:
+            redant.logger.info(error)
+            redant.logger.info("Successfully tested"
+                               " setting transport.listen-backlog"
+                               " to 128 for all volumes")
 
         # Checking if glusterd is running on all the nodes.
-        ret = is_glusterd_running(self.servers)
-        self.assertEqual(ret, 0, "glusterd has crashed.")
-        g.log.info("glusterd is running on all servers.")
+        for each_server in self.server_list:
+            ret = redant.is_glusterd_running(each_server)
+
+        redant.logger.info("Glusterd is running on all the servers")
 
         # Checking if all the peers are in connected state or not.
-        ret = is_peer_connected(self.mnode, self.servers)
-        self.assertTrue(ret, "All peers are not in connected state.")
-        g.log.info("All peers are in connected state.")
+        ret = redant.is_peer_connected(self.server_list[0], self.server_list)
+        if not ret:
+            raise Exception("All peers are not in connected state.")
+
+        redant.logger.info("All peers are in connected state.")
 
         # Set performance.parallel-readdir to on for all volumes.(Should fail!)
-        ret = set_volume_options(self.mnode, 'all',
-                                 {'performance.parallel-readdir': 'on'})
-        self.assertFalse(ret, "Error: Able to set performance.parallel"
-                         "-readdir to ON for all volumes.")
-        g.log.info("EXPECTED: Failed to set parallel-readdir to"
-                   " ON for all volumes.")
+        try:
+            ret = redant.set_volume_options(
+                'all', {'performance.parallel-readdir': 'on'},
+                self.server_list[0])
+        except Exception as error:
+            redant.logger.info("EXPECTED: Failed to set parallel-readdir to"
+                               " ON for all volumes.")
 
-        # Checking if glusterd is running on all the nodes
-        ret = is_glusterd_running(self.servers)
-        self.assertEqual(ret, 0, "glusterd has crashed.")
-        g.log.info("glusterd is running on all servers.")
+        # Checking if glusterd is running on all the nodes.
+        for each_server in self.server_list:
+            ret = redant.is_glusterd_running(each_server)
+
+        redant.logger.info("Glusterd is running on all the servers")
 
         # Checking if all the peers are in connected state or not.
-        ret = is_peer_connected(self.mnode, self.servers)
-        self.assertTrue(ret, "All peers are not in connected state.")
-        g.log.info("All peers are in connected state.")
+        ret = redant.is_peer_connected(self.server_list[0], self.server_list)
+        if not ret:
+            raise Exception("All peers are not in connected state.")
+
+        redant.logger.info("All peers are in connected state.")

--- a/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
@@ -1,24 +1,23 @@
 """
 Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
 
- This program is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- any later version.
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License along`
- with this program; if not, write to the Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+You should have received a copy of the GNU General Public License along`
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
- Description:
-
- In this test we are testing the volume level option to cluster
- """
+Description:
+In this test we are testing the volume level option to cluster
+"""
 
 # nonDisruptive;
 
@@ -28,12 +27,11 @@ from tests.abstract_test import AbstractTest
 class TestSettingVolumeLevelOptionToCluster(AbstractTest):
 
     def run_test(self, redant):
-        # pylint: disable=too-many-statements
         """
         Test Case:
         1) Create a cluster.
         2) Try to set volume level options to cluster level.
-           (These should fail!)
+           (This should fail!)
         eg: gluster v set all transport.listen-backlog 128
             gluster v set all performance.parallel-readdir on
         3) Check if glusterd has crashed or not.(Should not crash!)
@@ -41,9 +39,10 @@ class TestSettingVolumeLevelOptionToCluster(AbstractTest):
 
         # Set transport.listen-backlog to 128 for all volumes.(Should fail!)
         try:
-            ret = redant.set_volume_options(
-                'all', {'transport.listen-backlog': '128'},
-                self.server_list[0])
+            ret = (redant.
+                   set_volume_options('all',
+                                      {'transport.listen-backlog': '128'},
+                                      self.server_list[0]))
         except Exception as error:
             redant.logger.info(error)
             redant.logger.info("Successfully tested"
@@ -53,6 +52,9 @@ class TestSettingVolumeLevelOptionToCluster(AbstractTest):
         # Checking if glusterd is running on all the nodes.
         for each_server in self.server_list:
             ret = redant.is_glusterd_running(each_server)
+            if ret != 1:
+                raise Exception(f"Failed: Glusterd not running"
+                                f" on {each_server}")
 
         redant.logger.info("Glusterd is running on all the servers")
 
@@ -65,9 +67,9 @@ class TestSettingVolumeLevelOptionToCluster(AbstractTest):
 
         # Set performance.parallel-readdir to on for all volumes.(Should fail!)
         try:
-            ret = redant.set_volume_options(
-                'all', {'performance.parallel-readdir': 'on'},
-                self.server_list[0])
+            redant.set_volume_options('all',
+                                      {'performance.parallel-readdir': 'on'},
+                                      self.server_list[0])
         except Exception as error:
             redant.logger.info("EXPECTED: Failed to set parallel-readdir to"
                                " ON for all volumes.")
@@ -75,6 +77,10 @@ class TestSettingVolumeLevelOptionToCluster(AbstractTest):
         # Checking if glusterd is running on all the nodes.
         for each_server in self.server_list:
             ret = redant.is_glusterd_running(each_server)
+
+            if ret != 1:
+                raise Exception(f"Failed: Glusterd not running"
+                                f" on {each_server}")
 
         redant.logger.info("Glusterd is running on all the servers")
 


### PR DESCRIPTION
Added the [test
case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py).
Made modifications as per the ops in redant.

Updates: #292

Fixes: #345

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>