### PR TITLE
Migration of test_peer_probe and changes to cleanup_volume

### DIFF
--- a/core/environ.py
+++ b/core/environ.py
@@ -543,4 +543,5 @@ class FrameworkEnv:
         Returns:
             list : list of nodes whose bricks are part of the volume.
         """
+        self._validate_volname(volname)
         return list(self.volds[volname]['brickdata'].keys())

--- a/core/environ.py
+++ b/core/environ.py
@@ -533,3 +533,14 @@ class FrameworkEnv:
                 raise Exception(f"No data for node {n}")
             ret_val[n] = self.cleands[n]
         return ret_val
+
+    def get_volume_nodes(self, volname: str):
+        """
+        Function to get all the nodes whose bricks are
+        part of the volume given
+        Args:
+            volname (str): volume name whose nodes are to be returned.
+        Returns:
+            list : list of nodes whose bricks are part of the volume.
+        """
+        return list(self.volds[volname]['brickdata'].keys())

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -37,6 +37,7 @@ class DParentTest(metaclass=abc.ABCMeta):
         self.TEST_RES = True
         self.volume_type = volume_type
         self.vol_type_inf = param_obj.get_volume_types()
+        self.test_name = mname
         self.vol_name = (f"{mname}-{volume_type}")
         self._configure(self.vol_name, server_details, client_details,
                         env_obj, log_path, log_level)
@@ -94,7 +95,8 @@ class DParentTest(metaclass=abc.ABCMeta):
             self.redant.reset_volume_option('all', 'all', self.server_list[0])
             volnames = self.redant.es.get_volnames()
             for volname in volnames:
-                self.redant.cleanup_volume(volname, self.server_list)
+                volume_nodes = self.redant.es.get_volume_nodes(volname)
+                self.redant.cleanup_volume(volname, volume_nodes[0])
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -40,7 +40,7 @@ class TestPeerProbe(GlusterBaseClass):
             if ret != 0:
                 raise ExecutionError("Peer detach failed")
             g.log.info("Peer detach SUCCESSFUL.")
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
     def tearDown(self):
         """
