### PR TITLE
[Test] Migrating test_readonly_option_on_volume

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -27,7 +27,8 @@ class IoOps(AbstractOps):
         cmd = f"touch {path}/{filename}"
         self.execute_abstract_op_node(cmd, node)
 
-    def create_dir(self, path: str, dirname: str, node: str, excep: bool=True):
+    def create_dir(self, path: str, dirname: str, node: str,
+                   excep: bool = True):
         """
         Creates a directory in the specified path
         Args:

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -27,7 +27,7 @@ class IoOps(AbstractOps):
         cmd = f"touch {path}/{filename}"
         self.execute_abstract_op_node(cmd, node)
 
-    def create_dir(self, path: str, dirname: str, node: str):
+    def create_dir(self, path: str, dirname: str, node: str, excep: bool=True):
         """
         Creates a directory in the specified path
         Args:
@@ -36,9 +36,11 @@ class IoOps(AbstractOps):
             dirname (str): Name of the directory
             node (str): The node on which command
                         has to run.
+            excep (bool): Whether to bypass the exception handling in
+                          abstract ops.
         """
         cmd = f"mkdir -p {path}/{dirname}"
-        self.execute_abstract_op_node(cmd, node)
+        return self.execute_abstract_op_node(cmd, node, excep)
 
     def create_dirs(self, list_of_nodes: list, list_of_dir_paths: list):
         """

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -1,0 +1,156 @@
+#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+      Test read-only option on volumes
+"""
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.misc.misc_libs import upload_scripts
+from glustolibs.io.utils import validate_io_procs
+from glustolibs.gluster.volume_ops import set_volume_options
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
+class TestReadOnlyOptionOnVolume(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        cls.counter = 1
+        GlusterBaseClass.setUpClass.im_func(cls)
+
+        # Uploading file_dir script in all client direcotries
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", cls.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts to clients %s"
+                                 % cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+    def setUp(self):
+        """
+        setUp method for every test
+        """
+        # calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+
+        # Creating Volume
+        ret = self.setup_volume_and_mount_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Volume creation or mount failed: %s"
+                                 % self.volname)
+        g.log.info("Volme created and mounted successfully : %s",
+                   self.volname)
+
+    def tearDown(self):
+        """
+        tearDown for every test
+        """
+        # unmounting the volume and Cleaning up the volume
+        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Failed Cleanup the Volume %s"
+                                 % self.volname)
+
+        # Calling GlusterBaseClass tearDown
+
+    def test_readonly_option_on_volume(self):
+        '''
+        -> Create volume
+        -> Mount a volume
+        -> set 'read-only on' on a volume
+        -> perform some I/O's on mount point
+        -> set 'read-only off' on a volume
+        -> perform some I/O's on mount point
+        '''
+
+        # Setting Read-only on volume
+        ret = set_volume_options(self.mnode, self.volname,
+                                 {'read-only': 'on'})
+        self.assertTrue(ret, "gluster volume set %s read-only failed"
+                        % self.volname)
+        g.log.info("gluster volume set %s read-only executed successfully",
+                   self.volname)
+
+        # run IOs
+        g.log.info("Starting IO on all mounts...")
+        self.all_mounts_procs = []
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dirname-start-num %d "
+                   "--dir-depth 2 "
+                   "--dir-length 2 "
+                   "--max-num-of-dirs 2 "
+                   "--num-of-files 5 %s" % (self.script_upload_path,
+                                            self.counter,
+                                            mount_obj.mountpoint))
+
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+            self.counter = self.counter + 10
+
+        # Validate IO
+        g.log.info("Wait for IO to complete and validate IO ...")
+        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
+        self.assertFalse(ret, "IO should fail on mount points of readonly "
+                              "volumes but IO success")
+        g.log.info("IO failed on mount points of read only volumes "
+                   "as expected")
+
+        # Setting Read only off volume
+        ret = set_volume_options(self.mnode, self.volname,
+                                 {'read-only': 'off'})
+        self.assertTrue(ret, "gluster volume set %s read-only failed"
+                        % self.volname)
+        g.log.info("gluster volume set %s read-only executed successfully",
+                   self.volname)
+
+        # run IOs
+        g.log.info("Starting IO on all mounts...")
+        self.all_mounts_procs = []
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dirname-start-num %d "
+                   "--dir-depth 2 "
+                   "--dir-length 2 "
+                   "--max-num-of-dirs 2 "
+                   "--num-of-files 5 %s" % (self.script_upload_path,
+                                            self.counter,
+                                            mount_obj.mountpoint))
+
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+            self.counter = self.counter + 10
+
+        # Validate IO
+        g.log.info("Wait for IO to complete and validate IO ...")
+        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
+        self.assertTrue(ret, "IO failed on some of the clients")
+        g.log.info("IO is successful on all mounts")

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -40,11 +40,9 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                   "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, script_local_path)
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts to clients %s"
                                  % cls.clients)

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -1,80 +1,28 @@
-#  Copyright (C) 2018-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2018-2020  Red Hat, Inc. <http://www.redhat.com>
 
-""" Description:
-      Test read-only option on volumes
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-from glusto.core import Glusto as g
 
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.misc.misc_libs import upload_scripts
-from glustolibs.io.utils import validate_io_procs
-from glustolibs.gluster.volume_ops import set_volume_options
+from tests.nd_parent_test import NdParentTest
 
