### PR TITLE
Adding excep flag to bypass exception

### DIFF
--- a/common/ops/abstract_ops.py
+++ b/common/ops/abstract_ops.py
@@ -31,7 +31,7 @@ class AbstractOps:
                           cmd fails. If set to False the exception is
                           bypassed and value from remote executioner is
                           returned. Defaults to True
-            
+
         """
         self.logger.info(f"Running {cmd} on {node}")
 

--- a/common/ops/abstract_ops.py
+++ b/common/ops/abstract_ops.py
@@ -15,7 +15,8 @@ class AbstractOps:
     commands on the nodes
     """
 
-    def execute_abstract_op_node(self, cmd: str, node: str = None):
+    def execute_abstract_op_node(self, cmd: str, node: str = None,
+                                 excep: bool = True):
         """
         Calls the function in the remote executioner to execute
         commands on the nodes. Logging is also performed along
@@ -29,6 +30,9 @@ class AbstractOps:
         self.logger.info(f"Running {cmd} on {node}")
 
         ret = self.execute_command(cmd, node)
+
+        if not excep:
+            return ret
 
         if ret['error_code'] != 0:
             self.logger.error(ret['error_msg'])

--- a/common/ops/abstract_ops.py
+++ b/common/ops/abstract_ops.py
@@ -23,9 +23,15 @@ class AbstractOps:
         with handling exceptions while executng the commands.
         Args:
             cmd  (str): the command to be executed by the rexe
+        Kwargs:
             node (str): the node on which the command as to be executed.
                         If the node is None then the rexe chooses the
                         node randomly and executes the command on it.
+            excep (bool): exception flag to bypass the exception if the
+                          cmd fails. If set to False the exception is
+                          bypassed and value from remote executioner is
+                          returned. Defaults to True
+            
         """
         self.logger.info(f"Running {cmd} on {node}")
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -420,6 +420,11 @@ class VolumeOps(AbstractOps):
             options (str): options can be,
                 [detail|clients|mem|inode|fd|callpool|tasks]. If not given,
                 the function returns the output of gluster volume status
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
+
         Returns:
             dict: volume status in dict of dictionary format
             None: In case no volumes are present


### PR DESCRIPTION
In case the volume_status command is success, the volume status is
returned. In case the volume status command has failed then the
exception is bypassed and the ret value from abstract ops is
returned.

Fixes: #367
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>