@@ -64,7 +64,7 @@ class TestPeerProbe(GlusterBaseClass):
                                  "servers %s" % self.servers)
         g.log.info("Peer probe success for detached "
                    "servers %s", self.servers)
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_peer_probe(self):
         """

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -1,0 +1,240 @@
+#  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import (volume_create, volume_start,
+                                           get_volume_list, volume_stop,
+                                           volume_delete)
+from glustolibs.gluster.volume_libs import (cleanup_volume)
+from glustolibs.gluster.peer_ops import (peer_probe, peer_detach,
+                                         peer_probe_servers,
+                                         nodes_from_pool_list)
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.exceptions import ExecutionError
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestPeerProbe(GlusterBaseClass):
+
+    def setUp(self):
+
+        # Performing peer detach
+        for server in self.servers[1:]:
+            ret, _, _ = peer_detach(self.mnode, server)
+            if ret != 0:
+                raise ExecutionError("Peer detach failed")
+            g.log.info("Peer detach SUCCESSFUL.")
+        GlusterBaseClass.setUp.im_func(self)
+
+    def tearDown(self):
+        """
+        clean up all volumes and peer probe to form cluster
+        """
+        vol_list = get_volume_list(self.mnode)
+        if vol_list is not None:
+            for volume in vol_list:
+                ret = cleanup_volume(self.mnode, volume)
+                if not ret:
+                    raise ExecutionError("Failed to cleanup volume")
+                g.log.info("Volume deleted successfully : %s", volume)
+
+        # Peer probe detached servers
+        pool = nodes_from_pool_list(self.mnode)
+        for node in pool:
+            peer_detach(self.mnode, node)
+        ret = peer_probe_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Failed to probe detached "
+                                 "servers %s" % self.servers)
+        g.log.info("Peer probe success for detached "
+                   "servers %s", self.servers)
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_peer_probe(self):
+        """
+        In this test case:
+        1. Create Dist Volume on Node 1
+        2. Create Replica Volume on Node 2
+        3. Peer Probe N2 from N1(should fail)
+        4. Clean All Volumes
+        5. Peer Probe N1 to N2(should success)
+           Peer Probe N3 to N2(should fail)
+        6. Create replica Volume on N1 and N2
+        7. Peer probe from N3 to N1(should fail)
+        8. Peer probe from N1 to N3(should succeed)
+        9. Create replica Volume on N1, N2 and N2
+        10.Start Volume
+        11. delete volume (should fail)
+        12. Stop volume
+        13. Clean up all volumes
+        """
+
+        # pylint: disable=too-many-statements
+        # Create a distributed volume on Node1
+        number_of_brick = 1
+        servers_info_from_single_node = {}
+        servers_info_from_single_node[
+            self.servers[0]] = self.all_servers_info[self.servers[0]]
+        self.volname = "testvol"
+        bricks_list = form_bricks_list(self.servers[0], self.volname,
+                                       number_of_brick, self.servers[0],
+                                       servers_info_from_single_node)
+        ret, _, _ = volume_create(self.servers[0], self.volname,
+                                  bricks_list, True)
+        self.assertEqual(ret, 0, "Volume create failed")
+        g.log.info("Volume %s created successfully", self.volname)
+
+        # Create a replicate volume on Node2 without force
+        number_of_brick = 2
+        servers_info_from_single_node = {}
+        servers_info_from_single_node[
+            self.servers[1]] = self.all_servers_info[self.servers[1]]
+        kwargs = {'replica_count': 2}
+        self.volname = "new-volume"
+        bricks_list = form_bricks_list(self.servers[1], self.volname,
+                                       number_of_brick, self.servers[1],
+                                       servers_info_from_single_node)
+
+        # creation of replicate volume without force should fail
+        ret, _, _ = volume_create(self.servers[1], self.volname,
+                                  bricks_list, False, **kwargs)
+        self.assertNotEqual(ret, 0, ("Unexpected: Successfully created "
+                                     "the replicate volume on node2 "
+                                     "without force"))
+        g.log.info("Failed to create the replicate volume %s as "
+                   " expected without force", self.volname)
+
+        # Create a replica volume on Node2 with force
+        number_of_brick = 3
+        servers_info_from_single_node = {}
+        servers_info_from_single_node[
+            self.servers[1]] = self.all_servers_info[self.servers[1]]
+        kwargs = {'replica_count': 3}
+        self.volname = "new-volume"
+        bricks_list = form_bricks_list(self.servers[1], self.volname,
+                                       number_of_brick, self.servers[1],
+                                       servers_info_from_single_node)
+
+        # creation of replicate volume with force should succeed
+        ret, _, _ = volume_create(self.servers[1], self.volname,
+                                  bricks_list, True, **kwargs)
+        self.assertEqual(ret, 0, "Volume create failed")
+        g.log.info("Volume %s created", self.volname)
+
+        # Perform peer probe from N1 to N2
+        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
+        self.assertNotEqual(ret, 0, (
+            "peer probe is success from %s to %s even if %s "
+            " is a part of another cluster or having volumes "
+            " configured", self.servers[0], self.servers[1], self.servers[1]))
+        g.log.info("peer probe failed from %s to "
+                   "%s as expected", self.servers[0], self.servers[1])
+
+        # clean up all volumes
+        for server in self.servers[0:2]:
+            # Listing all the volumes
+            vol_list = get_volume_list(server)
+            self.assertIsNotNone(vol_list, "Unable to get volumes list")
+            g.log.info("Getting the volume list from %s", self.mnode)
+            for vol in vol_list:
+                g.log.info("deleting volume : %s", vol)
+                ret = cleanup_volume(server, vol)
+                self.assertTrue(ret, ("Failed to Cleanup the Volume %s", vol))
+                g.log.info("Volume deleted successfully : %s", vol)
+
+        # Perform peer probe from N1 to N2 should success
+        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
+        self.assertEqual(
+            ret, 0, ("peer probe from %s to %s is "
+                     "failed", self.servers[0], self.servers[1]))
+        g.log.info("peer probe is success from %s to "
+                   "%s", self.servers[0], self.servers[1])
+
+        # Perform peer probe from N3 to N2 should fail
+        ret, _, _ = peer_probe(self.servers[2], self.servers[1])
+        self.assertNotEqual(ret, 0, (
+            "peer probe is success from %s to %s even if %s "
+            "is a part of another cluster or having volumes "
+            "configured", self.servers[2], self.servers[1], self.servers[1]))
+        g.log.info("peer probe failed from %s to "
+                   "%s as expected", self.servers[2], self.servers[1])
+
+        # Create a replica volume on N1 and N2 with force
+        number_of_brick = 2
+        servers_info_from_two_node = {}
+        for server in self.servers[0:2]:
+            servers_info_from_two_node[server] = self.all_servers_info[server]
+        kwargs = {'replica_count': 2}
+        self.volname = "new-volume"
+        bricks_list = form_bricks_list(self.servers[0], self.volname,
+                                       number_of_brick, self.servers[0:2],
+                                       servers_info_from_two_node)
+        ret, _, _ = volume_create(self.servers[1], self.volname,
+                                  bricks_list, True, **kwargs)
+        self.assertEqual(ret, 0, "Volume create failed")
+        g.log.info("Volume %s created succssfully", self.volname)
+
+        # Perform peer probe from N3 to N1 should fail
+        ret, _, _ = peer_probe(self.servers[2], self.servers[0])
+        self.assertNotEqual(ret, 0, (
+            "peer probe is success from %s to %s even if %s "
+            "a part of another cluster or having volumes "
+            "configured", self.servers[2], self.servers[0], self.servers[0]))
+        g.log.info("peer probe is failed from %s to "
+                   "%s as expected", self.servers[2], self.servers[0])
+
+        # Perform peer probe from N1 to N3 should succed
+        ret, _, _ = peer_probe(self.servers[0], self.servers[2])
+        self.assertEqual(
+            ret, 0, ("peer probe from %s to %s is "
+                     "failed", self.servers[0], self.servers[2]))
+        g.log.info("peer probe is success from %s to "
+                   "%s", self.servers[0], self.servers[2])
+
+        # Create a replica volume on N1, N2 and N3 with force
+        number_of_brick = 3
+        server_info_from_three_node = {}
+        for server in self.servers[0:3]:
+            server_info_from_three_node[server] = self.all_servers_info[server]
+        kwargs = {'replica_count': 3}
+        self.volname = "new-replica-volume"
+        bricks_list = form_bricks_list(self.servers[2], self.volname,
+                                       number_of_brick, self.servers[0:3],
+                                       server_info_from_three_node)
+        ret, _, _ = volume_create(self.servers[1], self.volname,
+                                  bricks_list, True, **kwargs)
+        self.assertEqual(ret, 0, "Volume create failed")
+        g.log.info("creation of replica volume should succeed")
+
+        ret, _, _ = volume_start(self.servers[2], self.volname, True)
+        self.assertEqual(ret, 0, ("Failed to start the "
+                                  "volume %s", self.volname))
+        g.log.info("Volume %s start with force is success", self.volname)
+
+        # Volume delete should fail without stopping volume
+        ret = volume_delete(self.servers[2], self.volname)
+        self.assertFalse(ret, ("Unexpected Error: Volume deleted "
+                               "successfully without stopping"
+                               "volume %s", self.volname))
+        g.log.info("Expected: volume delete should fail without "
+                   "stopping volume: %s", self.volname)
+
+        # Volume stop with force
+        ret, _, _ = volume_stop(self.mnode, self.volname, True)
+        self.assertEqual(ret, 0, ("Failed to stop the volume "
+                                  "%s", self.volname))
+        g.log.info("Volume stop with force is success")

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -14,6 +14,7 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from time import sleep
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.volume_ops import (volume_create, volume_start,
@@ -22,6 +23,7 @@ from glustolibs.gluster.volume_ops import (volume_create, volume_start,
 from glustolibs.gluster.volume_libs import (cleanup_volume)
 from glustolibs.gluster.peer_ops import (peer_probe, peer_detach,
                                          peer_probe_servers,
+                                         is_peer_connected,
                                          nodes_from_pool_list)
 from glustolibs.gluster.lib_utils import form_bricks_list
 from glustolibs.gluster.exceptions import ExecutionError
@@ -164,6 +166,17 @@ class TestPeerProbe(GlusterBaseClass):
         g.log.info("peer probe is success from %s to "
                    "%s", self.servers[0], self.servers[1])
 
+        # Checking if peer is connected
+        counter = 0
+        while counter < 30:
+            ret = is_peer_connected(self.servers[0], self.servers[1])
+            counter += 1
+            if ret:
+                break
+            sleep(3)
+        self.assertTrue(ret, "Peer is not in connected state.")
+        g.log.info("Peers is in connected state.")
+
         # Perform peer probe from N3 to N2 should fail
         ret, _, _ = peer_probe(self.servers[2], self.servers[1])
         self.assertNotEqual(ret, 0, (
@@ -204,6 +217,17 @@ class TestPeerProbe(GlusterBaseClass):
                      "failed", self.servers[0], self.servers[2]))
         g.log.info("peer probe is success from %s to "
                    "%s", self.servers[0], self.servers[2])
+
+        # Checking if peer is connected
+        counter = 0
+        while counter < 30:
+            ret = is_peer_connected(self.servers[0], self.servers[:3])
+            counter += 1
+            if ret:
+                break
+            sleep(3)
+        self.assertTrue(ret, "Peer is not in connected state.")
+        g.log.info("Peers is in connected state.")
 
         # Create a replica volume on N1, N2 and N3 with force
         number_of_brick = 3

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -1,72 +1,33 @@
-#  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+  Validating various cases of peer probe between nodes with
+  volume creation on different nodes.
+"""
 
 from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import (volume_create, volume_start,
-                                           get_volume_list, volume_stop,
-                                           volume_delete)
-from glustolibs.gluster.volume_libs import (cleanup_volume)
-from glustolibs.gluster.peer_ops import (peer_probe, peer_detach,
-                                         peer_probe_servers,
-                                         is_peer_connected,
-                                         nodes_from_pool_list)
-from glustolibs.gluster.lib_utils import form_bricks_list
-from glustolibs.gluster.exceptions import ExecutionError
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed'], ['glusterfs']])
-class TestPeerProbe(GlusterBaseClass):
+# disruptive;
+class TestCase(DParentTest):
 
