### PR TITLE
[Tests] Moved tests from glusterd to example

### DIFF
--- a/tests/example/sample_component/test_add_remove_brick.py
+++ b/tests/example/sample_component/test_add_remove_brick.py
@@ -1,0 +1,28 @@
+"""
+This file contains a test case
+that checks the add-brick and remove-brick functionality
+"""
+# nonDisruptive;rep,arb,dist-rep,dist
+from tests.nd_parent_test import NdParentTest
+
+
+class TestCase(NdParentTest):
+    """
+    This test class tests the add-brick
+    functionality
+    """
+
+    def run_test(self, redant):
+        """
+        The following steps are undertaken in the testcase:
+        Bricks are added
+        Bricks are removed
+        """
+        vol_dict = self.conv_dict[self.volume_type]
+        redant.add_brick(self.vol_name, self.server_list[0],
+                         self.vol_type_inf[vol_dict],
+                         self.server_list, self.brick_roots, True)
+
+        redant.remove_brick(self.server_list[0], self.vol_name,
+                            self.vol_type_inf[vol_dict],
+                            self.server_list, self.brick_roots, 'force')

--- a/tests/example/sample_component/test_io.py
+++ b/tests/example/sample_component/test_io.py
@@ -1,0 +1,32 @@
+"""
+This file contains a test-case which tests glusterd
+starting and stopping of glusterd service.
+"""
+# nonDisruptive;dist
+
+from tests.nd_parent_test import NdParentTest
+
+
+class TestCase(NdParentTest):
+    """
+    The test case contains one function to test
+    for glusterd service operations
+    """
+
+    def run_test(self, redant):
+        """
+        This particular test case tests the io_functions
+        on mountpoints. The steps taken are:
+        1) call collect_mounts_arequal function
+        2) call get_mounts_stat function
+        3) call list_all_files_and_dirs_mounts function
+        4) execute a command in async and call validate_io_procs function
+        5) call cleanup_mounts
+        """
+
+        # redant.collect_mounts_arequal(mountpoints)
+        redant.get_mounts_stat(self.mountpoint)
+        redant.list_all_files_and_dirs_mounts(self.mountpoint)
+        async_obj = redant.execute_command_async("ls", self.server_list[0])
+        redant.validate_io_procs(async_obj, self.mountpoint)
+        redant.cleanup_mounts(self.mountpoint)


### PR DESCRIPTION
Following cases,
1. test_add_remove_brick
2. test_io

are migrated to example/sample_component.

Fixes: #360

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
