### PR TITLE
[Core][Common][Test] Sanitize and cleanup

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -348,3 +348,14 @@ class BrickOps:
             server_iter += 1
 
         return (brick_dict, brick_cmd)
+
+    def cleanup_brick_dirs(self):
+        """
+        This function requests for the cleands and clears the brick dirs which
+        have been populated in it.
+        """
+        cleands_val = list(self.es.get_cleands_data().items())
+        for (node, b_dir_l) in cleands_val:
+            for b_dir in b_dir_l:
+                self.execute_abstract_op_node(f"rm -rf {b_dir}", node)
+                self.es.remove_val_from_cleands(node, b_dir)

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -266,9 +266,8 @@ class VolumeOps(AbstractOps):
             # Check if mount dir exists in the node.
             mountdir = f"/mnt/{volname}"
             for node in client_list:
-                if not self.path_exists(node, mountdir):
-                    self.execute_abstract_op_node(f"mkdir -p {mountdir}",
-                                                  node)
+                self.execute_abstract_op_node(f"umount {mountdir}", node)
+                self.execute_abstract_op_node(f"mkdir -p {mountdir}", node)
                 self.volume_mount(server_list[0], volname, mountdir, node)
 
         # Clear out the mountpoint data.
@@ -298,12 +297,10 @@ class VolumeOps(AbstractOps):
                 # Check if mount dir exists in the node.
                 mounts = self.es.get_mnt_pts_dict_in_list(volname)
                 for mntd in mounts:
-                    if self.path_exists(mntd['client'], mntd['mountpath']):
-                        mount = mntd['mountpath']
-                        self.volume_unmount(volname, mount, mntd['client'])
-                        self.execute_abstract_op_node(f"rm -rf {mount}",
-                                                      mntd['client'])
-
+                    mount = mntd['mountpath']
+                    self.volume_unmount(volname, mount, mntd['client'])
+                    self.execute_abstract_op_node(f"rm -rf {mount}",
+                                                  mntd['client'])
             self.volume_stop(volname, server_list[0], True)
             self.volume_delete(volname, server_list[0])
 

--- a/core/environ.py
+++ b/core/environ.py
@@ -474,7 +474,19 @@ class FrameworkEnv:
         for node in brickdata:
             if node not in list(self.cleands):
                 self.cleands[node] = []
-            self.cleands[node].append(brickdata[node])
+            self.cleands[node] += brickdata[node]
+
+    def remove_val_from_cleands(self, node: str, brick_dir: str):
+        """
+        remove a specific brick_dir from the node list.
+        Args:
+            node (str)
+            brick_dir (str)
+        """
+        print(self.cleands)
+        #if len(self.cleands[node]) == 1:
+        #    del self.cleands[node]
+        #self.cleands[node].remove(brick_dir)
 
     def get_cleands_data(self, node: list = None) -> dict:
         """
@@ -486,7 +498,7 @@ class FrameworkEnv:
             A dictionary of bricks to be cleaned for a node.
         """
         if node is None:
-            return self.cleands
+            return copy.deepcopy(self.cleands)
         ret_val = {}
         for n in node:
             if n not in self.cleands.keys():

--- a/core/environ.py
+++ b/core/environ.py
@@ -161,7 +161,7 @@ class FrameworkEnv:
         Arg:
             volname (str)
         """
-        if volname in self.volds.keys():
+        if volname in list(self.volds.keys()):
             return True
         return False
 
@@ -183,7 +183,7 @@ class FrameworkEnv:
             volds dictionary specific to given volume.
         """
         self._validate_volname(volname)
-        return self.volds[volname]
+        return list(self.volds[volname])
 
     def set_vol_type(self, volname: str, voltype_dict: dict):
         """
@@ -254,7 +254,7 @@ class FrameworkEnv:
             dictionary of nodes and their list of mountpaths.
         """
         self._validate_volname(volname)
-        return self.volds[volname]['mountpath']
+        return list(self.volds[volname]['mountpath'])
 
     def get_mnt_pts_dict_in_list(self, volname: str) -> list:
         """
@@ -418,7 +418,7 @@ class FrameworkEnv:
             Dictionary
         """
         self._validate_volname(volname)