+# nonDisruptive;dist,rep,dist-rep,disp,dist-disp
 
-@runs_on([['distributed', 'replicated', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'], ['glusterfs']])
-class TestReadOnlyOptionOnVolume(GlusterBaseClass):
-    @classmethod
-    def setUpClass(cls):
-        cls.counter = 1
-        cls.get_super_method(cls, 'setUpClass')()
-
-        # Uploading file_dir script in all client direcotries
-        g.log.info("Upload io scripts to clients %s for running IO on "
-                   "mounts", cls.clients)
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts to clients %s"
-                                 % cls.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   cls.clients)
-
-    def setUp(self):
-        """
-        setUp method for every test
-        """
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        # Creating Volume
-        ret = self.setup_volume_and_mount_volume(self.mounts)
-        if not ret:
-            raise ExecutionError("Volume creation or mount failed: %s"
-                                 % self.volname)
-        g.log.info("Volme created and mounted successfully : %s",
-                   self.volname)
-
-    def tearDown(self):
-        """
-        tearDown for every test
-        """
-        # unmounting the volume and Cleaning up the volume
-        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
-        if not ret:
-            raise ExecutionError("Failed Cleanup the Volume %s"
-                                 % self.volname)
-
-        # Calling GlusterBaseClass tearDown
-
-    def test_readonly_option_on_volume(self):
+class TestCase(NdParentTest):
+    def run_test(self):
         '''
         -> Create volume
         -> Mount a volume
@@ -85,72 +33,29 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         '''
 
         # Setting Read-only on volume
-        ret = set_volume_options(self.mnode, self.volname,
-                                 {'read-only': 'on'})
-        self.assertTrue(ret, "gluster volume set %s read-only failed"
-                        % self.volname)
-        g.log.info("gluster volume set %s read-only executed successfully",
-                   self.volname)
+        ret = set_volume_options(self.mnode, self.volname,{'read-only': 'on'})
 
         # run IOs
-        g.log.info("Starting IO on all mounts...")
         self.all_mounts_procs = []
         for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dirname-start-num %d "
-                   "--dir-depth 2 "
-                   "--dir-length 2 "
-                   "--max-num-of-dirs 2 "
-                   "--num-of-files 5 %s" % (self.script_upload_path,
-                                            self.counter,
-                                            mount_obj.mountpoint))
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files ""--dirname-start-num %d ""--dir-depth 2 ""--dir-length 2 ""--max-num-of-dirs 2 ""--num-of-files 5 %s" % (self.script_upload_path,self.counter,mount_obj.mountpoint))
 
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
+            proc = g.run_async(mount_obj.client_system, cmd,user=mount_obj.user)
             self.all_mounts_procs.append(proc)
             self.counter = self.counter + 10
 
         # Validate IO
-        self.assertFalse(
-            validate_io_procs(self.all_mounts_procs, self.mounts),
-            "IO should fail on mount points of readonly "
-            "volumes but IO succeeded"
-        )
-        g.log.info("IO failed on mount points of read only volumes "
-                   "as expected")
 
         # Setting Read only off volume
-        ret = set_volume_options(self.mnode, self.volname,
-                                 {'read-only': 'off'})
-        self.assertTrue(ret, "gluster volume set %s read-only failed"
-                        % self.volname)
-        g.log.info("gluster volume set %s read-only executed successfully",
-                   self.volname)
+        ret = set_volume_options(self.mnode, self.volname,{'read-only': 'off'})
 
         # run IOs
-        g.log.info("Starting IO on all mounts...")
         self.all_mounts_procs = []
         for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dirname-start-num %d "
-                   "--dir-depth 2 "
-                   "--dir-length 2 "
-                   "--max-num-of-dirs 2 "
-                   "--num-of-files 5 %s" % (self.script_upload_path,
-                                            self.counter,
-                                            mount_obj.mountpoint))
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files ""--dirname-start-num %d ""--dir-depth 2 ""--dir-length 2 ""--max-num-of-dirs 2 ""--num-of-files 5 %s" % (self.script_upload_path,self.counter,mount_obj.mountpoint))
 
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
+            proc = g.run_async(mount_obj.client_system, cmd,user=mount_obj.user)
             self.all_mounts_procs.append(proc)
             self.counter = self.counter + 10
 
         # Validate IO
