### PR TITLE
Migration of test_setting_volume_option_with_more_than_4096_characters

### DIFF
--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -16,11 +16,11 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-from tests.abstract_test import AbstractTest
+from tests.d_parent_test import DParentTest
 
 
 # disruptive;dist
-class TestVolumeOptionSetWithMaxcharacters(AbstractTest):
+class TestCase(DParentTest):
 
     def run_test(self, redant):
         """
@@ -34,7 +34,7 @@ class TestVolumeOptionSetWithMaxcharacters(AbstractTest):
         """
 
         auth_list = []
-        for ip_addr in range(255):
+        for ip_addr in range(256):
             auth_list.append(f'192.168.122.{ip_addr}')
         for ip_addr in range(7):
             auth_list.append(f'192.168.123.{ip_addr}')
@@ -47,6 +47,11 @@ class TestVolumeOptionSetWithMaxcharacters(AbstractTest):
         redant.set_volume_options(self.vol_name, self.options,
                                   self.server_list[0])
         redant.restart_glusterd(self.server_list[0])
+
+        # wait for glusterd to start
+        if not redant.wait_for_glusterd_to_start(self.server_list[0]):
+            raise Exception("glusterd is not running on"
+                            f"{self.server_list}")
 
         # set auth.allow with >4096 characters and restart the glusterd
         ip_list = ip_list + ",192.168.123.7"

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -62,16 +62,12 @@ class TestCase(DParentTest):
         self.options = {"auth.allow": ip_list}
         redant.logger.info("Setting auth.allow with string of length "
                            f"{len(ip_list)} for {self.vol_name}")
-        try:
-            redant.set_volume_options(self.vol_name, self.options,
-                                      self.server_list[0])
-        except Exception:
-            redant.logger.info("EXPECTED: setting volume option with more than"
-                               " 4096 characters failed")
+
+        redant.set_volume_options(self.vol_name, self.options,
+                                  self.server_list[0])
+
         redant.restart_glusterd(self.server_list[0])
 
-        for server in self.server_list:
-            ret = redant.wait_for_glusterd_to_start(server)
-            if not ret:
-                raise Exception("glusterd is not running on"
-                                f"{self.server_list}")
+        if not redant.wait_for_glusterd_to_start(self.server_list[0]):
+            raise Exception("glusterd is not running on"
+                            f"{self.server_list}")

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,14 +14,14 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from time import sleep
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import runs_on, GlusterBaseClass
 from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
 from glustolibs.gluster.volume_libs import setup_volume
 from glustolibs.gluster.volume_ops import set_volume_options
 from glustolibs.gluster.gluster_init import (restart_glusterd,
-                                             is_glusterd_running)
+                                             wait_for_glusterd_to_start)
 
 
 @runs_on([['distributed'], ['glusterfs']])
@@ -37,16 +37,9 @@ class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
 
     def tearDown(self):
 
-        count = 0
-        while count < 60:
-            ret = self.validate_peers_are_connected()
-            if ret:
-                break
-            sleep(2)
-            count += 1
-
-        if not ret:
-            raise ExecutionError("Peers are not in connected state")
+        ret = wait_for_peers_to_connect(self.mnode, self.servers)
+        self.assertTrue(ret, "glusterd is not connected %s with peer %s"
+                        % (self.servers, self.servers))
 
         # stopping the volume and Cleaning up the volume
         ret = self.cleanup_volume()
@@ -91,11 +84,9 @@ class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
         ret = restart_glusterd(self.mnode)
         self.assertTrue(ret, "Failed to restart the glusterd on %s"
                         % self.mnode)
