### PR TITLE
Migrated test_probe_hostname and added form_brick_cmd in brick ops

### DIFF
--- a/common/mixin.py
+++ b/common/mixin.py
@@ -13,7 +13,7 @@ from .ops.gluster_ops.brick_ops import BrickOps
 from .ops.gluster_ops.profile_ops import ProfileOps
 
 
-class RedantMixin(GlusterOps, BrickOps, VolumeOps, PeerOps,
+class RedantMixin(GlusterOps, VolumeOps, BrickOps, PeerOps,
                   IoOps, ProfileOps, Rexe, Logger):
     """
     A mixin class for redant project to encompass all ops, support

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -308,3 +308,23 @@ class BrickOps:
         ret = self.execute_abstract_op_node(cmd=cmd, node=node)
 
         return ret
+
+    def form_brick_cmd(self, server_list: list, brick_root: list,
+                       volname: str, mul_fac: int):
+        brick_dict = {}
+        brick_cmd = ""
+        server_iter = 0
+
+        for iteration in range(mul_fac):
+            if server_iter == len(server_list):
+                server_iter = 0
+            server_val = server_list[server_iter]
+            if server_val not in brick_dict.keys():
+                brick_dict[server_val] = []
+            brick_path_val = \
+                f"{brick_root[server_list[server_iter]]}/{volname}-{iteration}"
+            brick_dict[server_val].append(brick_path_val)
+            brick_cmd = (f"{brick_cmd} {server_val}:{brick_path_val}")
+            server_iter += 1
+
+        return (brick_dict, brick_cmd)

--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -17,7 +17,7 @@ class PeerOps(AbstractOps):
     and list of peers in the pool.
     """
 
-    def peer_probe(self, server: str, node: str) -> dict:
+    def peer_probe(self, server: str, node: str) -> bool:
         """
         Adds a new peer to the cluster
         Args:
@@ -25,13 +25,7 @@ class PeerOps(AbstractOps):
             node (str): The node in the cluster where peer probe is to be run
 
         Returns:
-            ret: A dictionary consisting
-                - Flag : Flag to check if connection failed
-                - msg : message
-                - error_msg: error message
-                - error_code: error code returned
-                - cmd : command that got executed
-                - node : node on which the command got executed
+            ret: Boolean value
         """
 
         cmd = f'gluster --xml peer probe {server}'

--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -25,7 +25,7 @@ class PeerOps(AbstractOps):
             node (str): The node in the cluster where peer probe is to be run
 
         Returns:
-            ret: Boolean value
+            ret: bool: True on success, false on failure
         """
 
         cmd = f'gluster --xml peer probe {server}'

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -94,7 +94,6 @@ class VolumeOps(AbstractOps):
 
         """
         brick_cmd = ""
-        server_iter = 0
         mul_fac = 0
         cmd = ""
         brick_dict = {}
@@ -116,19 +115,8 @@ class VolumeOps(AbstractOps):
         else:
             mul_fac = conf_hash["disperse_count"]
 
-        server_iter = 0
-        for iteration in range(mul_fac):
-            if server_iter == len(server_list):
-                server_iter = 0
-            server_val = server_list[server_iter]
-            if server_val not in brick_dict.keys():
-                brick_dict[server_val] = []
-            brick_path_val = \
-                f"{brick_root[server_list[server_iter]]}/{volname}-{iteration}"
-            brick_dict[server_val].append(brick_path_val)
-            brick_cmd = (f"{brick_cmd} {server_val}:{brick_path_val}")
-            server_iter += 1
-
+        brick_dict, brick_cmd = self.form_brick_cmd(server_list, brick_root,
+                                                    volname, mul_fac)
         if "replica_count" in conf_hash:
             # arbiter vol and distributed-arbiter vol
             if "arbiter_count" in conf_hash:

--- a/core/environ.py
+++ b/core/environ.py
@@ -286,7 +286,7 @@ class FrameworkEnv:
         for node in brick_dict:
             if node not in self.volds[volname]['brickdata'].keys():
                 self.volds[volname]['brickdata'][node] = []
-            self.volds[volname]['brickdata'][node].append(brick_dict[node])
+            self.volds[volname]['brickdata'][node].extend(brick_dict[node])
 
     def set_brickdata(self, volname: str, brick_dict: dict):
         """
@@ -307,8 +307,10 @@ class FrameworkEnv:
         """
         self._validate_volname(volname)
         for node in brick_data:
-            self.volds[volname]["brickdata"][node].remove(brick_data[node])
+            for brick in brick_data[node]:
+                self.volds[volname]["brickdata"][node].remove(brick)
         self.add_data_to_cleands(brick_data)
+        
 
     def get_brickdata(self, volname: str) -> dict:
         """

--- a/core/environ.py
+++ b/core/environ.py
@@ -310,7 +310,6 @@ class FrameworkEnv:
             for brick in brick_data[node]:
                 self.volds[volname]["brickdata"][node].remove(brick)
         self.add_data_to_cleands(brick_data)
-        
 
     def get_brickdata(self, volname: str) -> dict:
         """

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -29,7 +29,7 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
-    def vol_operations(self, redant, volname: str):
+    def _vol_operations(self, redant, volname: str):
         """
         This function performs a
         set of colume operations like
@@ -115,7 +115,7 @@ class TestCase(DParentTest):
         redant.logger.info("Volume: test-vol created successfully")
 
         # perform the set of volume operations
-        self.vol_operations(redant, "test-vol")
+        self._vol_operations(redant, "test-vol")
 
         # Getting FQDN (Full qualified domain name) of each host and
         # replacing ip with FQDN name for each brick for example
@@ -140,7 +140,7 @@ class TestCase(DParentTest):
         redant.es.set_new_volume("test-vol-fqdn", brick_dict)
 
         # perform the set of volume operations
-        self.vol_operations(redant, "test-vol-fqdn")
+        self._vol_operations(redant, "test-vol-fqdn")
 
         # creating the cluster back again
         ret = redant.create_cluster(self.server_list)

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -39,7 +39,7 @@ class TestPeerProbe(GlusterBaseClass):
                 raise ExecutionError("Peer detach failed")
             g.log.info("Peer detach SUCCESSFUL.")
 
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
     def tearDown(self):
 
@@ -64,7 +64,7 @@ class TestPeerProbe(GlusterBaseClass):
                    "servers %s", self.servers)
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_peer_probe_validation(self):
         # pylint: disable=too-many-statements

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -103,14 +103,14 @@ class TestPeerProbe(GlusterBaseClass):
                                   self.brick_list, force=False)
         self.assertEqual(ret, 0, "Unable"
                          "to create volume % s" % self.volname)
-        g.log.info("Volume created successfuly % s", self.volname)
+        g.log.info("Volume created successfully % s", self.volname)
 
         # Start a volume
         g.log.info("Start a volume")
         ret, _, _ = volume_start(self.mnode, self.volname)
         self.assertEqual(ret, 0, "Unable"
                          "to start volume % s" % self.volname)
-        g.log.info("Volume started successfuly % s", self.volname)
+        g.log.info("Volume started successfully % s", self.volname)
 
         # Get volume info
         g.log.info("get volume info")
@@ -127,7 +127,7 @@ class TestPeerProbe(GlusterBaseClass):
         ret, _, _ = volume_stop(self.mnode, self.volname)
         self.assertEqual(ret, 0, "Unable"
                          "to stop volume % s" % self.volname)
-        g.log.info("Volume stopped successfuly % s", self.volname)
+        g.log.info("Volume stopped successfully % s", self.volname)
 
         # Create a volume
         self.volname = "test-vol-fqdn"
@@ -154,14 +154,14 @@ class TestPeerProbe(GlusterBaseClass):
                                   my_brick_list, force=False)
         self.assertEqual(ret, 0, "Unable"
                          "to create volume % s" % self.volname)
-        g.log.info("Volume created successfuly % s", self.volname)
+        g.log.info("Volume created successfully % s", self.volname)
 
         # Start a volume
         g.log.info("Start a volume")
         ret, _, _ = volume_start(self.mnode, self.volname)
         self.assertEqual(ret, 0, "Unable"
                          "to start volume % s" % self.volname)
-        g.log.info("Volume started successfuly % s", self.volname)
+        g.log.info("Volume started successfully % s", self.volname)
 
         # Get volume info
         g.log.info("get volume info")
@@ -178,4 +178,4 @@ class TestPeerProbe(GlusterBaseClass):
         ret, _, _ = volume_stop(self.mnode, self.volname)
         self.assertEqual(ret, 0, "Unable"
                          "to stop volume % s" % self.volname)
-        g.log.info("Volume stopped successfuly % s", self.volname)
+        g.log.info("Volume stopped successfully % s", self.volname)

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -35,10 +35,6 @@ class TestCase(DParentTest):
         set of colume operations like
         start, volume status, info,
         volume delete.
-
-        Args:
-            redant: Redant object
-            volname (str): Name of the volume
         """
 
         # Start a volume

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -1,0 +1,184 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import socket
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.peer_ops import (peer_probe, peer_detach,
+                                         peer_probe_servers)
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.volume_ops import (volume_create, volume_start,
+                                           get_volume_list, volume_stop,
+                                           get_volume_info, get_volume_status)
+from glustolibs.gluster.volume_libs import cleanup_volume
+from glustolibs.gluster.exceptions import ExecutionError
+
+
+class TestPeerProbe(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+        g.log.info("Starting %s ", cls.__name__)
+
+    def setUp(self):
+        # Performing peer detach
+        for server in self.servers[1:]:
+            # Peer detach
+            ret, _, _ = peer_detach(self.mnode, server)
+            if ret:
+                raise ExecutionError("Peer detach failed")
+            g.log.info("Peer detach SUCCESSFUL.")
+            self.peer_probe = False
+
+        GlusterBaseClass.setUp.im_func(self)
+
+    def tearDown(self):
+
+        # Peer probe detached servers
+        if not self.peer_probe:
+            ret = peer_probe_servers(self.mnode, self.servers)
+            if not ret:
+                raise ExecutionError("Failed to probe detached "
+                                     "servers %s" % self.servers)
+            g.log.info("Peer probe success for detached "
+                       "servers %s", self.servers)
+
+        # clean up all volumes and detaches peers from cluster
+
+        vol_list = get_volume_list(self.mnode)
+        for volume in vol_list:
+            ret = cleanup_volume(self.mnode, volume)
+            if not ret:
+                raise ExecutionError("Failed to Cleanup the "
+                                     "Volume %s" % volume)
+            g.log.info("Volume deleted successfully : %s", volume)
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_peer_probe_validation(self):
+        '''
+        -> Create trusted storage pool, by probing with networkshort names
+        -> Create volume using IP of host
+        -> perform basic operations like
+            -> gluster volume start <vol>
+            -> gluster volume info <vol>
+            -> gluster volume status <vol>
+            -> gluster volume stop <vol>
+        -> Create a volume using the FQDN of the host
+        -> perform basic operations like
+            -> gluster volume start <vol>
+            -> gluster volume info <vol>
+            -> gluster volume status <vol>
+            -> gluster volume stop <vol>
+        '''
+        # Peer probing using short name
+        for server in self.servers[1:]:
+            ret, hostname, _ = g.run(server, "hostname -s")
+            self.assertEqual(ret, 0, ("Unable to get short name "
+                                      "for server % s" % server))
+            ret, _, _ = peer_probe(self.mnode, hostname)
+            self.assertEqual(ret, 0, "Unable to peer"
+                             "probe to the server % s" % hostname)
+            g.log.info("Peer probe succeeded for server %s", hostname)
+        self.peer_probe = True
+
+        # Create a volume
+        self.volname = "test-vol"
+        self.brick_list = form_bricks_list(self.mnode, self.volname, 3,
+                                           self.servers,
+                                           self.all_servers_info)
+        g.log.info("Creating a volume")
+        ret, _, _ = volume_create(self.mnode, self.volname,
+                                  self.brick_list, force=False)
+        self.assertEqual(ret, 0, "Unable"
+                         "to create volume % s" % self.volname)
+        g.log.info("Volume created successfuly % s", self.volname)
+
+        # Start a volume
+        g.log.info("Start a volume")
+        ret, _, _ = volume_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Unable"
+                         "to start volume % s" % self.volname)
+        g.log.info("Volume started successfuly % s", self.volname)
+
+        # Get volume info
+        g.log.info("get volume info")
+        volinfo = get_volume_info(self.mnode, self.volname)
+        self.assertIsNotNone(volinfo, "Failed to get the volume "
+                                      "info for %s" % self.volname)
+
+        # Get volume status
+        vol_status = get_volume_status(self.mnode, self.volname)
+        self.assertIsNotNone(vol_status, "Failed to get volume "
+                                         "status for %s" % self.volname)
+
+        # stop volume
+        ret, _, _ = volume_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Unable"
+                         "to stop volume % s" % self.volname)
+        g.log.info("Volume stopped successfuly % s", self.volname)
+
+        # Create a volume
+        self.volname = "test-vol-fqdn"
+
+        self.brick_list = form_bricks_list(self.mnode, self.volname, 3,
+                                           self.servers,
+                                           self.all_servers_info)
+
+        # Getting FQDN (Full qualified domain name) of each host and
+        # replacing ip with FQDN name for each brick for example
+        # 10.70.37.219:/bricks/brick0/vol1 is a brick, here ip is replaced
+        # with FQDN name now brick looks like
+        # dhcp35-219.lab.eng.blr.redhat.com:/bricks/brick0/vol1
+
+        my_brick_list = []
+        for brick in self.brick_list:
+            fqdn_list = brick.split(":")
+            fqdn = socket.getfqdn(fqdn_list[0])
+            fqdn = fqdn + ":" + fqdn_list[1]
+            my_brick_list.append(fqdn)
+
+        g.log.info("Creating a volume")
+        ret, _, _ = volume_create(self.mnode, self.volname,
+                                  my_brick_list, force=False)
+        self.assertEqual(ret, 0, "Unable"
+                         "to create volume % s" % self.volname)
+        g.log.info("Volume created successfuly % s", self.volname)
+
+        # Start a volume
+        g.log.info("Start a volume")
+        ret, _, _ = volume_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Unable"
+                         "to start volume % s" % self.volname)
+        g.log.info("Volume started successfuly % s", self.volname)
+
+        # Get volume info
+        g.log.info("get volume info")
+        volinfo = get_volume_info(self.mnode, self.volname)
+        self.assertIsNotNone(volinfo, "Failed to get the volume "
+                                      "info for %s" % self.volname)
+
+        # Get volume status
+        vol_status = get_volume_status(self.mnode, self.volname)
+        self.assertIsNotNone(vol_status, "Failed to get volume "
+                                         "status for %s" % self.volname)
+
+        # stop volume
+        ret, _, _ = volume_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Unable"
+                         "to stop volume % s" % self.volname)
+        g.log.info("Volume stopped successfuly % s", self.volname)


### PR DESCRIPTION
1. Migrated the [test
   case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_probe_hostname.py).
2. Added form_brick_cmd in brick ops to reuse the function wherever
   needed. Used the same in the volume_crete part.
3. Modified peer_ops: Peer probe return type was wrong as it was returning boolean. Hence changed from dict to bool and modified the docstring.

Updates: #292

Fixes: #371

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>