### PR TITLE
Migrated test_add_brick_when_quorum_not_met

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -362,7 +362,8 @@ class BrickOps:
                 self.es.remove_val_from_cleands(node, b_dir)
 =======
     def are_bricks_offline(self, volname: str,
-                           brick_dict: dict, node: str) -> bool:
+                           brick_dict: dict, node: str,
+                           strict: bool = True) -> bool:
         """
         This function checks if the bricks are
         offline.
@@ -371,6 +372,7 @@ class BrickOps:
             volname (str) : Volume name
             brick_dict (dict) : the brick dictionary to compare
             node (str) : the node on which comparison has to be done
+            strict (bool) : To check strictly if all bricks are offline
 
         Returns:
             boolean value: True, if bricks are offline
@@ -387,7 +389,11 @@ class BrickOps:
             if brick_data['status'] == 1:
                 status_count += 1
 
-        if brick_count != status_count:
+        if strict and status_count == 0:
+            self.logger.info("All bricks are offline")
+            return True
+
+        if not strict and brick_count != status_count:
             self.logger.info("Some bricks are offline")
             return True
 

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -360,25 +360,6 @@ class BrickOps:
                 self.execute_abstract_op_node(f"rm -rf {b_dir}", node)
                 self.es.remove_val_from_cleands(node, b_dir)
 
-    def get_brick_dict_list(self, brick_dict: dict):
-        """
-        This function creates a list of
-        bricks from the brick dictionary
-
-        Args:
-            brick_dict: the brick dictionary
-
-        Returns:
-            List of bricks
-        """
-        brick_list = []
-        for server in brick_dict:
-            for brick in brick_dict[server]:
-                brick = f"{server}:{brick}"
-                brick_list.append(brick)
-
-        return brick_list
-
     def are_bricks_offline(self, volname: str,
                            bricks_list: list, node: str,
                            strict: bool = True) -> bool:

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -349,6 +349,7 @@ class BrickOps:
 
         return (brick_dict, brick_cmd)
 
+<<<<<<< HEAD
     def cleanup_brick_dirs(self):
         """
         This function requests for the cleands and clears the brick dirs which
@@ -359,3 +360,31 @@ class BrickOps:
             for b_dir in b_dir_l:
                 self.execute_abstract_op_node(f"rm -rf {b_dir}", node)
                 self.es.remove_val_from_cleands(node, b_dir)
+=======
+    def are_bricks_offline(self, volname: str,
+                           brick_dict: dict, node: str) -> bool:
+        """
+        This function checks if the bricks are
+        offline.
+
+        Args:
+            volname (str) : Volume name
+            brick_dict (dict) : the brick dictionary to compare
+            node (str) : the node on which comparison has to be done
+
+        Returns:
+            boolean value: True, if bricks are offline
+                           False if online
+        """
+
+        vol_status = self.get_volume_status(volname, node)
+
+        brick_count = 0
+        for each_node in brick_dict:
+            brick_count += len(brick_dict[each_node])
+
+        if brick_count != int(vol_status[volname]['nodeCount']):
+            return True
+
+        return False
+>>>>>>> d6ec396... Migrated test_add_brick_when_quorum_not_met

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -378,13 +378,19 @@ class BrickOps:
         """
 
         vol_status = self.get_volume_status(volname, node)
-
+        status_count = 0
         brick_count = 0
         for each_node in brick_dict:
             brick_count += len(brick_dict[each_node])
 
-        if brick_count != int(vol_status[volname]['nodeCount']):
+        for brick_data in vol_status[volname]['node']:
+            if brick_data['status'] == 1:
+                status_count += 1
+
+        if brick_count != status_count:
+            self.logger.info("Some bricks are offline")
             return True
 
+        self.logger.info("All bricks are online")
         return False
 >>>>>>> d6ec396... Migrated test_add_brick_when_quorum_not_met

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -391,6 +391,5 @@ class BrickOps:
             self.logger.info("Some bricks are offline")
             return True
 
-        self.logger.info("All bricks are online")
         return False
 >>>>>>> d6ec396... Migrated test_add_brick_when_quorum_not_met

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -349,7 +349,6 @@ class BrickOps:
 
         return (brick_dict, brick_cmd)
 
-<<<<<<< HEAD
     def cleanup_brick_dirs(self):
         """
         This function requests for the cleands and clears the brick dirs which
