### PR TITLE
Migrated test_ops_when_one_node_is_down

### DIFF
--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -30,7 +30,7 @@ class TestOpsWhenOneNodeIsDown(GlusterBaseClass):
 
     def setUp(self):
 
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # Create and start a volume.
         ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
@@ -63,7 +63,7 @@ class TestOpsWhenOneNodeIsDown(GlusterBaseClass):
             raise ExecutionError("Unable to delete volume % s" % self.volname)
         g.log.info("Volume deleted successfully : %s", self.volname)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_ops_when_one_node_is_down(self):
 

--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -23,10 +23,10 @@ This test deals with testing ops when one node is down.
 # disruptive;rep
 
 from random import randint
-from tests.abstract_test import AbstractTest
+from tests.d_parent_test import DParentTest
 
 
-class TestOpsWhenOneNodeIsDown(AbstractTest):
+class TestCase(DParentTest):
 
     def run_test(self, redant):
         """

--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -1,0 +1,102 @@
+#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from time import sleep
+from random import randint
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_init import stop_glusterd, start_glusterd
+from glustolibs.gluster.peer_ops import peer_status, is_peer_connected
+from glustolibs.gluster.volume_ops import volume_list, volume_info
+from glustolibs.gluster.volume_libs import (cleanup_volume, setup_volume)
+
+
+@runs_on([['replicated'], ['glusterfs']])
+class TestOpsWhenOneNodeIsDown(GlusterBaseClass):
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+
+        # Create and start a volume.
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        if ret:
+            ExecutionError("Failed to create and start volume")
+
+    def tearDown(self):
+
+        # Starting glusterd on node where stopped.
+        ret = start_glusterd(self.servers[self.random_server])
+        if ret:
+            ExecutionError("Failed to start glusterd.")
+        g.log.info("Successfully started glusterd.")
+
+        # Checking if peer is connected.
+        counter = 0
+        while counter < 30:
+            ret = is_peer_connected(self.mnode, self.servers)
+            counter += 1
+            if ret:
+                break
+            sleep(3)
+        if not ret:
+            ExecutionError("Peer is not in connected state.")
+        g.log.info("Peers is in connected state.")
+
+        # Stopping and deleting volume.
+        ret = cleanup_volume(self.mnode, self.volname)
+        if not ret:
+            raise ExecutionError("Unable to delete volume % s" % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_ops_when_one_node_is_down(self):
+
+        # pylint: disable=too-many-statements
+        """
+        Test Case:
+        1) Create a N node gluster cluster.
+        2) Stop gluster on one node.
+        3) Execute gluster peer status on other node.
+        4) Execute gluster v list on other node.
+        5) Execute gluster v info on other node.
+        """
+
+        # Fetching a random server from list.
+        self.random_server = randint(1, len(self.servers)-1)
+
+        # Stopping glusterd on one node.
+        ret = stop_glusterd(self.servers[self.random_server])
+        self.assertTrue(ret, "Failed to stop glusterd on one node.")
+        g.log.info("Successfully stopped glusterd on one node.")
+
+        # Running peer status on another node.
+        ret, _, err = peer_status(self.mnode)
+        self.assertEqual(ret, 0, ("Failed to get peer status from %s with "
+                                  "error message %s" % (self.mnode, err)))
+        g.log.info("Successfully got peer status from %s.", self.mnode)
+
+        # Running volume list on another node.
+        ret, _, _ = volume_list(self.mnode)
+        self.assertEqual(ret, 0, "Failed to get volume list.")
+        g.log.info("Successfully got volume list from %s.", self.mnode)
+
+        # Running volume info on another node.
+        ret, _, _ = volume_info(self.mnode)
+        self.assertEqual(ret, 0, "Failed to get volume info.")
+        g.log.info("Successfully got volume info from %s.", self.mnode)

--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -68,12 +68,12 @@ class TestOpsWhenOneNodeIsDown(AbstractTest):
         for server in self.server_list:
             ret = redant.wait_for_glusterd_to_start(server)
             if not ret:
-                raise Exception("Failed: wait for glusterd to start")
+                raise Exception(f"Failed: Glusterd not started on {server}")
         redant.logger.info("Glusterd start on the nodes succeeded")
 
         # Checking if peer is connected.
         ret = redant.wait_for_peers_to_connect(self.server_list[0],
                                                self.server_list)
         if not ret:
-            raise Exception("Failed : Wait for peers to connect")
+            raise Exception("Failed : All the peer are not connected")
         redant.logger.info("Peers is in connected state.")

--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -17,15 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 Description:
 This test deals with testing ops when one node is down.
-
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_init import (
-    start_glusterd, stop_glusterd, wait_for_glusterd_to_start)
-from glustolibs.gluster.peer_ops import peer_status, wait_for_peers_to_connect
-from glustolibs.gluster.volume_ops import volume_list, volume_info
-from glustolibs.gluster.volume_libs import (cleanup_volume, setup_volume)
 """
 
 
@@ -75,10 +66,14 @@ class TestOpsWhenOneNodeIsDown(AbstractTest):
         redant.logger.info("Successfully started glusterd.")
 
         for server in self.server_list:
