### PR TITLE
[Test] Migration of test_volume_status_xml

### DIFF
--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -29,8 +29,7 @@ from glustolibs.gluster.peer_ops import (peer_probe_servers, peer_detach,
 class TestVolumeStatusxml(GlusterBaseClass):
 
     def setUp(self):
-
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # check whether peers are in connected state
         ret = self.validate_peers_are_connected()
@@ -60,7 +59,7 @@ class TestVolumeStatusxml(GlusterBaseClass):
         if not ret:
             raise ExecutionError("Failed to probe detached "
                                  "servers %s" % self.servers)
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_volume_status_xml(self):
 

--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -14,6 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+    Test volume status before and after volume start.
 """
 
 

--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -1,0 +1,112 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_ops import (volume_create, volume_status,
+                                           get_volume_status, volume_start)
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.peer_ops import (peer_probe_servers, peer_detach,
+                                         peer_detach_servers,
+                                         nodes_from_pool_list)
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestVolumeStatusxml(GlusterBaseClass):
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+
+        # check whether peers are in connected state
+        ret = self.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+        # detach all the nodes
+        ret = peer_detach_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Peer detach failed to all the servers from "
+                                 "the node %s." % self.mnode)
+        g.log.info("Peer detach SUCCESSFUL.")
+
+    def tearDown(self):
+
+        # stopping and cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Cleanup the Volume %s"
+                                 % self.volname)
+
+        pool = nodes_from_pool_list(self.mnode)
+        for node in pool:
+            peer_detach(self.mnode, node)
+
+        ret = peer_probe_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Failed to probe detached "
+                                 "servers %s" % self.servers)
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_volume_status_xml(self):
+
+        # create a two node cluster
+        ret = peer_probe_servers(self.servers[0], self.servers[1])
+        self.assertTrue(ret, "Peer probe failed to %s from %s"
+                        % (self.mnode, self.servers[1]))
+
+        # create a distributed volume with single node
+        number_of_bricks = 1
+        servers_info_from_single_node = {}
+        servers_info_from_single_node[
+            self.servers[0]] = self.all_servers_info[self.servers[0]]
+
+        bricks_list = form_bricks_list(self.mnode, self.volname,
+                                       number_of_bricks, self.servers[0],
+                                       servers_info_from_single_node)
+        ret, _, _ = volume_create(self.servers[0], self.volname, bricks_list)
+        self.assertEqual(ret, 0, "Volume creation failed")
+        g.log.info("Volume %s created successfully", self.volname)
+
+        # Get volume status
+        ret, _, err = volume_status(self.servers[1], self.volname)
+        self.assertNotEqual(ret, 0, ("Unexpected: volume status is success for"
+                                     " %s, even though volume is not started "
+                                     "yet" % self.volname))
+        self.assertIn("is not started", err, ("volume status exited with"
+                                              " incorrect error message"))
+
+        # Get volume status with --xml
+        vol_status = get_volume_status(self.servers[1], self.volname)
+        self.assertIsNone(vol_status, ("Unexpected: volume status --xml for %s"
+                                       " is success even though the volume is"
+                                       " not stared yet" % self.volname))
+
+        # start the volume
+        ret, _, _ = volume_start(self.servers[1], self.volname)
+        self.assertEqual(ret, 0, "Failed to start volume %s" % self.volname)
+
+        # Get volume status
+        ret, _, _ = volume_status(self.servers[1], self.volname)
+        self.assertEqual(ret, 0, ("Failed to get volume status for %s"
+                                  % self.volname))
+
+        # Get volume status with --xml
+        vol_status = get_volume_status(self.servers[1], self.volname)
+        self.assertIsNotNone(vol_status, ("Failed to get volume "
+                                          "status --xml for %s"
+                                          % self.volname))


### PR DESCRIPTION
The check for error logs in the glusterd
has been removed as the glusterd does throw
a harmless Error log saying volume is not started
when someone tries to query status when the
volume isn't started.

Fixes: #401 


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
