### PR TITLE
Migrated test_profile_start_with_quorum_not_met

### DIFF
--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -277,3 +277,38 @@ class PeerOps(AbstractOps):
             sleep(1)
             count += 1
         return False
+
+    def validate_peers_are_connected(self, server_list: list,
+                                     node: str) -> bool:
+        """
+        Validate whether each server in the cluster is connected to
+        all other servers in cluster.
+
+        Returns (bool): True if all peers are in connected
+                        state with other peers.
+                        False otherwise.
+        """
+        # if the setup has single node cluster
+        # then by-pass this validation
+        if len(server_list) == 1:
+            return True
+
+        # validate if peer is connected from all
+        # the servers
+        self.logger.info(f"Validating if {server_list} are connnected in"
+                         f" the cluster")
+
+        for server in server_list:
+            self.logger.info(f"Is peer connected {server}->{server_list}")
+            ret = self.is_peer_connected(server, server_list)
+            self.logger.info(f"Peer {server} is connected")
+
+            if not ret:
+                self.logger.error(f"Servers are not in connected state"
+                                  f" from {server}")
+                return False
+
+        self.logger.info("Successfully validated. All the servers"
+                         " in the cluster are connected")
+        self.get_peer_status(node)
+        return True

--- a/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
+++ b/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
@@ -60,9 +60,12 @@ class TestCase(DParentTest):
             ret = redant.validate_peers_are_connected(self.server_list[:],
                                                       self.server_list[0])
             if ret:
-                redant.logger.error("Peers are in connected state even after "
-                                    "stopping glusterd on one node")
+                break
             sleep(2)
+
+        if ret:
+            redant.logger.error("Peers are in connected state even after "
+                                "stopping glusterd on one node")
 
         # Starting volume profile when quorum is not met
         new_servers = self.server_list[:]
@@ -81,8 +84,11 @@ class TestCase(DParentTest):
             ret = redant.validate_peers_are_connected(self.server_list[:],
                                                       self.server_list[0])
             if not ret:
-                redant.logger.error("Peers are not in connected state")
+                break
             sleep(2)
+
+        if not ret:
+            redant.logger.error("Peers are not in connected state")
 
         # Starting profile when volume quorum is met
         redant.profile_start(self.vol_name, self.server_list[0])

--- a/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
+++ b/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
@@ -59,7 +59,7 @@ class TestCase(DParentTest):
         for _ in range(5):
             ret = redant.validate_peers_are_connected(self.server_list[:],
                                                       self.server_list[0])
-            if ret:
+            if not ret:
                 break
             sleep(2)
 
@@ -83,7 +83,7 @@ class TestCase(DParentTest):
         for _ in range(5):
             ret = redant.validate_peers_are_connected(self.server_list[:],
                                                       self.server_list[0])
-            if not ret:
+            if ret:
                 break
             sleep(2)
 

--- a/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
+++ b/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
@@ -31,7 +31,7 @@ class TestProfileStartWithQuorumNotMet(GlusterBaseClass):
     def setUp(self):
 
         # calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # Creating Volume
         g.log.info("Started creating volume")
@@ -59,7 +59,7 @@ class TestProfileStartWithQuorumNotMet(GlusterBaseClass):
         g.log.info("Volume deleted successfully : %s", self.volname)
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_profile_start_with_quorum_not_met(self):
         # pylint: disable=too-many-statements