-            redant.wait_for_glusterd_to_start(server)
+            ret = redant.wait_for_glusterd_to_start(server)
+            if not ret:
+                raise Exception("Failed: wait for glusterd to start")
         redant.logger.info("Glusterd start on the nodes succeeded")
 
         # Checking if peer is connected.
-        redant.wait_for_peers_to_connect(self.server_list[0],
-                                         self.server_list)
+        ret = redant.wait_for_peers_to_connect(self.server_list[0],
+                                               self.server_list)
+        if not ret:
+            raise Exception("Failed : Wait for peers to connect")
         redant.logger.info("Peers is in connected state.")

--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -1,20 +1,23 @@
-#  Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
 
-from random import randint
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along`
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+This test deals with testing ops when one node is down.
+
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
@@ -23,50 +26,18 @@ from glustolibs.gluster.gluster_init import (
 from glustolibs.gluster.peer_ops import peer_status, wait_for_peers_to_connect
 from glustolibs.gluster.volume_ops import volume_list, volume_info
 from glustolibs.gluster.volume_libs import (cleanup_volume, setup_volume)
+"""
 
 
-@runs_on([['replicated'], ['glusterfs']])
-class TestOpsWhenOneNodeIsDown(GlusterBaseClass):
+# disruptive;rep
 
-    def setUp(self):
+from random import randint
+from tests.abstract_test import AbstractTest
 
-        self.get_super_method(self, 'setUp')()
 
-        # Create and start a volume.
-        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
-        if ret:
-            ExecutionError("Failed to create and start volume")
+class TestOpsWhenOneNodeIsDown(AbstractTest):
 
-    def tearDown(self):
-
-        # Starting glusterd on node where stopped.
-        ret = start_glusterd(self.servers[self.random_server])
-        if ret:
-            ExecutionError("Failed to start glusterd.")
-        g.log.info("Successfully started glusterd.")
-
-        ret = wait_for_glusterd_to_start(self.servers)
-        if not ret:
-            ExecutionError("glusterd is not running on %s" % self.servers)
-        g.log.info("Glusterd start on the nodes succeeded")
-
-        # Checking if peer is connected.
-        ret = wait_for_peers_to_connect(self.mnode, self.servers)
-        if not ret:
-            ExecutionError("Peer is not in connected state.")
-        g.log.info("Peers is in connected state.")
-
-        # Stopping and deleting volume.
-        ret = cleanup_volume(self.mnode, self.volname)
-        if not ret:
-            raise ExecutionError("Unable to delete volume % s" % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_ops_when_one_node_is_down(self):
-
-        # pylint: disable=too-many-statements
+    def run_test(self, redant):
         """
         Test Case:
         1) Create a N node gluster cluster.
@@ -74,28 +45,40 @@ class TestOpsWhenOneNodeIsDown(GlusterBaseClass):
         3) Execute gluster peer status on other node.
         4) Execute gluster v list on other node.
         5) Execute gluster v info on other node.
+        6) Start gluster back again
         """
 
         # Fetching a random server from list.
-        self.random_server = randint(1, len(self.servers)-1)
+        random_server = randint(1, len(self.server_list)-1)
 
         # Stopping glusterd on one node.
-        ret = stop_glusterd(self.servers[self.random_server])
-        self.assertTrue(ret, "Failed to stop glusterd on one node.")
-        g.log.info("Successfully stopped glusterd on one node.")
+        redant.stop_glusterd(self.server_list[random_server])
+        redant.logger.info("Successfully stopped glusterd on one node.")
 
         # Running peer status on another node.
-        ret, _, err = peer_status(self.mnode)
-        self.assertEqual(ret, 0, ("Failed to get peer status from %s with "
-                                  "error message %s" % (self.mnode, err)))
-        g.log.info("Successfully got peer status from %s.", self.mnode)
+        redant.get_peer_status(self.server_list[0])
+        redant.logger.info(f"Successfully got peer status from "
+                           f"{self.server_list[0]}.")
 
         # Running volume list on another node.
-        ret, _, _ = volume_list(self.mnode)
-        self.assertEqual(ret, 0, "Failed to get volume list.")
-        g.log.info("Successfully got volume list from %s.", self.mnode)
+        redant.get_volume_list(self.server_list[0])
+        redant.logger.info(f"Successfully got volume list from "
+                           f"{self.server_list[0]}")
 
         # Running volume info on another node.
-        ret, _, _ = volume_info(self.mnode)
-        self.assertEqual(ret, 0, "Failed to get volume info.")
-        g.log.info("Successfully got volume info from %s.", self.mnode)
+        redant.get_volume_info(self.server_list[0])
+        redant.logger.info(f"Successfully got volume info from "
+                           f"{self.server_list[0]}")
+
+        # Starting glusterd on node where stopped.
+        redant.start_glusterd(self.server_list[random_server])
+        redant.logger.info("Successfully started glusterd.")
+
+        for server in self.server_list:
+            redant.wait_for_glusterd_to_start(server)
+        redant.logger.info("Glusterd start on the nodes succeeded")
+
+        # Checking if peer is connected.
+        redant.wait_for_peers_to_connect(self.server_list[0],
+                                         self.server_list)
+        redant.logger.info("Peers is in connected state.")


### PR DESCRIPTION
Added the [test
case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_ops_when_one_node_is_down.py).
Made modifications as per the ops.

Updates: #292

Fixes: #348

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>