### PR TITLE
Migrated TC test_volume_set_with_quorum_enabled

### DIFF
--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -232,6 +232,8 @@ class PeerOps(AbstractOps):
         """
         if not isinstance(servers, list):
             servers = [servers]
+        else:
+            servers = servers[:]
 
         for index, server in enumerate(servers):
             servers[index] = socket.gethostbyname(server)
@@ -309,7 +311,6 @@ class PeerOps(AbstractOps):
         for server in server_list:
             self.logger.info(f"Is peer connected {server}->{server_list}")
             ret = self.is_peer_connected(server, server_list)
-            self.logger.info(f"Peer {server} is connected")
 
             if not ret:
                 self.logger.error(f"Servers are not in connected state"

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -622,14 +622,14 @@ class VolumeOps(AbstractOps):
         return ret_dict
 
     def set_volume_options(self, volname: str, options: dict,
-                           node: str = None):
+                           node: str = None, excep: bool = True):
         """
         Sets the option values for the given volume.
         Args:
             node (str): Node on which cmd has to be executed.
             volname (str): volume name
-            options (dict): volume options in key
-                value format
+            options (dict): volume options in key:value format
+            excep (bool): To bypass or not to bypass the exception handling.
         Example:
             options = {"user.cifs":"enable","user.smb":"enable"}
             set_volume_options("test-vol1", options, server)
@@ -643,13 +643,13 @@ class VolumeOps(AbstractOps):
             for group_option in group_options:
                 cmd = (f"gluster volume set {volname} group {group_option} "
                        "--mode=script --xml")
-                self.execute_abstract_op_node(cmd, node)
+                self.execute_abstract_op_node(cmd, node, excep)
 
         for option in volume_options:
             cmd = (f"gluster volume set {volname} {option} "
                    f"{volume_options[option]} --mode=script --xml")
 
-            self.execute_abstract_op_node(cmd, node)
+            self.execute_abstract_op_node(cmd, node, excep)
             if volname != 'all':
                 self.es.set_vol_option(volname,
                                        {option: volume_options[option]})

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -29,7 +29,7 @@ class TestVolumeSetOpWithQuorum(GlusterBaseClass):
     def setUp(self):
 
         # calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # Creating Volume
         g.log.info("Started creating volume")
