### PR TITLE
Migration of test_volume_status_with_absent_bricks

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -173,7 +173,7 @@ class VolumeOps(AbstractOps):
                 will get executed with force option. If it is set to False,
                 then start volume will get executed without force option
             excep (bool): To bypass or not to bypass the exception handling.
-            
+
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -172,7 +172,6 @@ class VolumeOps(AbstractOps):
             force (bool): If this option is set to True, then start volume
                 will get executed with force option. If it is set to False,
                 then start volume will get executed without force option
-            excep (bool): To bypass or not to bypass the exception handling.
 
         Returns:
             ret: A dictionary consisting

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -172,6 +172,8 @@ class VolumeOps(AbstractOps):
             force (bool): If this option is set to True, then start volume
                 will get executed with force option. If it is set to False,
                 then start volume will get executed without force option
+            excep (bool): To bypass or not to bypass the exception handling.
+            
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed

--- a/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
+++ b/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
@@ -59,7 +59,7 @@ class TestCase(DParentTest):
         # Checking volume status
         ret = redant.get_volume_status(self.vol_name, self.server_list[0],
                                        excep=False)
-        if ret['error_code'] != 0 and ret['msg']['opErrstr'] != \
-        f'Volume {self.vol_name} is not started':
+        if ret['error_code'] != 0 and ret['msg']['opErrstr'] !=\
+           f'Volume {self.vol_name} is not started':
             raise Exception("Incorrect error message for gluster vol "
                             "status")

--- a/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
+++ b/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
@@ -1,0 +1,118 @@
+#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+      Volume start when one of the brick is absent
+"""
+
+import random
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import (volume_create, volume_start,
+                                           volume_status)
+from glustolibs.gluster.lib_utils import form_bricks_list
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated'],
+          ['glusterfs']])
+class TestVolumeStatusWithAbsentBricks(GlusterBaseClass):
+
+    def tearDown(self):
+        """
+        tearDown for every test
+        """
+        # stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed Cleanup the Volume %s"
+                                 % self.volname)
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_volume_absent_bricks(self):
+        '''
+        -> Create Volume
+        -> Remove any one Brick directory
+        -> Start Volume
+        -> Check the gluster volume status
+        '''
+        num_of_bricks = 0
+        replica = True
+
+        if self.volume_type == 'distributed':
+            num_of_bricks = 3
+            replica = False
+
+        elif self.volume_type == 'replicated':
+            num_of_bricks = 3
+
+        elif self.volume_type == 'distributed-replicated':
+            num_of_bricks = 6
+
+        # Forming brick list
+        brick_list = form_bricks_list(self.mnode, self.volname, num_of_bricks,
+                                      self.servers, self.all_servers_info)
+        if replica:
+            # Creating Volume
+            ret, _, _ = volume_create(self.mnode, self.volname, brick_list,
+                                      replica_count=3)
+            self.assertEqual(ret, 0, "Volume creation failed for %s"
+                             % self.volname)
+            g.log.info("volume created successfully %s", self.volname)
+        else:
+            # Creating Volume
+            ret, _, _ = volume_create(self.mnode, self.volname, brick_list)
+            self.assertEqual(ret, 0, "Volume creation failed for %s"
+                             % self.volname)
+            g.log.info("volume created successfully %s", self.volname)
+
+        # Command for removing brick directory
+        random_brick = random.choice(brick_list)
+        node, brick_path = random_brick.split(r':')
+        cmd = 'rm -rf ' + brick_path
+
+        # Removing brick directory of one node
+        ret, _, _ = g.run(node, cmd)
+        self.assertEqual(ret, 0, "Failed to remove brick dir")
+        g.log.info("Brick directory removed successfully")
+
+        # Starting volume
+        ret, _, err = volume_start(self.mnode, self.volname)
+        self.assertNotEqual(ret, 0, "Unexpected: Volume started successfully "
+                                    "even though brick directory is removed "
+                                    "for %s" % self.volname)
+        g.log.info("Expected: Failed to start volume %s", self.volname)
+
+        # Checking volume start failed message
+        msg = "Failed to find brick directory"
+        self.assertIn(msg, err, "Expected message is %s but volume start "
+                                "command failed with this "
+                                "message %s" % (msg, err))
+        g.log.info("Volume start failed with correct error message %s", err)
+
+        # Checking Volume status
+        ret, _, err = volume_status(self.mnode, self.volname)
+        self.assertNotEqual(ret, 0, "Success in getting volume status, volume "
+                                    "status should fail when volume is in "
+                                    "not started state ")
+        g.log.info("Failed to get volume status which is expected")
+
+        # Checking volume status message
+        msg = ' '.join(['Volume', self.volname, 'is not started'])
+        self.assertIn(msg, err, 'Incorrect error message for gluster vol '
+                                'status')
+        g.log.info("Correct error message for volume status")

--- a/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
+++ b/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
@@ -33,28 +33,28 @@ class TestCase(DParentTest):
         3) Start Volume and compare the failure message
         4) Check the gluster volume status and compare the status message
         """
