### PR TITLE
[Common][Tests] Encapsulation for file_dir_ops.py

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -99,6 +99,32 @@ class IoOps(AbstractOps):
 
         return True
 
+    def create_deep_dirs_with_files(self, path: str, dir_start_no: int,
+                                    dir_depth: int, dir_length: int,
+                                    max_no_dirs: int, no_files: int,
+                                    node: str):
+        """
+        Create deep directories and files. This function encapsulates the
+        operation of the file_dir_ops script present in the client machines.
+        Args:
+            path (str) : Path wherein this io is to be done.
+            dir_start_no (int) : From which number, the dir numbering will be
+                                 started
+            dir_depth (int) : The depth till which dirs have to be created.
+            dir_length (int) : The number of dirs at the top level.
+            max_no_dirs (int) : The number of dirs in a level.
+            no_files (int) : The number of files to be created under a
+                             directory.
+            node (str) : Node wherein the commad has to be run.
+        Returns:
+            async_object
+        """
+        cmd = (f"python3 /tmp/file_dir_ops.py create_deep_dirs_with_files "
+               f"--dirname-start-num {dir_start_no} --dir-depth {dir_depth}"
+               f" --dir-length {dir_length} --max-num-of-dirs {max_no_dirs} "
+               f"--num-of-files {no_files} {path}")
+        return self.execute_command_async(cmd, node)
+
     def collect_mounts_arequal(self, mounts: dict, path=''):
         """
         Collects arequal from all the mounts

--- a/tests/example/sample_component/test_io.py
+++ b/tests/example/sample_component/test_io.py
@@ -1,6 +1,5 @@
 """
-This file contains a test-case which tests glusterd
-starting and stopping of glusterd service.
+Sample test for showing how special IO operations can be handled.
 """
 # nonDisruptive;dist
 
@@ -15,18 +14,25 @@ class TestCase(NdParentTest):
 
     def run_test(self, redant):
         """
-        This particular test case tests the io_functions
-        on mountpoints. The steps taken are:
-        1) call collect_mounts_arequal function
-        2) call get_mounts_stat function
-        3) call list_all_files_and_dirs_mounts function
-        4) execute a command in async and call validate_io_procs function
-        5) call cleanup_mounts
+        The purpose of this test case is for verifying the IO
+        ops functions present in redant and also to give code
+        references for people looking for inspiration of how to use
+        an ops function. This test case will deal with the following
+        flows,
+        1. Using the special function for IO, create_deep_dirs_with_files.
+        2. Performing a simple IO operation.
         """
+        # Test the create_deep_dirs_with_files.
+        async_obj = redant.create_deep_dirs_with_files(self.mountpoint, 1, 2,
+                                                       3, 4, 10,
+                                                       self.client_list[0])
+        ret_dict = redant.wait_till_async_command_ends(async_obj)
+        if ret_dict['error_code'] != 0:
+            raise Exception(f"Failure : {ret_dict['error_msg']}")
 
-        # redant.collect_mounts_arequal(mountpoints)
-        redant.get_mounts_stat(self.mountpoint)
-        redant.list_all_files_and_dirs_mounts(self.mountpoint)
-        async_obj = redant.execute_command_async("ls", self.server_list[0])
-        redant.validate_io_procs(async_obj, self.mountpoint)
-        redant.cleanup_mounts(self.mountpoint)
+        # Performing simple IO opreation.
+        cmd = (f"ls {self.mountpoint}/*")
+        ret_dict = redant.execute_abstract_op_node(cmd, self.client_list[0],
+                                                   False)
+        if ret_dict['error_code'] != 0:
+            raise Exception(f"Failure : {ret_dict['error_msg']}")

--- a/tools/file_dir_ops.py
+++ b/tools/file_dir_ops.py
@@ -32,8 +32,17 @@ import shutil
 import string
 import subprocess
 import sys
+import pkg_resources
 
-from docx import Document
+required = {'numpy', 'sh'}
+installed = {pkg.key for pkg in pkg_resources.working_set}
+missing = required - installed
+
+if missing:
+    python = sys.executable
+    subprocess.check_call([python, '-m', 'pip', 'install', *missing],
+                          stdout=subprocess.DEVNULL)
+
 import numpy as np
 from sh import rsync as sh_rsync
 
@@ -277,19 +286,6 @@ def _create_file(file_abs_path, file_type, file_size):
                 print("Unable to write to file '%s' : %s" % (
                     file_abs_path, err.strerror))
                 rc = 1
-
-    elif file_type == 'docx':
-        file_abs_path += ".docx"
-        try:
-            document = Document()
-            str_to_write = list(string.ascii_letters + string.digits)
-            file_str = ''.join(np.random.choice(str_to_write, file_size))
-            document.add_paragraph(file_str)
-            document.save(file_abs_path)
-        except Exception as err:
-            print("Unable to write to file '%s' : %s" % (
-                file_abs_path, err.strerror))
-            rc = 1
 
     elif file_type == 'empty_file':
         try:


### PR DESCRIPTION
The file_dir_ops.py file is to be accessed through the
functions available in the io_ops. This patch adds an
simple function for handling one of the functionalities.

Fixes: #434

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