@@ -77,7 +77,7 @@ class TestVolumeSetOpWithQuorum(GlusterBaseClass):
         g.log.info("Volume deleted successfully : %s", self.volname)
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_volume_set_wit_quorum_enabled(self):
         # pylint: disable=too-many-statements

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -1,0 +1,129 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+import random
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
+
+
+@runs_on([['distributed', 'replicated', 'dispersed',
+           'distributed-replicated', 'distributed-dispersed'], ['glusterfs']])
+class TestVolumeSetOpWithQuorum(GlusterBaseClass):
+
+    def setUp(self):
+
+        # calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+
+        # Creating Volume
+        g.log.info("Started creating volume")
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Volume creation failed: %s" % self.volname)
+        g.log.info("Volme created successfully : %s", self.volname)
+
+    def tearDown(self):
+
+        # stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_volume_set_wit_quorum_enabled(self):
+        # pylint: disable=too-many-statements
+        """
+        Create a volume
+        Set the quorum type to server and ratio to 90
+        Stop glusterd randomly on one of the node
+        Set the volume option on the volume
+        Start glusterd on the node where it is stopped
+        Set the volume option on the volume
+        """
+
+        # Enabling server quorum
+        self.quorum_options = {'cluster.server-quorum-type': 'server'}
+        ret = set_volume_options(self.mnode, self.volname, self.quorum_options)
+        self.assertTrue(ret, "gluster volume set %s cluster.server-quorum-type"
+                             " server Failed" % self.volname)
+        g.log.info("gluster volume set %s cluster.server-quorum-type server "
+                   "enabled successfully", self.volname)
+
+        # Setting Quorum ratio to 90%
+        self.quorum_perecent = {'cluster.server-quorum-ratio': '90%'}
+        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
+        self.assertTrue(ret, "gluster volume set all cluster.server-quorum-rat"
+                             "io percentage Failed :%s" % self.servers)
+        g.log.info("gluster volume set all cluster.server-quorum-ratio 90 "
+                   "percentage enabled successfully on :%s", self.servers)
+
+        # Stop glusterd on one of the node randomly
+        self.node_on_glusterd_to_stop = random.choice(self.servers)
+        ret = stop_glusterd(self.node_on_glusterd_to_stop)
+        self.assertTrue(ret, "glusterd stop on the node failed")
+        g.log.info("glusterd stop on the node: % "
+                   "succeeded", self.node_on_glusterd_to_stop)
+
+        # checking whether peers are connected or not
+        count = 0
+        while count < 5:
+            sleep(2)
+            ret = self.validate_peers_are_connected()
+            if not ret:
+                break
+            count += 1
+        self.assertFalse(ret, "Peers are in connected state even after "
+                              "stopping glusterd on one node")
+
+        # Setting volume option when quorum is not met
+        self.new_servers = self.servers[:]
+        self.new_servers.remove(self.node_on_glusterd_to_stop)
+        self.nfs_options = {"nfs.disable": "off"}
+        ret = set_volume_options(
+            random.choice(self.new_servers), self.volname, self.nfs_options)
+        self.assertFalse(ret, "gluster volume set %s nfs.disable off "
+                         "succeeded" % self.volname)
+        g.log.info("gluster volume set %s nfs.disable off"
+                   "successfully", self.volname)
+
+        # Start glusterd on the node where it is stopped
+        ret = start_glusterd(self.node_on_glusterd_to_stop)
+        self.assertTrue(ret, "glusterd start on the node failed")
+        g.log.info("glusterd start succeeded")
+
+        # checking whether peers are connected or not
+        count = 0
+        while count < 5:
+            sleep(5)
+            ret = self.validate_peers_are_connected()
+            if ret:
+                break
+            count += 1
+        self.assertTrue(ret, "Peer are not in connected state ")
+
+        # Setting the volume option when quorum is met
+        self.nfs_options['nfs.disable'] = 'off'
+        ret = set_volume_options(self.mnode, self.volname, self.nfs_options)
+        self.assertTrue(ret, "gluster volume set %s nfs.disable "
+                             "off failed" % self.volname)
+        g.log.info("gluster volume set %s nfs.disable "
+                   "off successfully", self.volname)

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -66,7 +66,7 @@ class TestCase(DParentTest):
 
         # Stop glusterd on one of the node randomly
         self.node_on_glusterd_to_stop = choice(self.server_list[1:])
-        ret = redant.stop_glusterd(self.node_on_glusterd_to_stop)
+        redant.stop_glusterd(self.node_on_glusterd_to_stop)
 
         # checking whether peers are connected or not
         count = 0
@@ -86,19 +86,19 @@ class TestCase(DParentTest):
         self.new_servers.remove(self.node_on_glusterd_to_stop)
         self.nfs_options = {"nfs.disable": "off"}
         try:
-            ret = redant.set_volume_options(self.vol_name,
-                                            self.nfs_options,
-                                            choice(self.new_servers), False)
+            redant.set_volume_options(self.vol_name,
+                                      self.nfs_options,
+                                      choice(self.new_servers), False)
         except Exception as error:
             redant.logger.info(f"Volume set failed as expected : {error}")
 
         # Start glusterd on the node where it is stopped
-        ret = redant.start_glusterd(self.node_on_glusterd_to_stop)
+        redant.start_glusterd(self.node_on_glusterd_to_stop)
 
         # checking whether peers are connected or not
         count = 0
         while count < 5:
-            sleep(5)
+            sleep(2)
             ret = redant.validate_peers_are_connected(self.server_list,
                                                       self.server_list[0])
             if ret:
@@ -106,6 +106,6 @@ class TestCase(DParentTest):
             count += 1
 
         # Setting the volume option when quorum is met