@@ -360,10 +359,9 @@ class BrickOps:
             for b_dir in b_dir_l:
                 self.execute_abstract_op_node(f"rm -rf {b_dir}", node)
                 self.es.remove_val_from_cleands(node, b_dir)
-=======
+
     def are_bricks_offline(self, volname: str,
-                           brick_dict: dict, node: str,
-                           strict: bool = True) -> bool:
+                           brick_dict: dict, node: str) -> bool:
         """
         This function checks if the bricks are
         offline.
@@ -372,30 +370,20 @@ class BrickOps:
             volname (str) : Volume name
             brick_dict (dict) : the brick dictionary to compare
             node (str) : the node on which comparison has to be done
-            strict (bool) : To check strictly if all bricks are offline
 
         Returns:
             boolean value: True, if bricks are offline
                            False if online
         """
-
+        # TODO: take care of the scenario where a certain
+        # number of bricks have to be checked
         vol_status = self.get_volume_status(volname, node)
-        status_count = 0
+
         brick_count = 0
         for each_node in brick_dict:
             brick_count += len(brick_dict[each_node])
 
-        for brick_data in vol_status[volname]['node']:
-            if brick_data['status'] == 1:
-                status_count += 1
-
-        if strict and status_count == 0:
-            self.logger.info("All bricks are offline")
-            return True
-
-        if not strict and brick_count != status_count:
-            self.logger.info("Some bricks are offline")
+        if brick_count != int(vol_status[volname]['nodeCount']):
             return True
 
         return False
->>>>>>> d6ec396... Migrated test_add_brick_when_quorum_not_met

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -403,3 +403,27 @@ class BrickOps:
 
         self.logger.info(f"All bricks are offline: {bricks_list}")
         return ret
+
+    def check_if_bricks_list_changed(self,
+                                     bricks_list: list,
+                                     volname: str,
+                                     node: str) -> bool:
+        """
+        Checks if the brick list changed.
+
+        Returns:
+        bool: True is list changed
+              else False
+        """
+        vol_info = self.get_volume_info(node, volname)
+
+        vol_info_brick_list = []
+        for n in vol_info[volname]['bricks']:
+            vol_info_brick_list.append(n['name'])
+
+        if len(vol_info_brick_list) == len(bricks_list):
+            for each in bricks_list:
+                if each not in vol_info_brick_list:
+                    return True
+            return False
+        return True

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -411,6 +411,11 @@ class BrickOps:
         """
         Checks if the brick list changed.
 
+        Args:
+            bricks_list: list of bricks
+            volname: Name of volume
+            node: Node on which to execute vol info
+
         Returns:
         bool: True is list changed
               else False

--- a/core/environ.py
+++ b/core/environ.py
@@ -348,6 +348,25 @@ class FrameworkEnv:
         self._validate_volname(volname)
         return self.volds[volname]['brickdata']
 
+    def get_all_bricks_list(self, volname: str) -> list:
+        """
+        This function creates a list of
+        bricks from the brick dictionary
+
+        Args:
+            volname: Name of volume
+        Returns:
+            List of bricks
+        """
+        brick_dict = self.get_brickdata(volname)
+        brick_list = []
+        for server in brick_dict:
+            for brick in brick_dict[server]:
+                brick = f"{server}:{brick}"
+                brick_list.append(brick)
+
+        return brick_list
+
     def get_brick_list(self, volname: str, node: str) -> list:
         """
         Method to obtain brick list

--- a/docs/BP/Ops/brick_ops.md
+++ b/docs/BP/Ops/brick_ops.md
@@ -108,3 +108,14 @@ mul_fac (int) : Stores the number of bricks
 ### How does it work?
 
 A loop runs from 0 to `mul_fac-1` and creates the brick command using the `server_val` and `brick_path_val`. The paths are appended in the brick_dict for the following servers and then are returned with the brick command `brick_cmd`.