-    def setUp(self):
-
-        # Performing peer detach
-        for server in self.servers[1:]:
-            ret, _, _ = peer_detach(self.mnode, server)
-            if ret != 0:
-                raise ExecutionError("Peer detach failed")
-            g.log.info("Peer detach SUCCESSFUL.")
-        self.get_super_method(self, 'setUp')()
-
-    def tearDown(self):
-        """
-        clean up all volumes and peer probe to form cluster
-        """
-        vol_list = get_volume_list(self.mnode)
-        if vol_list is not None:
-            for volume in vol_list:
-                ret = cleanup_volume(self.mnode, volume)
-                if not ret:
-                    raise ExecutionError("Failed to cleanup volume")
-                g.log.info("Volume deleted successfully : %s", volume)
-
-        # Peer probe detached servers
-        pool = nodes_from_pool_list(self.mnode)
-        for node in pool:
-            peer_detach(self.mnode, node)
-        ret = peer_probe_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Failed to probe detached "
-                                 "servers %s" % self.servers)
-        g.log.info("Peer probe success for detached "
-                   "servers %s", self.servers)
-        self.get_super_method(self, 'tearDown')()
-
-    def test_peer_probe(self):
+    def run_test(self, redant):
         """
         In this test case:
         1. Create Dist Volume on Node 1
@@ -84,182 +45,149 @@ class TestPeerProbe(GlusterBaseClass):
         12. Stop volume
         13. Clean up all volumes
         """
