### PR TITLE
Mount cleanup corner case handling

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -43,7 +43,7 @@ class VolumeOps(AbstractOps):
         return ret
 
     def volume_unmount(self, volname: str, path: str, node: str = None,
-                       excep: bool=True):
+                       excep: bool = True):
         """
         Unmounts the gluster volume .
         Args:

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -89,13 +89,14 @@ class IoOps(AbstractOps):
             list_of_paths = (list_of_paths.split(" "))
 
         for path in list_of_paths:
-            cmd = f"ls -l {path}"
+            cmd = f"stat {path}"
             ret = self.execute_command_multinode(cmd, list_of_nodes)
-        for each_ret in ret:
-            if each_ret['error_code'] != 0:
-                error_string = each_ret['error_msg'].rstrip('\n')
-                self.logger.error(f"{error_string} on node {each_ret['node']}")
-                return False
+            for each_ret in ret:
+                if each_ret['error_code'] != 0:
+                    error_string = each_ret['error_msg'].rstrip('\n')
+                    self.logger.error(f"{error_string} on node "
+                                      f"{each_ret['node']}")
+                    return False
 
         return True
 


### PR DESCRIPTION
The mount cleanup is not done properly due to some corner cases
1. When the mountpount is already unmounted
2. When the mountpoint is unmount and deleted

And this is done in such a manner that the update escapes the data structure itself.

Fixes: #467

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
