### PR TITLE
Lint Script modification

### DIFF
--- a/tools/linting.sh
+++ b/tools/linting.sh
@@ -81,8 +81,8 @@ while getopts "p:flh" opt; do
         ;;
         f)
             echo "Flake operation starts"
-            flake8 $FILEPATH --ignore=C901,F811,F841,E722,E226,E402,W503 --count --select=E9,F63,F7,F82 --show-source --statistics
-            flake8 $FILEPATH --ignore=C901,F811,F841,E722,E226,E402,W503 --count --max-complexity=10 --max-line-length=79 --statistics
+            flake8 $FILEPATH --ignore=C901,F811,F841,E722,E226,E402,W503,W605 --count --select=E9,F63,F7,F82 --show-source --statistics
+            flake8 $FILEPATH --ignore=C901,F811,F841,E722,E226,E402,W503,W605 --count --max-complexity=10 --max-line-length=79 --statistics
         ;;
         l)
             echo "Lint operation starts"


### PR DESCRIPTION
Linting.yaml was modified in the recent patches. The same command has to
be present in the linting.sh script. Hence, modified the same.

Fixes: #398

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