+        # Destroy the cluster environment
+        redant.delete_cluster(self.server_list)
 
-        # pylint: disable=too-many-statements
         # Create a distributed volume on Node1
-        number_of_brick = 1
-        servers_info_from_single_node = {}
-        servers_info_from_single_node[
-            self.servers[0]] = self.all_servers_info[self.servers[0]]
-        self.volname = "testvol"
-        bricks_list = form_bricks_list(self.servers[0], self.volname,
-                                       number_of_brick, self.servers[0],
-                                       servers_info_from_single_node)
-        ret, _, _ = volume_create(self.servers[0], self.volname,
-                                  bricks_list, True)
-        self.assertEqual(ret, 0, "Volume create failed")
-        g.log.info("Volume %s created successfully", self.volname)
+        volume_type1 = 'dist'
+        volume_name1 = f"{self.test_name}-{volume_type1}-1"
+        self.vol_type_inf[self.conv_dict[volume_type1]]['dist-count'] = 1
+        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type1]]
+        ret = redant.volume_create(volume_name1, self.server_list[0],
+                                   vol_params_dict, [self.server_list[0]],
+                                   self.brick_roots, True)
 
-        # Create a replicate volume on Node2 without force
-        number_of_brick = 2
-        servers_info_from_single_node = {}
-        servers_info_from_single_node[
-            self.servers[1]] = self.all_servers_info[self.servers[1]]
-        kwargs = {'replica_count': 2}
-        self.volname = "new-volume"
-        bricks_list = form_bricks_list(self.servers[1], self.volname,
-                                       number_of_brick, self.servers[1],
-                                       servers_info_from_single_node)
+        # Create a replicate volume on Node2 without force should fail
+        volume_type2 = 'rep'
+        volume_name2 = f"{self.test_name}-{volume_type2}-2"
+        self.vol_type_inf[self.conv_dict[volume_type2]]['replica_count'] = 2
+        try:
+            vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type2]]
+            ret = redant.volume_create(volume_name2, self.server_list[1],
+                                       vol_params_dict, [self.server_list[1]],
+                                       self.brick_roots)
+            raise Exception("Unexpected: Successfully created "
+                            "the replicate volume on node2 "
+                            "without force")
+        except Exception:
+            redant.logger.info("Expected: Failed to create the replicate "
+                               f"volume {volume_name2} as  expected without "
+                               "force")
 