-        count = 0
-        while count < 60:
-            ret = is_glusterd_running(self.mnode)
-            if not ret:
-                break
-            sleep(2)
-            count += 1
-        self.assertEqual(ret, 0, "glusterd is not running on %s" % self.mnode)
+
+        ret = wait_for_glusterd_to_start(self.servers)
+        self.assertTrue(ret, "glusterd is not running on %s"
+                        % self.servers)
+        g.log.info("Glusterd start on the nodes : %s "
+                   "succeeded", self.servers)

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -14,6 +14,10 @@
   You should have received a copy of the GNU General Public License along
   with this program; if not, write to the Free Software Foundation, Inc.,
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+  Checks for setting of volution of with lesser and greater than
+  4096 characters.
 """
 
 from tests.d_parent_test import DParentTest

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -1,0 +1,102 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import runs_on, GlusterBaseClass
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_libs import setup_volume
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.gluster.gluster_init import (restart_glusterd,
+                                             is_glusterd_running)
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+
+        # check whether peers are in connected state
+        ret = self.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+    def tearDown(self):
+
+        count = 0
+        while count < 60:
+            ret = self.validate_peers_are_connected()
+            if ret:
+                break
+            sleep(2)
+            count += 1
+
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+        # stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Cleanup the Volume %s"
+                                 % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_setting_vol_option_with_max_characters(self):
+
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertTrue(ret, ("Failed to create "
+                              "and start volume %s" % self.volname))
+        auth_list = []
+        for ip_addr in range(256):
+            auth_list.append('192.168.122.%d' % ip_addr)
+        for ip_addr in range(7):
+            auth_list.append('192.168.123.%d' % ip_addr)
+        ip_list = ','.join(auth_list)
+
+        # set auth.allow with <4096 characters and restart the glusterd
+        g.log.info("Setting auth.allow with string of length %d for %s",
+                   len(ip_list), self.volname)
+        self.options = {"auth.allow": ip_list}
+        ret = set_volume_options(self.mnode, self.volname, self.options)
+        self.assertTrue(ret, ("Failed to set auth.allow with string of length"
+                              " %d for %s" % (len(ip_list), self.volname)))
+        ret = restart_glusterd(self.mnode)
+        self.assertTrue(ret, "Failed to restart the glusterd on %s"
+                        % self.mnode)
+
+        # set auth.allow with >4096 characters and restart the glusterd
+        ip_list = ip_list + ",192.168.123.7"
+        self.options = {"auth.allow": ip_list}
+        g.log.info("Setting auth.allow with string of length %d for %s",
+                   len(ip_list), self.volname)
+        ret = set_volume_options(self.mnode, self.volname, self.options)
+        self.assertTrue(ret, ("Failed to set auth.allow with string of length"
+                              " %d for %s" % (len(ip_list), self.volname)))
+        ret = restart_glusterd(self.mnode)
+        self.assertTrue(ret, "Failed to restart the glusterd on %s"
+                        % self.mnode)
+        count = 0
+        while count < 60:
+            ret = is_glusterd_running(self.mnode)
+            if not ret:
+                break
+            sleep(2)
+            count += 1
+        self.assertEqual(ret, 0, "glusterd is not running on %s" % self.mnode)

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -21,7 +21,9 @@ from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
 from glustolibs.gluster.volume_libs import setup_volume
 from glustolibs.gluster.volume_ops import set_volume_options
 from glustolibs.gluster.gluster_init import (restart_glusterd,
-                                             wait_for_glusterd_to_start)
+                                             wait_for_glusterd_to_start,
+                                             is_glusterd_running,
+                                             start_glusterd)
 
 
 @runs_on([['distributed'], ['glusterfs']])
@@ -36,6 +38,14 @@ class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
             raise ExecutionError("Peers are not in connected state")
 
     def tearDown(self):
+
+        ret = is_glusterd_running(self.servers)
+        if ret:
+            ret = start_glusterd(self.servers)
+            if not ret:
+                raise ExecutionError("Failed to start glusterd on %s"
+                                     % self.servers)
+        g.log.info("Glusterd started successfully on %s", self.servers)
 
         ret = wait_for_peers_to_connect(self.mnode, self.servers)
         self.assertTrue(ret, "glusterd is not connected %s with peer %s"

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -28,8 +28,7 @@ from glustolibs.gluster.gluster_init import (restart_glusterd,
 class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
 
     def setUp(self):
-
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # check whether peers are in connected state
         ret = self.validate_peers_are_connected()
@@ -56,7 +55,7 @@ class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
                                  % self.volname)
         g.log.info("Volume deleted successfully : %s", self.volname)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_setting_vol_option_with_max_characters(self):
 

--- a/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
+++ b/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py
@@ -1,102 +1,68 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import runs_on, GlusterBaseClass
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
-from glustolibs.gluster.volume_libs import setup_volume
-from glustolibs.gluster.volume_ops import set_volume_options
-from glustolibs.gluster.gluster_init import (restart_glusterd,
-                                             wait_for_glusterd_to_start,
-                                             is_glusterd_running,
-                                             start_glusterd)
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+
+from tests.abstract_test import AbstractTest
 
 
-@runs_on([['distributed'], ['glusterfs']])
-class TestVolumeOptionSetWithMaxcharacters(GlusterBaseClass):
+# disruptive;dist
+class TestVolumeOptionSetWithMaxcharacters(AbstractTest):
 
-    def setUp(self):
-        self.get_super_method(self, 'setUp')()
+    def run_test(self, redant):
+        """
+        Steps:
+        1. Make a string of <4096 characters.
+        2. Set volume option for auth.allow with <4096 characters.
+        3. Restart glusterd.
+        4. Make a string of >4096 characters.
+        5. set volume option for auth.allow with >4096 characsters.
+        6. Restart glusterd
+        """
 
-        # check whether peers are in connected state
-        ret = self.validate_peers_are_connected()
-        if not ret:
-            raise ExecutionError("Peers are not in connected state")
-
-    def tearDown(self):
-
-        ret = is_glusterd_running(self.servers)
-        if ret:
-            ret = start_glusterd(self.servers)
-            if not ret:
-                raise ExecutionError("Failed to start glusterd on %s"
-                                     % self.servers)
-        g.log.info("Glusterd started successfully on %s", self.servers)
-
-        ret = wait_for_peers_to_connect(self.mnode, self.servers)
-        self.assertTrue(ret, "glusterd is not connected %s with peer %s"
-                        % (self.servers, self.servers))
-
-        # stopping the volume and Cleaning up the volume
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Cleanup the Volume %s"
-                                 % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_setting_vol_option_with_max_characters(self):
-
-        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
-        self.assertTrue(ret, ("Failed to create "
-                              "and start volume %s" % self.volname))
         auth_list = []
-        for ip_addr in range(256):
-            auth_list.append('192.168.122.%d' % ip_addr)
+        for ip_addr in range(255):
+            auth_list.append(f'192.168.122.{ip_addr}')
         for ip_addr in range(7):
-            auth_list.append('192.168.123.%d' % ip_addr)
+            auth_list.append(f'192.168.123.{ip_addr}')
         ip_list = ','.join(auth_list)
 
         # set auth.allow with <4096 characters and restart the glusterd
-        g.log.info("Setting auth.allow with string of length %d for %s",
-                   len(ip_list), self.volname)
+        redant.logger.info("Setting auth.allow with string of length "
+                           f"{len(ip_list)} for {self.vol_name}")
         self.options = {"auth.allow": ip_list}
-        ret = set_volume_options(self.mnode, self.volname, self.options)
-        self.assertTrue(ret, ("Failed to set auth.allow with string of length"
-                              " %d for %s" % (len(ip_list), self.volname)))
-        ret = restart_glusterd(self.mnode)
-        self.assertTrue(ret, "Failed to restart the glusterd on %s"
-                        % self.mnode)
+        redant.set_volume_options(self.vol_name, self.options,
+                                  self.server_list[0])
+        redant.restart_glusterd(self.server_list[0])
 
         # set auth.allow with >4096 characters and restart the glusterd
         ip_list = ip_list + ",192.168.123.7"
         self.options = {"auth.allow": ip_list}
-        g.log.info("Setting auth.allow with string of length %d for %s",
-                   len(ip_list), self.volname)
-        ret = set_volume_options(self.mnode, self.volname, self.options)
-        self.assertTrue(ret, ("Failed to set auth.allow with string of length"
-                              " %d for %s" % (len(ip_list), self.volname)))
-        ret = restart_glusterd(self.mnode)
-        self.assertTrue(ret, "Failed to restart the glusterd on %s"
-                        % self.mnode)
+        redant.logger.info("Setting auth.allow with string of length "
+                           f"{len(ip_list)} for {self.vol_name}")
+        try:
+            redant.set_volume_options(self.vol_name, self.options,
+                                      self.server_list[0])
+        except Exception:
+            redant.logger.info("EXPECTED: setting volume option with more than"
+                               " 4096 characters failed")
+        redant.restart_glusterd(self.server_list[0])
 
-        ret = wait_for_glusterd_to_start(self.servers)
-        self.assertTrue(ret, "glusterd is not running on %s"
-                        % self.servers)
-        g.log.info("Glusterd start on the nodes : %s "
-                   "succeeded", self.servers)
+        for server in self.server_list:
+            ret = redant.wait_for_glusterd_to_start(server)
+            if not ret:
+                raise Exception("glusterd is not running on"
+                                f"{self.server_list}")


### PR DESCRIPTION
Migration of [test_setting_volume_option_with_more_than_4096_characters.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_setting_volume_option_with_more_than_4096_characters.py) test case

Updates: #292
Fixes: #353
Signed-off-by: Nishith Vihar Sakinala nsakinal@redhat.com