### PR TITLE
Changes in test_add_brick_when_quorum_not_met

### DIFF
--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -37,8 +37,6 @@ class TestCase(DParentTest):
                 self.redant.start_glusterd(server)
                 self.redant.wait_for_glusterd_to_start(server)
 
-        self.redant.logger.info("Glusterd running on all the servers")
-
         # checking for peer status from every node
         for _ in range(80):
             ret = self.redant.validate_peers_are_connected(self.server_list,
@@ -49,8 +47,6 @@ class TestCase(DParentTest):
 
         if not ret:
             raise Exception("Servers are not in connected state")
-
-        self.redant.logger.info("Peers are in connected state")
 
         super().terminate()
 


### PR DESCRIPTION
* Replaced the logic for wait_for_glusterd_to_stop with the pre-existing
  function.

* Added the last part of the test case in the terminate.

Fixes: #459

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>

