### PR TITLE
Migration of test_host_uuid_in_volume_info_xml.py

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -324,10 +324,12 @@ class VolumeOps(AbstractOps):
                                          'name': 'server-vm1:/brick1',
                                          'isArbiter': '0',
                                          '#text': 'server-vm1:/brick1'
+                                         'hostUuid': '56d8....'
                                         },
                                         {'name': 'server-vm1:/brick3',
                                          'isArbiter': '0',
                                          '#text': 'server-vm1:/brick3'
+                                         'hostUuid': '56d8....'
                                          }],
                             'optCount': '4',
                             'options': {
@@ -346,6 +348,7 @@ class VolumeOps(AbstractOps):
                                          'name': 'server-vm1:/brick2',
                                          'isArbiter': '0',
                                          '#text': 'server-vm1:/brick2'
+                                         'hostUuid': '56d8....'
                                         }],
                             'optCount': '4',
                             'options': {

--- a/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py
+++ b/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py
@@ -1,0 +1,105 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_libs import setup_volume
+from glustolibs.gluster.volume_ops import get_volume_info
+from glustolibs.gluster.peer_ops import (peer_probe_servers, peer_detach,
+                                         peer_detach_servers,
+                                         nodes_from_pool_list)
+
+
+@runs_on([['distributed-replicated'], ['glusterfs']])
+class TestUUID(GlusterBaseClass):
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+
+        # check whether peers are in connected state
+        ret = self.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+        # detach all the nodes
+        ret = peer_detach_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Peer detach failed to all the servers from "
+                                 "the node %s." % self.mnode)
+        g.log.info("Peer detach SUCCESSFUL.")
+
+    def tearDown(self):
+
+        # stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Cleanup the Volume %s"
+                                 % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        pool = nodes_from_pool_list(self.mnode)
+        for node in pool:
+            peer_detach(self.mnode, node)
+
+        ret = peer_probe_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Failed to probe detached "
+                                 "servers %s" % self.servers)
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_uuid_in_volume_info_xml(self):
+
+        # create a two node cluster
+        ret = peer_probe_servers(self.servers[0], self.servers[1])
+        self.assertTrue(ret, "Peer probe failed to %s from %s"
+                        % (self.mnode, self.servers[1]))
+
+        # create a 2x2 volume
+        servers_info_from_two_node_cluster = {}
+        for server in self.servers[0:2]:
+            servers_info_from_two_node_cluster[
+                server] = self.all_servers_info[server]
+
+        self.volume['servers'] = self.servers[0:2]
+        self.volume['voltype']['replica_count'] = 2
+        self.volume['voltype']['dist_count'] = 2
+        ret = setup_volume(self.mnode, servers_info_from_two_node_cluster,
+                           self.volume)
+        self.assertTrue(ret, ("Failed to create"
+                              "and start volume %s" % self.volname))
+
+        # probe a new node from cluster
+        ret = peer_probe_servers(self.mnode, self.servers[2])
+        self.assertTrue(ret, "Peer probe failed to %s from %s"
+                        % (self.mnode, self.servers[2]))
+
+        # check gluster vol info --xml from newly probed node
+        xml_output = get_volume_info(self.servers[2], self.volname)
+        self.assertIsNotNone(xml_output, ("Failed to get volume info --xml for"
+                                          "volume %s from newly probed node %s"
+                                          % (self.volname, self.servers[2])))
+
+        # volume info --xml should have non zero UUID for host and brick
+        uuid_with_zeros = '00000000-0000-0000-0000-000000000000'
+        len_of_uuid = len(uuid_with_zeros)
+        number_of_bricks = int(xml_output[self.volname]['brickCount'])
+        for i in range(number_of_bricks):
+            uuid = xml_output[self.volname]['bricks']['brick'][i]['hostUuid']
+            self.assertEqual(len(uuid), len_of_uuid, "Invalid uuid length")
+            self.assertNotEqual(uuid, uuid_with_zeros, ("Invalid uuid %s"
+                                                        % uuid))

--- a/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py
+++ b/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py
@@ -29,7 +29,7 @@ class TestUUID(GlusterBaseClass):
 
     def setUp(self):
 
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # check whether peers are in connected state
         ret = self.validate_peers_are_connected()
@@ -60,7 +60,7 @@ class TestUUID(GlusterBaseClass):
         if not ret:
             raise ExecutionError("Failed to probe detached "
                                  "servers %s" % self.servers)
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_uuid_in_volume_info_xml(self):
 