-        self.assertTrue(
-            validate_io_procs(self.all_mounts_procs, self.mounts),
-            "IO failed on some of the clients"
-        )

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2018-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,8 +17,6 @@
 """ Description:
       Test read-only option on volumes
 """
-
-import sys
 
 from glusto.core import Glusto as g
 
@@ -100,13 +98,12 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
-                   "--num-of-files 5 %s" % (sys.version_info.major,
-                                            self.script_upload_path,
+                   "--num-of-files 5 %s" % (self.script_upload_path,
                                             self.counter,
                                             mount_obj.mountpoint))
 
@@ -138,13 +135,12 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
-                   "--num-of-files 5 %s" % (sys.version_info.major,
-                                            self.script_upload_path,
+                   "--num-of-files 5 %s" % (self.script_upload_path,
                                             self.counter,
                                             mount_obj.mountpoint))
 

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -114,10 +114,11 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
             self.counter = self.counter + 10
 
         # Validate IO
-        g.log.info("Wait for IO to complete and validate IO ...")
-        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
-        self.assertFalse(ret, "IO should fail on mount points of readonly "
-                              "volumes but IO success")
+        self.assertFalse(
+            validate_io_procs(self.all_mounts_procs, self.mounts),
+            "IO should fail on mount points of readonly "
+            "volumes but IO succeeded"
+        )
         g.log.info("IO failed on mount points of read only volumes "
                    "as expected")
 
@@ -150,7 +151,7 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
             self.counter = self.counter + 10
 
         # Validate IO
-        g.log.info("Wait for IO to complete and validate IO ...")
-        ret = validate_io_procs(self.all_mounts_procs, self.mounts)
-        self.assertTrue(ret, "IO failed on some of the clients")
-        g.log.info("IO is successful on all mounts")
+        self.assertTrue(
+            validate_io_procs(self.all_mounts_procs, self.mounts),
+            "IO failed on some of the clients"
+        )

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -18,7 +18,10 @@
       Test read-only option on volumes
 """
 
+import sys
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.misc.misc_libs import upload_scripts
@@ -32,7 +35,7 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
     @classmethod
     def setUpClass(cls):
         cls.counter = 1
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
 
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
@@ -53,7 +56,7 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         setUp method for every test
         """
         # calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # Creating Volume
         ret = self.setup_volume_and_mount_volume(self.mounts)