+
+## are_bricks_offline()
+
+This function checks if the bricks are offline. The comparison is made between the nodeCount and the number of bricks in the brick-dict. If equal that means all bricks are online else a few or all may be offline.
+
+```m
+Args:
+volname (str) : Volume name
+brick_dict (dict) : the brick dictionary to compare
+node (str) : the node on which comparison has to be done
+```

--- a/docs/BP/Ops/brick_ops.md
+++ b/docs/BP/Ops/brick_ops.md
@@ -111,7 +111,7 @@ A loop runs from 0 to `mul_fac-1` and creates the brick command using the `serve
 
 ## are_bricks_offline()
 
-This function checks if the bricks are offline. The comparison is made between the nodeCount and the number of bricks in the brick-dict. If equal that means all bricks are online else a few or all may be offline.
+This function checks if the bricks are offline. The status is 1 if the bricks are online and 0 if offline. This count can tell if all the bricks are online or not.
 
 ```m
 Args:

--- a/docs/BP/Ops/brick_ops.md
+++ b/docs/BP/Ops/brick_ops.md
@@ -111,11 +111,41 @@ A loop runs from 0 to `mul_fac-1` and creates the brick command using the `serve
 
 ## are_bricks_offline()
 
-This function checks if the bricks are offline. The status is 1 if the bricks are online and 0 if offline. This count can tell if all the bricks are online or not.
+This function checks if the given list of bricks are offline.
 
 ```m
 Args:
-volname (str) : Volume name
-brick_dict (dict) : the brick dictionary to compare
-node (str) : the node on which comparison has to be done
+    volname (str) : Volume name
+    bricks_list (list) : list of bricks to check
+    node (str) : the node on which comparison has to be done
+    strict (bool) : To check strictly if all bricks are offline
+Returns:
+    boolean value: True, if bricks are offline
+                    False if online
+```
+
+```js
+ex 1: redant.are_bricks_offline(self.vol_name, bricks_list, self.server_list[0])
+
+ex 2: redant.are_bricks_offline(self.vol_name, bricks_list, self.server_list[0], False)
+```
+
+## check_if_bricks_list_changed()
+
+It checks if the bricks list changed. Basically, compares the bricks list with the bricks attained from volume info.
+
+```m
+ Args:
+    bricks_list: list of bricks
+    volname: Name of volume
+    node: Node on which to execute vol info
+
+Returns:
+bool: True is list changed
+        else False
+```
+
+```js
+Ex:
+redant.check_if_bricks_list_changed(bricks_list, self.vol_name, self.server_list[0])
 ```

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -1,0 +1,159 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import runs_on, GlusterBaseClass
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_libs import setup_volume
+from glustolibs.gluster.volume_ops import set_volume_options, get_volume_status
+from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
+                                             is_glusterd_running)
+from glustolibs.gluster.brick_libs import get_all_bricks, are_bricks_offline
+from glustolibs.gluster.brick_ops import add_brick
+from glustolibs.gluster.lib_utils import form_bricks_list
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+
+        # check whether peers are in connected state
+        ret = self.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+        g.log.info("Peers are in connected state")
+
+    def tearDown(self):
+
+        ret = is_glusterd_running(self.servers)
+        if ret:
+            ret = start_glusterd(self.servers)
+            if not ret:
+                raise ExecutionError("Failed to start glusterd on servers")
+
+        g.log.info("glusterd is running on all the nodes")
+
+        # checking for peer status from every node
+        count = 0
+        while count < 80:
+            ret = self.validate_peers_are_connected()
+            if ret:
+                break
+            sleep(2)
+            count += 1
+
+        if not ret:
+            raise ExecutionError("Servers are not in connected state")
+
+        g.log.info("Peers are in connected state")
+
+        # stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Cleanup the Volume %s"
+                                 % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_add_brick_when_quorum_not_met(self):
+
+        # create and start a volume
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertTrue(ret, ("Failed to create "
+                              "and start volume %s" % self.volname))
+        g.log.info("Volume is created and started successfully")
+
+        # set cluster.server-quorum-type as server
+        ret = set_volume_options(self.mnode, self.volname,
+                                 {'cluster.server-quorum-type': 'server'})
+        self.assertTrue(ret, ("Failed to set the quorum type as a server"
+                              " on volume %s", self.volname))
+        g.log.info("Able to set server quorum successfully on volume %s",
+                   self.volname)
+
+        # Setting quorum ratio to 95%
+        ret = set_volume_options(self.mnode, 'all',
+                                 {'cluster.server-quorum-ratio': '95%'})
+        self.assertTrue(ret, "Failed to set server quorum ratio on %s"
+                        % self.volname)
+        g.log.info("Able to set server quorum ratio successfully on %s",
+                   self.servers)
+
+        # bring down glusterd of half nodes
+        num_of_servers = len(self.servers)
+        num_of_nodes_to_bring_down = num_of_servers/2
+
+        for node in range(num_of_nodes_to_bring_down, num_of_servers):
+            ret = stop_glusterd(self.servers[node])
+            self.assertTrue(ret, ("Failed to stop glusterd on %s"
+                                  % self.servers[node]))
+            g.log.info("Glusterd stopped successfully on server %s",
+                       self.servers[node])
+
+        for node in range(num_of_nodes_to_bring_down, num_of_servers):
+            count = 0
+            while count < 80:
+                ret = is_glusterd_running(self.servers[node])
+                if ret:
+                    break
+                sleep(2)
+                count += 1
+            self.assertNotEqual(ret, 0, "glusterd is still running on %s"
+                                % self.servers[node])
+
+        # Verifying node count in volume status after glusterd stopped
+        # on half of the servers, Its not possible to check the brick status
+        # immediately in volume status after glusterd stop
+        count = 0
+        while count < 100:
+            vol_status = get_volume_status(self.mnode, self.volname)
+            servers_count = len(vol_status[self.volname])
+            if servers_count == (num_of_servers - num_of_nodes_to_bring_down):
+                break
+            sleep(2)
+            count += 1
+
+        # confirm that quorum is not met, brick process should be down
+        bricks_list = get_all_bricks(self.mnode, self.volname)
+        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
+        bricks_to_check = bricks_list[0:num_of_nodes_to_bring_down]
+        ret = are_bricks_offline(self.mnode, self.volname, bricks_to_check)
+        self.assertTrue(ret, "Server quorum is not met, Bricks are up")
+        g.log.info("Server quorum is met, bricks are down")
+
+        # try add brick operation, which should fail
+        num_bricks_to_add = 1
+        brick = form_bricks_list(self.mnode, self.volname, num_bricks_to_add,
+                                 self.servers, self.all_servers_info)
+        ret, _, _ = add_brick(self.mnode, self.volname, brick)
+        self.assertNotEqual(ret, 0, ("add brick is success, when quorum is"
+                                     " met"))
+        g.log.info("Add brick is failed as expected, when quorum is met")
+
+        # confirm that, newly added brick is not part of volume
+        bricks_list = get_all_bricks(self.mnode, self.volname)
+        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
+        if brick in bricks_list:
+            ret = False
+            self.assertTrue(ret, ("add brick is success, when quorum is"
+                                  " met"))
+        g.log.info("Add brick is failed as expected, when quorum is met")

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -20,8 +20,7 @@ from glustolibs.gluster.gluster_base_class import runs_on, GlusterBaseClass
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.volume_libs import setup_volume
 from glustolibs.gluster.volume_ops import (set_volume_options,
-                                           get_volume_status,
-                                           volume_reset)
+                                           get_volume_status)
 from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
                                              is_glusterd_running)
 from glustolibs.gluster.brick_libs import get_all_bricks, are_bricks_offline
@@ -55,12 +54,6 @@ class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
             raise ExecutionError("Servers are not in connected state")
 
         g.log.info("Peers are in connected state")
-
-        # reset quorum ratio to default
-        g.log.info("resetting quorum ratio")
-        ret, _, _ = volume_reset(self.mnode, 'all')
-        self.assertEqual(ret, 0, "Failed to reset quorum ratio")
-        g.log.info("Successfully resetted quorum ratio")
 
         # stopping the volume and Cleaning up the volume
         ret = self.cleanup_volume()

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -100,7 +100,7 @@ class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
 
         # bring down glusterd of half nodes
         num_of_servers = len(self.servers)
-        num_of_nodes_to_bring_down = num_of_servers/2
+        num_of_nodes_to_bring_down = num_of_servers//2
 
         for node in range(num_of_nodes_to_bring_down, num_of_servers):
             ret = stop_glusterd(self.servers[node])

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -92,8 +92,8 @@ class TestCase(DParentTest):
             sleep(2)
 
         # confirm that quorum is not met, brick process should be down
-        bricks_to_check = redant.es.get_all_bricks_list(self.vol_name)
-        bricks_to_check = bricks_to_check[0:num_of_nodes_to_bring_down]
+        all_bricks = redant.es.get_all_bricks_list(self.vol_name)
+        bricks_to_check = all_bricks[0:num_of_nodes_to_bring_down]
         ret = redant.are_bricks_offline(self.vol_name, bricks_to_check,
                                         self.server_list[0])
         if not ret:
@@ -108,6 +108,11 @@ class TestCase(DParentTest):
         except Exception as error:
             redant.logger.info(f"Add brick failed as expected: {error}")
 
+        ret = redant.check_if_bricks_list_changed(all_bricks, self.vol_name,
+                                                  self.server_list[0])
+
+        if ret:
+            raise Exception("Unexpected: Bricks were added.")
         # set cluster.server-quorum-type as none
         redant.set_volume_options(self.vol_name,
                                   {'cluster.server-quorum-type': 'none'},

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -20,6 +20,7 @@ from glustolibs.gluster.gluster_base_class import runs_on, GlusterBaseClass
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.volume_libs import setup_volume
 from glustolibs.gluster.volume_ops import (set_volume_options,
+                                           volume_reset,
                                            get_volume_status)
 from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
                                              is_glusterd_running)
@@ -62,13 +63,12 @@ class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
                                  % self.volname)
         g.log.info("Volume deleted successfully : %s", self.volname)
 
-        # Setting quorum ratio to 51%
-        ret = set_volume_options(self.mnode, 'all',
-                                 {'cluster.server-quorum-ratio': '51%'})
+        # Reset Cluster options
+        ret = volume_reset(self.mnode, 'all')
         if not ret:
-            raise ExecutionError("Failed to set server quorum ratio on %s"
+            raise ExecutionError("Failed to reset cluster options on %s"
                                  % self.volname)
-        g.log.info("Able to set server quorum ratio successfully on %s",
+        g.log.info("Cluster options reset successfully on %s",
                    self.servers)
 
         self.get_super_method(self, 'tearDown')()

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -117,7 +117,6 @@ class TestCase(DParentTest):
             ret = redant.is_glusterd_running(server)
             if ret != 1:
                 redant.start_glusterd(server)
-                sleep(1)
                 redant.wait_for_glusterd_to_start(server)
 
         redant.logger.info("Glusterd running on all the servers")

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -69,10 +69,20 @@ class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
                                  % self.volname)
         g.log.info("Volume deleted successfully : %s", self.volname)
 
+        # Setting quorum ratio to 51%
+        ret = set_volume_options(self.mnode, 'all',
+                                 {'cluster.server-quorum-ratio': '51%'})
+        if not ret:
+            raise ExecutionError("Failed to set server quorum ratio on %s"
+                                 % self.volname)
+        g.log.info("Able to set server quorum ratio successfully on %s",
+                   self.servers)
+
         GlusterBaseClass.tearDown.im_func(self)
 
     def test_add_brick_when_quorum_not_met(self):
 
+        # pylint: disable=too-many-statements
         # create and start a volume
         ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
         self.assertTrue(ret, ("Failed to create "
@@ -155,3 +165,11 @@ class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
             self.assertTrue(ret, ("Unexpected: add brick is success, "
                                   "when quorum is not met"))
         g.log.info("Add brick is failed as expected, when quorum is not met")
+
+        # set cluster.server-quorum-type as none
+        ret = set_volume_options(self.mnode, self.volname,
+                                 {'cluster.server-quorum-type': 'none'})
+        self.assertTrue(ret, ("Failed to set the quorum type as a server"
+                              " on volume %s", self.volname))
+        g.log.info("Able to set server quorum successfully on volume %s",
+                   self.volname)

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -96,7 +96,8 @@ class TestCase(DParentTest):
         ret = redant.are_bricks_offline(self.vol_name, bricks_to_check,
                                         self.server_list[0])
         if not ret:
-            raise Exception("Unexpected: Few bricks are online")
+            raise Exception("Unexpected: Server quorum is not met, "
+                            "bricks are up")
 
         vol_dict = self.conv_dict[self.volume_type]
         try:
@@ -116,7 +117,8 @@ class TestCase(DParentTest):
             ret = redant.is_glusterd_running(server)
             if ret != 1:
                 redant.start_glusterd(server)
-                sleep(15)
+                sleep(1)
+                redant.wait_for_glusterd_to_start(server)
 
         redant.logger.info("Glusterd running on all the servers")
 
@@ -129,6 +131,6 @@ class TestCase(DParentTest):
             sleep(2)
 
         if not ret:
-            raise Exception("Peers are not in connected state")
+            raise Exception("Servers are not in connected state")
 
         redant.logger.info("Peers are in connected state")

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -78,7 +78,7 @@ class TestAddBrickWhenQuorumNotMet(GlusterBaseClass):
         g.log.info("Able to set server quorum ratio successfully on %s",
                    self.servers)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_add_brick_when_quorum_not_met(self):
 

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -96,8 +96,8 @@ class TestCase(DParentTest):
         ret = redant.are_bricks_offline(self.vol_name, bricks_to_check,
                                         self.server_list[0])
         if not ret:
-            raise Exception("Unexpected: Server quorum is not met, "
-                            "bricks are up")
+            raise Exception("Unexpected: Server quorum is met, "
+                            "Few bricks are up")
 
         vol_dict = self.conv_dict[self.volume_type]
         try:

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -92,7 +92,9 @@ class TestCase(DParentTest):
             sleep(2)
 
         # confirm that quorum is not met, brick process should be down
-        bricks_to_check = redant.es.get_brickdata(self.vol_name)
+        brick_d = redant.es.get_brickdata(self.vol_name)
+        bricks_to_check = redant.get_brick_dict_list(brick_d)
+        bricks_to_check = bricks_to_check[0:num_of_nodes_to_bring_down]
         ret = redant.are_bricks_offline(self.vol_name, bricks_to_check,
                                         self.server_list[0])
         if not ret:

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -92,8 +92,7 @@ class TestCase(DParentTest):
             sleep(2)
 
         # confirm that quorum is not met, brick process should be down
-        brick_d = redant.es.get_brickdata(self.vol_name)
-        bricks_to_check = redant.get_brick_dict_list(brick_d)
+        bricks_to_check = redant.es.get_all_bricks_list(self.vol_name)
         bricks_to_check = bricks_to_check[0:num_of_nodes_to_bring_down]
         ret = redant.are_bricks_offline(self.vol_name, bricks_to_check,
                                         self.server_list[0])

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -96,8 +96,7 @@ class TestCase(DParentTest):
         ret = redant.are_bricks_offline(self.vol_name, bricks_to_check,
                                         self.server_list[0])
         if not ret:
-            raise Exception("Unexpected: Server quorum is not met, "
-                            "bricks are up")
+            raise Exception("Unexpected: Few bricks are online")
 
         vol_dict = self.conv_dict[self.volume_type]
         try:
@@ -130,6 +129,6 @@ class TestCase(DParentTest):
             sleep(2)
 
         if not ret:
-            raise Exception("Servers are not in connected state")
+            raise Exception("Peers are not in connected state")
 
         redant.logger.info("Peers are in connected state")


### PR DESCRIPTION
Migrated the [test case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py).
Added `are_bricks_offline` in brick ops.

Updates: #292

Fixes: #352

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>