--- a/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py
+++ b/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py
@@ -1,105 +1,45 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.volume_libs import setup_volume
-from glustolibs.gluster.volume_ops import get_volume_info
-from glustolibs.gluster.peer_ops import (peer_probe_servers, peer_detach,
-                                         peer_detach_servers,
-                                         nodes_from_pool_list)
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+
+from tests.nd_parent_test import NdParentTest
 
 
-@runs_on([['distributed-replicated'], ['glusterfs']])
-class TestUUID(GlusterBaseClass):
+# nonDisruptive;dist-rep
+class TestCase(NdParentTest):
 
-    def setUp(self):
+    def run_test(self, redant):
+        """
+        Steps:
+        1) Get Volume info
+        2) Extract number of bricks
+        3) Check for uuid validity for all the bricks.
+        """
 
-        self.get_super_method(self, 'setUp')()
-
-        # check whether peers are in connected state
-        ret = self.validate_peers_are_connected()
-        if not ret:
-            raise ExecutionError("Peers are not in connected state")
-
-        # detach all the nodes
-        ret = peer_detach_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Peer detach failed to all the servers from "
-                                 "the node %s." % self.mnode)
-        g.log.info("Peer detach SUCCESSFUL.")
-
-    def tearDown(self):
-
-        # stopping the volume and Cleaning up the volume
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Cleanup the Volume %s"
-                                 % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-        pool = nodes_from_pool_list(self.mnode)
-        for node in pool:
-            peer_detach(self.mnode, node)
-
-        ret = peer_probe_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Failed to probe detached "
-                                 "servers %s" % self.servers)
-        self.get_super_method(self, 'tearDown')()
-
-    def test_uuid_in_volume_info_xml(self):
-
-        # create a two node cluster
-        ret = peer_probe_servers(self.servers[0], self.servers[1])
-        self.assertTrue(ret, "Peer probe failed to %s from %s"
-                        % (self.mnode, self.servers[1]))
-
-        # create a 2x2 volume
-        servers_info_from_two_node_cluster = {}
-        for server in self.servers[0:2]:
-            servers_info_from_two_node_cluster[
-                server] = self.all_servers_info[server]
-
-        self.volume['servers'] = self.servers[0:2]
-        self.volume['voltype']['replica_count'] = 2
-        self.volume['voltype']['dist_count'] = 2
-        ret = setup_volume(self.mnode, servers_info_from_two_node_cluster,
-                           self.volume)
-        self.assertTrue(ret, ("Failed to create"
-                              "and start volume %s" % self.volname))
-
-        # probe a new node from cluster
-        ret = peer_probe_servers(self.mnode, self.servers[2])
-        self.assertTrue(ret, "Peer probe failed to %s from %s"
-                        % (self.mnode, self.servers[2]))
-
-        # check gluster vol info --xml from newly probed node
-        xml_output = get_volume_info(self.servers[2], self.volname)
-        self.assertIsNotNone(xml_output, ("Failed to get volume info --xml for"
-                                          "volume %s from newly probed node %s"
-                                          % (self.volname, self.servers[2])))
+        # check gluster vol info --xml
+        xml_output = redant.get_volume_info(self.server_list[0], self.vol_name)
 
         # volume info --xml should have non zero UUID for host and brick
         uuid_with_zeros = '00000000-0000-0000-0000-000000000000'
         len_of_uuid = len(uuid_with_zeros)
-        number_of_bricks = int(xml_output[self.volname]['brickCount'])
+        number_of_bricks = int(xml_output[self.vol_name]['brickCount'])
         for i in range(number_of_bricks):
-            uuid = xml_output[self.volname]['bricks']['brick'][i]['hostUuid']
-            self.assertEqual(len(uuid), len_of_uuid, "Invalid uuid length")
-            self.assertNotEqual(uuid, uuid_with_zeros, ("Invalid uuid %s"
-                                                        % uuid))
+            uuid = xml_output[self.vol_name]['bricks'][i]['hostUuid']
+            if len(uuid) != len_of_uuid:
+                raise Exception("Invalid uuid length")
+            if uuid == uuid_with_zeros:
+                raise Exception(f"Invalid uuid {uuid}")


### PR DESCRIPTION
Migration of [test_case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_host_uuid_in_volume_info_xml.py) from glusto to redant

Updates: #292
Fixes: #446 
Signed-off-by: Nishith Vihar Sakinala nsakinal@redhat.com