-        # creation of replicate volume without force should fail
-        ret, _, _ = volume_create(self.servers[1], self.volname,
-                                  bricks_list, False, **kwargs)
-        self.assertNotEqual(ret, 0, ("Unexpected: Successfully created "
-                                     "the replicate volume on node2 "
-                                     "without force"))
-        g.log.info("Failed to create the replicate volume %s as "
-                   " expected without force", self.volname)
-
-        # Create a replica volume on Node2 with force
-        number_of_brick = 3
-        servers_info_from_single_node = {}
-        servers_info_from_single_node[
-            self.servers[1]] = self.all_servers_info[self.servers[1]]
-        kwargs = {'replica_count': 3}
-        self.volname = "new-volume"
-        bricks_list = form_bricks_list(self.servers[1], self.volname,
-                                       number_of_brick, self.servers[1],
-                                       servers_info_from_single_node)
-
-        # creation of replicate volume with force should succeed
-        ret, _, _ = volume_create(self.servers[1], self.volname,
-                                  bricks_list, True, **kwargs)
-        self.assertEqual(ret, 0, "Volume create failed")
-        g.log.info("Volume %s created", self.volname)
+        # Create a replica volume on Node2 with force should succeed
+        volume_type3 = 'rep'
+        volume_name3 = f"{self.test_name}-{volume_type3}-3"
+        self.vol_type_inf[self.conv_dict[volume_type3]]['replica-count'] = 3
+        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type3]]
+        ret = redant.volume_create(volume_name3, self.server_list[1],
+                                   vol_params_dict, [self.server_list[1]],
+                                   self.brick_roots, True)
 
         # Perform peer probe from N1 to N2
-        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
-        self.assertNotEqual(ret, 0, (
-            "peer probe is success from %s to %s even if %s "
-            " is a part of another cluster or having volumes "
-            " configured", self.servers[0], self.servers[1], self.servers[1]))
-        g.log.info("peer probe failed from %s to "
-                   "%s as expected", self.servers[0], self.servers[1])
+        try:
+            ret = redant.peer_probe(self.server_list[1], self.server_list[0])
+            raise Exception("peer probe is success from "
+                            f"{self.server_list[0]} to "
+                            f"{self.server_list[1]} even if "
+                            f"{self.server_list[1]} "
+                            " is a part of another cluster or having "
+                            "volumes  configured")
+        except Exception:
+            redant.logger.info("Expected: peer probe failed from "
+                               f"{self.server_list[0]} "
+                               f"to {self.server_list[1]} "
+                               "as expected")
 
         # clean up all volumes
-        for server in self.servers[0:2]:
-            # Listing all the volumes
-            vol_list = get_volume_list(server)
-            self.assertIsNotNone(vol_list, "Unable to get volumes list")
-            g.log.info("Getting the volume list from %s", self.mnode)
-            for vol in vol_list:
-                g.log.info("deleting volume : %s", vol)
-                ret = cleanup_volume(server, vol)
-                self.assertTrue(ret, ("Failed to Cleanup the Volume %s", vol))
-                g.log.info("Volume deleted successfully : %s", vol)
+        volnames = redant.es.get_volnames()
+        for volname in volnames:
+            volume_nodes = self.redant.es.get_volume_nodes(volname)
+            redant.cleanup_volume(volname, volume_nodes[0])
 
         # Perform peer probe from N1 to N2 should success