-        return self.volds[volname]['options']
+        return copy.deepcopy(self.volds[volname]['options'])
 
     def is_volume_options_populated(self, volname: str) -> bool:
         """

--- a/core/environ.py
+++ b/core/environ.py
@@ -483,10 +483,10 @@ class FrameworkEnv:
             node (str)
             brick_dir (str)
         """
-        print(self.cleands)
-        #if len(self.cleands[node]) == 1:
-        #    del self.cleands[node]
-        #self.cleands[node].remove(brick_dir)
+        if len(self.cleands[node]) == 1:
+            del self.cleands[node]
+        else:
+            self.cleands[node].remove(brick_dir)
 
     def get_cleands_data(self, node: list = None) -> dict:
         """

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -93,19 +93,6 @@ class DParentTest(metaclass=abc.ABCMeta):
         try:
             volnames = self.redant.es.get_volnames()
             for volname in volnames:
-                """mountpoints = self.redant.es.get_mnt_pts_dict_in_list(volname)
-                for mountpoint in mountpoints:
-                    mountpath = mountpoint["mountpath"]
-                    client = mountpoint["client"]
-                    self.redant.volume_unmount(volname, mountpath, client)
-                    self.redant.execute_abstract_op_node(f"rm -rf "
-                                                         f"{mountpath}",
-                                                         client)
-                if self.redant.es.get_volume_start_status(volname):
-                    self.redant.volume_stop(
-                        volname, self.server_list[0], True)
-                if self.redant.es.does_volume_exists(volname):
-                    self.redant.volume_delete(volname, self.server_list[0])"""
                 self.redant.cleanup_volume(volname, self.server_list)
         except Exception:
             pass

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -93,7 +93,7 @@ class DParentTest(metaclass=abc.ABCMeta):
         try:
             volnames = self.redant.es.get_volnames()
             for volname in volnames:
-"""                mountpoints = self.redant.es.get_mnt_pts_dict_in_list(volname)
+                """mountpoints = self.redant.es.get_mnt_pts_dict_in_list(volname)
                 for mountpoint in mountpoints:
                     mountpath = mountpoint["mountpath"]
                     client = mountpoint["client"]

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -93,7 +93,7 @@ class DParentTest(metaclass=abc.ABCMeta):
         try:
             volnames = self.redant.es.get_volnames()
             for volname in volnames:
-                mountpoints = self.redant.es.get_mnt_pts_dict_in_list(volname)
+"""                mountpoints = self.redant.es.get_mnt_pts_dict_in_list(volname)
                 for mountpoint in mountpoints:
                     mountpath = mountpoint["mountpath"]
                     client = mountpoint["client"]
@@ -105,7 +105,8 @@ class DParentTest(metaclass=abc.ABCMeta):
                     self.redant.volume_stop(
                         volname, self.server_list[0], True)
                 if self.redant.es.does_volume_exists(volname):
-                    self.redant.volume_delete(volname, self.server_list[0])
+                    self.redant.volume_delete(volname, self.server_list[0])"""
+                self.redant.cleanup_volume(volname, self.server_list)
         except Exception:
             pass
         self.redant.deconstruct_connection()

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -109,4 +109,5 @@ class DParentTest(metaclass=abc.ABCMeta):
                 self.redant.cleanup_volume(volname, self.server_list)
         except Exception:
             pass
+        self.redant.cleanup_brick_dirs()
         self.redant.deconstruct_connection()

--- a/tests/functional/glusterd/test_enable_storage_reserve_volume.py
+++ b/tests/functional/glusterd/test_enable_storage_reserve_volume.py
@@ -39,12 +39,11 @@ class TestCase(NdParentTest):
             self.server_list[0])
 
         # Get the mount point
-        mount_point = redant.es.get_mnt_pts_dict(self.vol_name)
-        mount_point = mount_point[self.client_list[0]][0]
+        mount_point = redant.es.get_mnt_pts_dict_in_list(self.vol_name)[0]
 
         # check df -h output
-        cmd = f"df -h | grep -i {mount_point}"
-        ret = redant.execute_command(cmd, self.client_list[0])
+        cmd = f"df -h | grep -i {mount_point['mountpath']}"
+        ret = redant.execute_command(cmd, mount_point['client'])
         out = ret['msg'][0].split(" ")[-2][:-1]
 
         if int(out) < 50:

--- a/tests/lazy_parent_test.py
+++ b/tests/lazy_parent_test.py
@@ -60,7 +60,7 @@ class LazyParentTest(metaclass=abc.ABCMeta):
         """
         try:
             self.vol_name = (f"redant-{self.volume_type}")