-        ret = redant.set_volume_options(self.vol_name,
-                                        self.nfs_options,
-                                        self.server_list[0])
+        redant.set_volume_options(self.vol_name,
+                                  self.nfs_options,
+                                  self.server_list[0])

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -1,72 +1,46 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+    TC to check volume set when quorum is enabled
+"""
+
 from random import choice
 from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
-from glustolibs.gluster.volume_ops import set_volume_options
-from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed', 'replicated', 'dispersed',
-           'distributed-replicated', 'distributed-dispersed'], ['glusterfs']])
-class TestVolumeSetOpWithQuorum(GlusterBaseClass):
+# disruptive;dist,rep,disp,dist-rep,dist-disp
 
-    def setUp(self):
+class TestCase(DParentTest):
 
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
+    def terminate(self):
+        """
+        In case the test fails midway and one of the nodes has
+        glusterd stopped then the glusterd is started on that node
+        and then the terminate function in the DParentTest is called
+        """
+        if self.glusterd_stopped:
+            self.redant.start_glusterd(self.node_on_glusterd_to_stop)
+            node = self.node_on_glusterd_to_stop
+            self.redant.wait_for_glusterd_to_start(node)
+        super().terminate()
 
-        # Creating Volume
-        g.log.info("Started creating volume")
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Volume creation failed: %s" % self.volname)
-        g.log.info("Volme created successfully : %s", self.volname)
-
-    def tearDown(self):
-
-        # Check and start if glusterd isn't running.
-        if not self.validate_peers_are_connected():
-
-            # Starting glusterd on node where stopped.
-            ret = start_glusterd(self.node_on_glusterd_to_stop)
-            if ret:
-                raise ExecutionError("Failed to start glusterd.")
-            g.log.info("Successfully started glusterd.")
-
-            # Checking if peer is connected.
-            ret = wait_for_peers_to_connect(self.mnode, self.servers)
-            self.assertTrue(ret, "glusterd is not connected %s with peer %s"
-                            % (self.mnode, self.servers))
-            g.log.info("Peers is in connected state.")
-
-        # stopping the volume and Cleaning up the volume
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_volume_set_wit_quorum_enabled(self):
-        # pylint: disable=too-many-statements
+    def run_test(self, redant):
         """
         Create a volume
         Set the quorum type to server and ratio to 90