-        
         # Fetching the brick list
         redant.volume_stop(self.vol_name, self.server_list[0])
         brick_list = redant.es.get_brickdata(self.vol_name)
-       
+
         # Removing any one brick directory
         brick_list = list(brick_list.items())
         random_brick = random.choice(brick_list)
         random_brick_path = random.choice(random_brick[1])
         cmd = f'rm -rf {random_brick_path}'
-        redant.execute_abstract_op_node(cmd, random_brick[0])        
-        
+        redant.execute_abstract_op_node(cmd, random_brick[0])
+
         # Starting volume
         err_msg = 'Failed to find brick directory'
-        ret = redant.volume_start(self.vol_name, self.server_list[0], excep = False)
+        ret = redant.volume_start(self.vol_name, self.server_list[0],
+                                  excep=False)
         if err_msg not in ret['msg']['opErrstr']:
             raise Exception("Unexpected:Volume started successfully"
                             " even though brick is deleted.")
-       
+
         # Checking volume status
-        ret = redant.get_volume_status(self.vol_name, self.server_list[0], excep = False)
+        ret = redant.get_volume_status(self.vol_name, self.server_list[0],
+                                       excep=False)
         if ret['msg']['opErrstr'] != f'Volume {self.vol_name} is not started':
             raise Exception("Incorrect error message for gluster vol "
                             "status")
-       

--- a/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
+++ b/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
@@ -24,6 +24,7 @@ from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.volume_ops import (volume_create, volume_start,
                                            volume_status)
+from glustolibs.gluster.volume_libs import cleanup_volume
 from glustolibs.gluster.lib_utils import form_bricks_list
 
 
@@ -36,10 +37,10 @@ class TestVolumeStatusWithAbsentBricks(GlusterBaseClass):
         tearDown for every test
         """
         # stopping the volume and Cleaning up the volume
-        ret = self.cleanup_volume()
+        ret = cleanup_volume(self.mnode, self.volname)
         if not ret:
-            raise ExecutionError("Failed Cleanup the Volume %s"
-                                 % self.volname)
+            raise ExecutionError("Failed to cleanup volume")
+        g.log.info("Volume deleted successfully : %s", self.volname)
         # Calling GlusterBaseClass tearDown
         self.get_super_method(self, 'tearDown')()
 

--- a/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
+++ b/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
@@ -41,7 +41,7 @@ class TestVolumeStatusWithAbsentBricks(GlusterBaseClass):
             raise ExecutionError("Failed Cleanup the Volume %s"
                                  % self.volname)
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_volume_absent_bricks(self):
         '''


### PR DESCRIPTION
Migrated [test case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_volume_status_with_absent_bricks.py)

Updates: #465 

Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>