--- a/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
+++ b/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
@@ -1,0 +1,147 @@
+#  Copyright (C) 2017-2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from random import choice
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
+from glustolibs.gluster.profile_ops import profile_start, profile_stop
+
+
+@runs_on([['distributed', 'replicated', 'dispersed',
+           'distributed-replicated', 'distributed-dispersed'], ['glusterfs']])
+class TestProfileStartWithQuorumNotMet(GlusterBaseClass):
+
+    def setUp(self):
+
+        # calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+
+        # Creating Volume
+        g.log.info("Started creating volume")
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Volume creation failed: %s" % self.volname)
+        g.log.info("Volme created successfully : %s", self.volname)
+
+    def tearDown(self):
+
+        # Setting Quorum ratio to 51%
+        self.quorum_perecent = {'cluster.server-quorum-ratio': '51%'}
+        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
+        if not ret:
+            raise ExecutionError("gluster volume set all cluster."
+                                 "server-quorum-ratio percentage "
+                                 "Failed :%s" % self.servers)
+        g.log.info("gluster volume set all cluster.server-quorum-ratio 51 "
+                   "percentage enabled successfully on :%s", self.servers)
+
+        # stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_profile_start_with_quorum_not_met(self):
+        # pylint: disable=too-many-statements
+        """
+        1. Create a volume
+        2. Set the quorum type to server and ratio to 90
+        3. Stop glusterd randomly on one of the node
+        4. Start profile on the volume
+        5. Start glusterd on the node where it is stopped
+        6. Start profile on the volume
+        7. Stop profile on the volume where it is started
+        """
+
+        # Enabling server quorum
+        self.quorum_options = {'cluster.server-quorum-type': 'server'}
+        ret = set_volume_options(self.mnode, self.volname, self.quorum_options)
+        self.assertTrue(ret, "gluster volume set %s cluster.server-quorum-type"
+                             " server Failed" % self.volname)
+        g.log.info("gluster volume set %s cluster.server-quorum-type server "
+                   "enabled successfully", self.volname)
+
+        # Setting Quorum ratio to 90%
+        self.quorum_perecent = {'cluster.server-quorum-ratio': '90%'}
+        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
+        self.assertTrue(ret, "gluster volume set all cluster.server-quorum-rat"
+                             "io percentage Failed :%s" % self.servers)
+        g.log.info("gluster volume set all cluster.server-quorum-ratio 90 "
+                   "percentage enabled successfully on :%s", self.servers)
+
+        # Stop glusterd on one of the node randomly
+        self.node_on_glusterd_to_stop = choice(self.servers)
+        ret = stop_glusterd(self.node_on_glusterd_to_stop)
+        self.assertTrue(ret, "glusterd stop on the node failed")
+        g.log.info("glusterd stop on the node: % "
+                   "succeeded", self.node_on_glusterd_to_stop)
+
+        # checking whether peers are connected or not
+        count = 0
+        while count < 5:
+            ret = self.validate_peers_are_connected()
+            if not ret:
+                break
+            sleep(2)
+            count += 1
+        self.assertFalse(ret, "Peers are in connected state even after "
+                              "stopping glusterd on one node")
+
+        # Starting volume profile when quorum is not met
+        self.new_servers = self.servers[:]
+        self.new_servers.remove(self.node_on_glusterd_to_stop)
+        ret, _, _ = profile_start(choice(self.new_servers),
+                                  self.volname)
+        self.assertNotEqual(ret, 0, "Expected: Should not be able to start "
+                                    "volume profile. Acutal: Able to start "
+                                    "the volume profile start")
+        g.log.info("gluster vol profile start is failed as expected")
+
+        # Start glusterd on the node where it is stopped
+        ret = start_glusterd(self.node_on_glusterd_to_stop)
+        self.assertTrue(ret, "glusterd start on the node failed")
+        g.log.info("glusterd start succeeded")
+
+        # checking whether peers are connected or not
+        count = 0
+        while count < 5:
+            ret = self.validate_peers_are_connected()
+            if ret:
+                break
+            sleep(5)
+            count += 1
+        self.assertTrue(ret, "Peer are not in connected state ")
+
+        # Starting profile when volume quorum is met
+        ret, _, _ = profile_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Expected: Should be able to start the"
+                                 "volume profile start. Acutal: Not able"
+                                 " to start the volume profile start")
+        g.log.info("gluster vol profile start is successful")
+
+        # Stop the profile
+        ret, _, _ = profile_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Expected: Should be able to stop the "
+                                 "profile stop. Acutal: Not able to stop"
+                                 " the profile stop")
+        g.log.info("gluster volume profile stop is successful")

--- a/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
+++ b/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
@@ -54,8 +54,6 @@ class TestCase(DParentTest):
         # Stop glusterd on one of the node randomly
         node_on_glusterd_to_stop = choice(self.server_list[1:])
         redant.stop_glusterd(node_on_glusterd_to_stop)
-        redant.logger.info(f"glusterd stop on the node: "
-                           f"{node_on_glusterd_to_stop} succeeded")
 
         # checking whether peers are connected or not
         for _ in range(5):
@@ -78,8 +76,6 @@ class TestCase(DParentTest):
 
         # Start glusterd on the node where it is stopped
         redant.start_glusterd(node_on_glusterd_to_stop)
-        redant.logger.info(f"Successfully started glusterd "
-                           f" on {node_on_glusterd_to_stop}")
 
         for _ in range(5):
             ret = redant.validate_peers_are_connected(self.server_list[:],

--- a/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
+++ b/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py
@@ -42,16 +42,6 @@ class TestProfileStartWithQuorumNotMet(GlusterBaseClass):
 
     def tearDown(self):
 
-        # Setting Quorum ratio to 51%
-        self.quorum_perecent = {'cluster.server-quorum-ratio': '51%'}
-        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
-        if not ret:
-            raise ExecutionError("gluster volume set all cluster."
-                                 "server-quorum-ratio percentage "
-                                 "Failed :%s" % self.servers)
-        g.log.info("gluster volume set all cluster.server-quorum-ratio 51 "
-                   "percentage enabled successfully on :%s", self.servers)
-
         # stopping the volume and Cleaning up the volume
         ret = self.cleanup_volume()
         if not ret:


### PR DESCRIPTION
Migrated the [test case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_profile_start_with_quorum_not_met.py).

Added validate_peer_is_connected in peer ops. It's originally in Gluster
Base class in glusto-tests.

Updates: #292
Fixes: #387

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>