-        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
-        self.assertEqual(
-            ret, 0, ("peer probe from %s to %s is "
-                     "failed", self.servers[0], self.servers[1]))
-        g.log.info("peer probe is success from %s to "
-                   "%s", self.servers[0], self.servers[1])
+        ret = redant.peer_probe(self.server_list[1], self.server_list[0])
 
         # Checking if peer is connected
         counter = 0
         while counter < 30:
-            ret = is_peer_connected(self.servers[0], self.servers[1])
+            ret = redant.is_peer_connected(self.server_list[0],
+                                           self.server_list[1])
             counter += 1
             if ret:
                 break
             sleep(3)
-        self.assertTrue(ret, "Peer is not in connected state.")
-        g.log.info("Peers is in connected state.")
+        if not ret:
+            raise Exception("Peer is not in connected state.")
 
         # Perform peer probe from N3 to N2 should fail
-        ret, _, _ = peer_probe(self.servers[2], self.servers[1])
-        self.assertNotEqual(ret, 0, (
-            "peer probe is success from %s to %s even if %s "
-            "is a part of another cluster or having volumes "
-            "configured", self.servers[2], self.servers[1], self.servers[1]))
-        g.log.info("peer probe failed from %s to "
-                   "%s as expected", self.servers[2], self.servers[1])
+        try:
+            ret = redant.peer_probe(self.server_list[2], self.server_list[1])
+            raise Exception("peer probe is success from "
+                            f"{self.server_list[2]} "
+                            f"to {self.server_list[1]} even if "
+                            f"{self.server_list[1]} is a part of another "
+                            "cluster or having volumes configured")
+        except Exception:
+            redant.logger.info("Expected: peer probe failed from "
+                               f"{self.server_list[2]} to "
+                               f"{self.server_list[1]} as expected")
 
         # Create a replica volume on N1 and N2 with force
-        number_of_brick = 2
-        servers_info_from_two_node = {}
-        for server in self.servers[0:2]:
-            servers_info_from_two_node[server] = self.all_servers_info[server]
-        kwargs = {'replica_count': 2}
-        self.volname = "new-volume"
-        bricks_list = form_bricks_list(self.servers[0], self.volname,
-                                       number_of_brick, self.servers[0:2],
-                                       servers_info_from_two_node)
-        ret, _, _ = volume_create(self.servers[1], self.volname,
-                                  bricks_list, True, **kwargs)
-        self.assertEqual(ret, 0, "Volume create failed")
-        g.log.info("Volume %s created succssfully", self.volname)
+        volume_type4 = 'rep'
+        volume_name4 = f"{self.test_name}-{volume_type4}-4"
+        self.vol_type_inf[self.conv_dict[volume_type4]]['replica-count'] = 2
+        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type4]]
+        ret = redant.volume_create(volume_name4, self.server_list[0],
+                                   vol_params_dict, self.server_list[0:2],
+                                   self.brick_roots, True)
 
         # Perform peer probe from N3 to N1 should fail
-        ret, _, _ = peer_probe(self.servers[2], self.servers[0])
-        self.assertNotEqual(ret, 0, (
-            "peer probe is success from %s to %s even if %s "
-            "a part of another cluster or having volumes "
-            "configured", self.servers[2], self.servers[0], self.servers[0]))
-        g.log.info("peer probe is failed from %s to "
-                   "%s as expected", self.servers[2], self.servers[0])
+        try:
+            ret = redant.peer_probe(self.server_list[0], self.server_list[2])
+            raise Exception("peer probe is success from "
+                            f"{self.server_list[2]} "
+                            f"to {self.server_list[0]} even if "
+                            f"{self.server_list[0]} is a part of another "
+                            "cluster or having volumes configured")
+        except Exception:
+            redant.logger.info("Expected: peer probe failed from "
+                               f"{self.server_list[2]} to "
+                               f"{self.server_list[0]} as expected")
 
         # Perform peer probe from N1 to N3 should succed
-        ret, _, _ = peer_probe(self.servers[0], self.servers[2])
-        self.assertEqual(
-            ret, 0, ("peer probe from %s to %s is "
-                     "failed", self.servers[0], self.servers[2]))
-        g.log.info("peer probe is success from %s to "
-                   "%s", self.servers[0], self.servers[2])
+        ret = redant.peer_probe(self.server_list[2], self.server_list[0])
 
         # Checking if peer is connected
         counter = 0
         while counter < 30:
