### PR TITLE
[Core][Test] d_parent_handling and mount ds fix

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -66,7 +66,7 @@ class VolumeOps(AbstractOps):
         cmd = f"umount {path}"
 
         ret = self.execute_abstract_op_node(cmd, node)
-        self.es.remove_mountpath(volname, node, path)
+        #self.es.remove_mountpath(volname, node, path)
         return ret
 
     def volume_create(self, volname: str, node: str, conf_hash: dict,

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -66,7 +66,7 @@ class VolumeOps(AbstractOps):
         cmd = f"umount {path}"
 
         ret = self.execute_abstract_op_node(cmd, node)
-        #self.es.remove_mountpath(volname, node, path)
+        self.es.remove_mountpath(volname, node, path)
         return ret
 
     def volume_create(self, volname: str, node: str, conf_hash: dict,

--- a/core/environ.py
+++ b/core/environ.py
@@ -234,9 +234,10 @@ class FrameworkEnv:
                          mountpath :p )
         """
         self._validate_volname(volname)
-        if node not in self.volds[volname]['mountpath'].keys():
+        if node not in list(self.volds[volname]['mountpath'].keys()):
             self.volds[volname]['mountpath'][node] = []
-        self.volds[volname]['mountpath'][node].append(path)
+        if path not in list(self.volds[volname]['mountpath'][node]):
+            self.volds[volname]['mountpath'][node].append(path)
 
     def remove_mountpath(self, volname: str, node: str, path: str):
         """

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -95,7 +95,10 @@ class DParentTest(metaclass=abc.ABCMeta):
             volnames = self.redant.es.get_volnames()
             for volname in volnames:
                 self.redant.cleanup_volume(volname, self.server_list)
-        except Exception:
-            pass
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+            self.TEST_RES = False
         self.redant.cleanup_brick_dirs()
         self.redant.deconstruct_connection()


### PR DESCRIPTION
This fix is aimed towards handling the mount point
data structure handling which was adding same paths multiple
times and also added the traceback in d_parent_test
teardown.

Fixes: #453

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
