### PR TITLE
[Test] Fixing spurious failure in TC.

### DIFF
--- a/tests/functional/glusterd/test_gluster_volume_status_xml_dump.py
+++ b/tests/functional/glusterd/test_gluster_volume_status_xml_dump.py
@@ -44,6 +44,7 @@ class TestCase(NdParentTest):
                              self.server_list, self.brick_roots, True)
         redant.volume_start(volume_name1, self.server_list[0])
         redant.volume_stop(self.vol_name, self.server_list[0], force=True)
+        sleep(2)
         out = redant.get_volume_status(node=self.server_list[0])
         if out is None:
             raise Exception("Failed to get volume status on "


### PR DESCRIPTION
test_gluster_volume_status_xml_dump has
spurious failure which is happening because
we are not waiting for a volume to stop before
going on with our other operations.

Fixes: #483

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>


<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
