### PR TITLE
Change path of glusterd.vol in the test

### DIFF
--- a/tests/functional/glusterd/test_default_ping_timer_and_epoll_thread_count.py
+++ b/tests/functional/glusterd/test_default_ping_timer_and_epoll_thread_count.py
@@ -39,7 +39,7 @@ class TestCase(NdParentTest):
         """
         # Fetch the ping timeout value from glusterd.vol file
         # TODO: this path might change as per the installation
-        cmd = "cat /usr/local/etc/glusterfs/glusterd.vol |\
+        cmd = "cat /etc/glusterfs/glusterd.vol |\
                grep -i ping-timeout"
 
         ret = redant.execute_command(cmd, self.server_list[0])


### PR DESCRIPTION
In test_default_ping_timer_and_epoll_thread_count, the path needs to be
changed.

Fixes: #470

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