-            self.mountpoint = (f"/mnt/{self.volume_type}")
+            self.mountpoint = (f"/mnt/redant-{self.volume_type}")
             self.run_test(self.redant)
         except Exception as error:
             tb = traceback.format_exc()

--- a/tests/nd_parent_test.py
+++ b/tests/nd_parent_test.py
@@ -77,12 +77,13 @@ class NdParentTest(metaclass=abc.ABCMeta):
         # pre_test env state.
         if self.volume_type != "Generic":
             try:
-            # Condition 1. Volume started state.
+                # Condition 1. Volume started state.
                 vol_param = self.vol_type_inf[self.conv_dict[self.volume_type]]
                 self.redant.sanitize_volume(self.vol_name, self.server_list,
                                             self.client_list, self.brick_roots,
                                             vol_param)
-            # Condition 2. Volume options if set to be reset.
+
+                # Condition 2. Volume options if set to be reset.
                 if self.redant.es.is_volume_options_populated(self.vol_name):
                     vol_options = self.redant.es.get_vol_option(self.vol_name)
                     for opt in vol_options:

--- a/tests/nd_parent_test.py
+++ b/tests/nd_parent_test.py
@@ -75,13 +75,13 @@ class NdParentTest(metaclass=abc.ABCMeta):
         """
         # Check if the post_test env state is same as that of the
         # pre_test env state.
-        # Condition 1. Volume started state.
         if self.volume_type != "Generic":
             try:
-                if not self.redant.es.get_volume_start_status(self.vol_name):
-                    self.redant.volume_start(self.vol_name,
-                                             self.server_list[0])
-
+            # Condition 1. Volume started state.
+                vol_param = self.vol_type_inf[self.conv_dict[self.volume_type]]
+                self.redant.sanitize_volume(self.vol_name, self.server_list,
+                                            self.client_list, self.brick_roots,
+                                            vol_param)
             # Condition 2. Volume options if set to be reset.
                 if self.redant.es.is_volume_options_populated(self.vol_name):
                     vol_options = self.redant.es.get_vol_option(self.vol_name)
@@ -89,6 +89,7 @@ class NdParentTest(metaclass=abc.ABCMeta):
                         self.redant.reset_volume_option(self.vol_name, opt,
                                                         self.server_list[0])
             except Exception as e:
+                self.TEST_RES = False
                 tb = traceback.format_exc()
                 self.redant.logger.error(e)
                 self.redant.logger.error(tb)

--- a/tests/nd_parent_test.py
+++ b/tests/nd_parent_test.py
@@ -93,4 +93,5 @@ class NdParentTest(metaclass=abc.ABCMeta):
                 tb = traceback.format_exc()
                 self.redant.logger.error(e)
                 self.redant.logger.error(tb)
+        self.redant.cleanup_brick_dirs()
         self.redant.deconstruct_connection()

--- a/tests/vol_destroy_test.py
+++ b/tests/vol_destroy_test.py
@@ -30,3 +30,4 @@ class VolDestroy(LazyParentTest):
         of said type and its mountpoint.
         """
         redant.cleanup_volume(self.vol_name, self.server_list)
+        redant.cleanup_brick_dirs()

--- a/tests/vol_destroy_test.py
+++ b/tests/vol_destroy_test.py
@@ -29,9 +29,4 @@ class VolDestroy(LazyParentTest):
         This child is responsible for the destruction of a volume
         of said type and its mountpoint.
         """
-        redant.volume_unmount(self.vol_name, self.mountpoint,
-                              self.client_list[0])
-        redant.execute_abstract_op_node(f"rm -rf {self.mountpoint}",
-                                        self.client_list[0])
-        redant.volume_stop(self.vol_name, self.server_list[0], True)
-        redant.volume_delete(self.vol_name, self.server_list[0])
+        redant.cleanup_volume(self.vol_name, self.server_list)


### PR DESCRIPTION
Sanitize and cleanup functionalities added.
1. The volume sanitize is used for prepping a volume for the next TC or even to be used within a test case.
2. The volume cleanup is to be used for complete cleanup of volume and its mount.

Also added is the brick dir deletion which is handled at
1. nd_parent_test
2. d_parent_test
3. vol_destroy_test

Fixes: #408
    
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>