-            ret = is_peer_connected(self.servers[0], self.servers[:3])
+            ret = redant.is_peer_connected(self.server_list[0],
+                                           self.server_list[:3])
             counter += 1
             if ret:
                 break
             sleep(3)
-        self.assertTrue(ret, "Peer is not in connected state.")
-        g.log.info("Peers is in connected state.")
+        if not ret:
+            raise Exception("Peer is not in connected state.")
 
         # Create a replica volume on N1, N2 and N3 with force
-        number_of_brick = 3
-        server_info_from_three_node = {}
-        for server in self.servers[0:3]:
-            server_info_from_three_node[server] = self.all_servers_info[server]
-        kwargs = {'replica_count': 3}
-        self.volname = "new-replica-volume"
-        bricks_list = form_bricks_list(self.servers[2], self.volname,
-                                       number_of_brick, self.servers[0:3],
-                                       server_info_from_three_node)
-        ret, _, _ = volume_create(self.servers[1], self.volname,
-                                  bricks_list, True, **kwargs)
-        self.assertEqual(ret, 0, "Volume create failed")
-        g.log.info("creation of replica volume should succeed")
+        volume_type5 = 'rep'
+        volume_name5 = f"{self.test_name}-{volume_type5}-5"
+        self.vol_type_inf[self.conv_dict[volume_type5]]['replica-count'] = 3
+        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type5]]
+        ret = redant.volume_create(volume_name5, self.server_list[0],
+                                   vol_params_dict, self.server_list,
+                                   self.brick_roots, True)
 
-        ret, _, _ = volume_start(self.servers[2], self.volname, True)
-        self.assertEqual(ret, 0, ("Failed to start the "
-                                  "volume %s", self.volname))
-        g.log.info("Volume %s start with force is success", self.volname)
+        ret = redant.volume_start(volume_name5, self.server_list[2], True)
 
         # Volume delete should fail without stopping volume
-        self.assertTrue(
-            volume_delete(self.servers[2], self.volname, xfail=True),
-            "Unexpected Error: Volume deleted "
-            "successfully without stopping volume"
-        )
-        g.log.info("Expected: volume delete should fail without "
-                   "stopping volume: %s", self.volname)
+        try:
+            redant.volume_delete(volume_name5, self.server_list[2])
+            raise Exception("Unexpected Error: Volume deleted "
+                            "successfully without stopping volume")
+        except Exception:
+            redant.logger.info("Expected: volume delete should fail without "
+                               f"stopping volume: {volume_name5}")
 
         # Volume stop with force
-        ret, _, _ = volume_stop(self.mnode, self.volname, True)
-        self.assertEqual(ret, 0, ("Failed to stop the volume "
-                                  "%s", self.volname))
-        g.log.info("Volume stop with force is success")
+        ret = redant.volume_stop(volume_name5, self.server_list[0], True)

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -226,10 +226,11 @@ class TestPeerProbe(GlusterBaseClass):
         g.log.info("Volume %s start with force is success", self.volname)
 
         # Volume delete should fail without stopping volume
-        ret = volume_delete(self.servers[2], self.volname)
-        self.assertFalse(ret, ("Unexpected Error: Volume deleted "
-                               "successfully without stopping"
-                               "volume %s", self.volname))
+        self.assertTrue(
+            volume_delete(self.servers[2], self.volname, xfail=True),
+            "Unexpected Error: Volume deleted "
+            "successfully without stopping volume"
+        )
         g.log.info("Expected: volume delete should fail without "
                    "stopping volume: %s", self.volname)
 

--- a/tests/vol_destroy_test.py
+++ b/tests/vol_destroy_test.py
@@ -29,5 +29,6 @@ class VolDestroy(LazyParentTest):
         This child is responsible for the destruction of a volume
         of said type and its mountpoint.
         """
-        redant.cleanup_volume(self.vol_name, self.server_list)
+        volume_nodes = self.redant.es.get_volume_nodes(self.vol_name)
+        self.redant.cleanup_volume(self.vol_name, volume_nodes[0])
         redant.cleanup_brick_dirs()


### PR DESCRIPTION
Migration of the [test case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_peer_probe.py) is done from glusto to redant.
cleanup volume now takes a single node as parameter on which
the command has to run unlike list of servers like before. Accordingly
changes are done to all the calls to cleanup_volume
    
Updates: #292
Fixes: #452

Signed-off-by: Nishith Vihar Sakinala nsakinal@redhat.com