@@ -76,70 +50,60 @@ class TestVolumeSetOpWithQuorum(GlusterBaseClass):
         Set the volume option on the volume
         """
 
-        # Enabling server quorum
-        self.quorum_options = {'cluster.server-quorum-type': 'server'}
-        ret = set_volume_options(self.mnode, self.volname, self.quorum_options)
-        self.assertTrue(ret, "gluster volume set %s cluster.server-quorum-type"
-                             " server Failed" % self.volname)
-        g.log.info("gluster volume set %s cluster.server-quorum-type server "
-                   "enabled successfully", self.volname)
+        # Setting default value for variable to be used in terminate
+        self.glusterd_stopped = False
 
-        # Setting Quorum ratio to 90%
-        self.quorum_perecent = {'cluster.server-quorum-ratio': '90%'}
-        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
-        self.assertTrue(ret, "gluster volume set all cluster.server-quorum-rat"
-                             "io percentage Failed :%s" % self.servers)
-        g.log.info("gluster volume set all cluster.server-quorum-ratio 90 "
-                   "percentage enabled successfully on :%s", self.servers)
+        # set cluster.server-quorum-type as server
+        redant.set_volume_options(self.vol_name,
+                                  {'cluster.server-quorum-type': 'server'},
+                                  self.server_list[0])
+
+        # Setting quorum ratio to 90%
+        redant.set_volume_options('all',
+                                  {'cluster.server-quorum-ratio': '90%'},
+                                  self.server_list[0])
 
         # Stop glusterd on one of the node randomly
-        self.node_on_glusterd_to_stop = choice(self.servers[1:])
-        ret = stop_glusterd(self.node_on_glusterd_to_stop)
-        self.assertTrue(ret, "glusterd stop on the node failed")
-        g.log.info("glusterd stop on the node: % "
-                   "succeeded", self.node_on_glusterd_to_stop)
+        self.node_on_glusterd_to_stop = choice(self.server_list[1:])
+        ret = redant.stop_glusterd(self.node_on_glusterd_to_stop)
+        self.glusterd_stopped = True
 
         # checking whether peers are connected or not
         count = 0
         while count < 5:
             sleep(2)
-            ret = self.validate_peers_are_connected()
+            ret = redant.validate_peers_are_connected(self.server_list,
+                                                      self.server_list[0])
             if not ret:
                 break
             count += 1
-        self.assertFalse(ret, "Peers are in connected state even after "
-                              "stopping glusterd on one node")
+
+        if ret:
+            raise Exception("Peers are still in connected state")
 
         # Setting volume option when quorum is not met
-        self.new_servers = self.servers[1:]
+        self.new_servers = self.server_list[1:]
         self.new_servers.remove(self.node_on_glusterd_to_stop)
         self.nfs_options = {"nfs.disable": "off"}
-        ret = set_volume_options(
-            choice(self.new_servers), self.volname, self.nfs_options)
-        self.assertFalse(ret, "gluster volume set %s nfs.disable off "
-                         "succeeded" % self.volname)
-        g.log.info("gluster volume set %s nfs.disable off"
-                   "successfully", self.volname)
+        ret = redant.set_volume_options(self.vol_name,
+                                        self.nfs_options,
+                                        choice(self.new_servers))
 
         # Start glusterd on the node where it is stopped
-        ret = start_glusterd(self.node_on_glusterd_to_stop)
-        self.assertTrue(ret, "glusterd start on the node failed")
-        g.log.info("glusterd start succeeded")
+        ret = redant.start_glusterd(self.node_on_glusterd_to_stop)
+        self.glusterd_stopped = False
 
         # checking whether peers are connected or not
         count = 0
         while count < 5:
             sleep(5)
-            ret = self.validate_peers_are_connected()
+            ret = self.validate_peers_are_connected(self.server_list,
+                                                    self.server_list[0])
             if ret:
                 break
             count += 1
-        self.assertTrue(ret, "Peer are not in connected state ")
 
         # Setting the volume option when quorum is met
-        self.nfs_options['nfs.disable'] = 'off'
-        ret = set_volume_options(self.mnode, self.volname, self.nfs_options)
-        self.assertTrue(ret, "gluster volume set %s nfs.disable "
-                             "off failed" % self.volname)
-        g.log.info("gluster volume set %s nfs.disable "
-                   "off successfully", self.volname)
+        ret = redant.set_volume_options(self.vol_name,
+                                        self.nfs_options,
+                                        self.server_list[0])

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -40,6 +40,14 @@ class TestVolumeSetOpWithQuorum(GlusterBaseClass):
 
     def tearDown(self):
 
+        # Setting Quorum ratio to 51%
+        self.quorum_perecent = {'cluster.server-quorum-ratio': '51%'}
+        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
+        self.assertTrue(ret, "gluster volume set all cluster.server-quorum-rat"
+                             "io percentage Failed :%s" % self.servers)
+        g.log.info("gluster volume set all cluster.server-quorum-ratio 51 "
+                   "percentage enabled successfully on :%s", self.servers)
+
         # stopping the volume and Cleaning up the volume
         ret = self.cleanup_volume()
         if not ret:

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -56,15 +56,6 @@ class TestVolumeSetOpWithQuorum(GlusterBaseClass):
                             % (self.mnode, self.servers))
             g.log.info("Peers is in connected state.")
 
-        # Setting Quorum ratio to 51%
-        self.quorum_perecent = {'cluster.server-quorum-ratio': '51%'}
-        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
-        if not ret:
-            raise ExecutionError("gluster volume set all cluster.server-quorum"
-                                 "-ratio percentage Failed :%s" % self.servers)
-        g.log.info("gluster volume set all cluster.server-quorum-ratio 51 "
-                   "percentage enabled successfully on :%s", self.servers)
-
         # stopping the volume and Cleaning up the volume
         ret = self.cleanup_volume()
         if not ret:

--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@ from time import sleep
 from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
 from glustolibs.gluster.volume_ops import set_volume_options
 from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
 
@@ -50,15 +51,9 @@ class TestVolumeSetOpWithQuorum(GlusterBaseClass):
             g.log.info("Successfully started glusterd.")
 
             # Checking if peer is connected.
-            counter = 0
-            while counter < 30:
-                ret = self.validate_peers_are_connected()
-                counter += 1
-                if ret:
-                    break
-                sleep(3)
-            if not ret:
-                raise ExecutionError("Peer is not in connected state.")
+            ret = wait_for_peers_to_connect(self.mnode, self.servers)
+            self.assertTrue(ret, "glusterd is not connected %s with peer %s"
+                            % (self.mnode, self.servers))
             g.log.info("Peers is in connected state.")
 
         # Setting Quorum ratio to 51%


### PR DESCRIPTION
Migrated the TC [test_volume_set_with_quorum_enabled](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py)

Fixes: #457 
Updates: #292

Signed-off-by: nik-redhat <nladha@redhat.com>