@@ -99,12 +102,13 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
-                   "--num-of-files 5 %s" % (self.script_upload_path,
+                   "--num-of-files 5 %s" % (sys.version_info.major,
+                                            self.script_upload_path,
                                             self.counter,
                                             mount_obj.mountpoint))
 
@@ -136,12 +140,13 @@ class TestReadOnlyOptionOnVolume(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 2 "
                    "--dir-length 2 "
                    "--max-num-of-dirs 2 "
-                   "--num-of-files 5 %s" % (self.script_upload_path,
+                   "--num-of-files 5 %s" % (sys.version_info.major,
+                                            self.script_upload_path,
                                             self.counter,
                                             mount_obj.mountpoint))
 

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -24,6 +24,7 @@ from tests.nd_parent_test import NdParentTest
 
 # nonDisruptive;dist,rep,dist-rep,disp,dist-disp
 
+
 class TestCase(NdParentTest):
 
     def run_test(self, redant):

--- a/tests/functional/glusterd/test_readonly_option_on_volume.py
+++ b/tests/functional/glusterd/test_readonly_option_on_volume.py
@@ -14,6 +14,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+    To validate read only option on mount.
 """
 
 
@@ -22,31 +25,33 @@ from tests.nd_parent_test import NdParentTest
 # nonDisruptive;dist,rep,dist-rep,disp,dist-disp
 
 class TestCase(NdParentTest):
-    def run_test(self):
-        '''
-        -> Create volume
-        -> Mount a volume
-        -> set 'read-only on' on a volume
-        -> perform some I/O's on mount point
-        -> set 'read-only off' on a volume
-        -> perform some I/O's on mount point
-        '''
+
+    def run_test(self, redant):
+        """
+        Test steps:
+        1. Create a volume
+        2. Mount the volume
+        3. set 'read-only on' on the volume
+        4. perform some I/O's on mount point
+        5. set 'read-only off' on the volume
+        6. perform some I/O's on mount point
+        """
 
         # Setting Read-only on volume
-        ret = set_volume_options(self.mnode, self.volname,{'read-only': 'on'})
+        redant.set_volume_options(self.vol_name, {'read-only': 'on'},
+                                  self.server_list[0])
 
-        # run IOs
-        self.all_mounts_procs = []
-        for mount_obj in self.mounts:
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files ""--dirname-start-num %d ""--dir-depth 2 ""--dir-length 2 ""--max-num-of-dirs 2 ""--num-of-files 5 %s" % (self.script_upload_path,self.counter,mount_obj.mountpoint))
+        # run IO
+        cmd = (f'cd /mnt/{self.volume_type};'
+               'for i in {1..100};do mkdir '
+               ' dir${i}; for j in {1..30};do echo "sample" > dir${i}/f${j};'
+               'done;done')
+        async_object = redant.execute_command_async(cmd, self.client_list[0])
 
-            proc = g.run_async(mount_obj.client_system, cmd,user=mount_obj.user)
-            self.all_mounts_procs.append(proc)
-            self.counter = self.counter + 10
-
-        # Validate IO
-
-        # Setting Read only off volume
+        # Setting read only off in volume options.
+        redant.set_volume_options(self.vol_name, {'read-only': 'off'},
+                                  self.server_list[0])
+        """ # Setting Read only off volume
         ret = set_volume_options(self.mnode, self.volname,{'read-only': 'off'})
 
         # run IOs
@@ -58,4 +63,4 @@ class TestCase(NdParentTest):
             self.all_mounts_procs.append(proc)
             self.counter = self.counter + 10
 
-        # Validate IO
+        # Validate IO"""


### PR DESCRIPTION
Test migration :  [test_readonly_option_on_volume](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_readonly_option_on_volume.py)

Fixes: #403 

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
