### PR TITLE
Migrated TC test_profile_operations

### DIFF
--- a/common/ops/gluster_ops/profile_ops.py
+++ b/common/ops/gluster_ops/profile_ops.py
@@ -14,12 +14,17 @@ class ProfileOps(AbstractOps):
     check_profile_options etc.
     """
 
-    def profile_start(self, volname: str, node: str = None) -> dict:
+    def profile_start(self, volname: str, node: str = None,
+                      excep: bool = True) -> dict:
         """
         Start profile on the specified volume.
         Args:
             volname (str): Volume on which profile has to be started.
             node (str): Node on which command has to be executed.
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Returns:
             ret: A dictionary consisting
                     - Flag : Flag to check if connection failed
@@ -34,21 +39,25 @@ class ProfileOps(AbstractOps):
         """
         cmd = f"gluster volume profile {volname} start"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
 
         return ret
 
-    def profile_info(self, volname: str, options: str = '',
-                     node: str = None) -> dict:
+    def profile_info(self, volname: str, node: str = None,
+                     options: str = None, excep: bool = True) -> dict:
         """
         Run profile info on the specified volume.
         Args:
             volname (str): Volume for which profile info has to be retrived.
+            node (str): Node on which command has to be executed.
             options (str): Options can be
                            [peek|incremental [peek]|cumulative|clear].If not
                            given the function returns the output of gluster
                            volume profile <volname> info.
-            node (str): Node on which command has to be executed.
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Returns:
             ret: A dictionary consisting
                     - Flag : Flag to check if connection failed
@@ -61,19 +70,24 @@ class ProfileOps(AbstractOps):
         Example:
             profile_info(node, "testvol")
         """
-        if not self.check_profile_options(options):
+        if options is not None and not self.check_profile_options(options):
             return None
         cmd = f"gluster volume profile {volname} info {options}"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
 
         return ret
 
-    def profile_stop(self, volname: str, node: str = None) -> dict:
+    def profile_stop(self, volname: str, node: str = None,
+                     excep: bool = True) -> dict:
         """Stop profile on the specified volume.
         Args:
             volname (str): Volume on which profile has to be stopped.
             node (str): Node on which command has to be executed.
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Returns:
             ret: A dictionary consisting
                     - Flag : Flag to check if connection failed
@@ -87,7 +101,7 @@ class ProfileOps(AbstractOps):
         """
         cmd = f"gluster volume profile {volname} stop"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
 
         return ret
 
@@ -103,7 +117,7 @@ class ProfileOps(AbstractOps):
         """
 
         list_of_options = ['peek', 'incremental', 'incremental peek',
-                           'cumulative', 'clear', '']
+                           'cumulative', 'clear']
         if options not in list_of_options:
             self.logger.error("Invalid profile info option given.")
             return False

--- a/common/ops/gluster_ops/profile_ops.py
+++ b/common/ops/gluster_ops/profile_ops.py
@@ -44,7 +44,7 @@ class ProfileOps(AbstractOps):
         return ret
 
     def profile_info(self, volname: str, node: str = None,
-                     options: str = None, excep: bool = True) -> dict:
+                     options: str = '', excep: bool = True) -> dict:
         """
         Run profile info on the specified volume.
         Args:
@@ -70,7 +70,7 @@ class ProfileOps(AbstractOps):
         Example:
             profile_info(node, "testvol")
         """
-        if options is not None and not self.check_profile_options(options):
+        if options != '' and not self.check_profile_options(options):
             return None
         cmd = f"gluster volume profile {volname} info {options}"
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -64,7 +64,7 @@ class VolumeOps(AbstractOps):
         return ret
 
     def volume_mount(self, server: str, volname: str,
-                     path: str, node: str = None):
+                     path: str, node: str = None, excep: bool = True):
         """
         Mounts the gluster volume to the client's filesystem.
         Args:
@@ -73,6 +73,10 @@ class VolumeOps(AbstractOps):
             server (str): Hostname or IP address
             volname (str): Name of volume to be mounted
             path (str): The path of the mount directory(mount point)
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
 
         Returns:
             ret: A dictionary consisting
@@ -87,7 +91,7 @@ class VolumeOps(AbstractOps):
 
         cmd = f"mount -t glusterfs {server}:/{volname} {path}"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
         self.es.add_new_mountpath(volname, node, path)
         return ret
 
@@ -122,18 +126,22 @@ class VolumeOps(AbstractOps):
 
     def volume_create(self, volname: str, node: str, conf_hash: dict,
                       server_list: list, brick_root: list,
-                      force: bool = False):
+                      force: bool = False, excep: bool = True):
         """
         Create the gluster volume with specified configuration
         Args:
             volname(str): volume name that has to be created
             node(str): server on which command has to be executed
             conf_hash (dict): Config hash providing parameters for volume
-            creation.
+                              creation.
             server_list (list): List of servers
             brick_root (list): List of root path of bricks
             force (bool): If this option is set to True, then create volume
-            will get executed with force option.
+                          will get executed with force option.
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
 
         Returns:
             ret: A dictionary consisting
@@ -193,18 +201,22 @@ class VolumeOps(AbstractOps):
         if force:
             cmd = (f"{cmd} force")
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
         self.es.set_new_volume(volname, brick_dict)
 
         return ret
 
     def volume_start(self, volname: str, node: str = None,
-                     force: bool = False):
+                     force: bool = False, excep: bool = True):
         """
         Starts the gluster volume
         Args:
             node (str): Node on which cmd has to be executed.
             volname (str): Name of the volume to start
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
 
         Kwargs:
             force (bool): If this option is set to True, then start volume
@@ -226,17 +238,22 @@ class VolumeOps(AbstractOps):
         else:
             cmd = f"gluster volume start {volname} --mode=script --xml"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
         self.es.set_volume_start_status(volname, True)
 
         return ret
 
-    def volume_stop(self, volname: str, node: str = None, force: bool = False):
+    def volume_stop(self, volname: str, node: str = None, force: bool = False,
+                    excep: bool = True):
         """
         Stops the gluster volume
         Args:
             node (str): Node on which cmd has to be executed.
             volname (str): Name of the volume to stop
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Kwargs:
             force (bool): If this option is set to True, then start volume
                 will get executed with force option. If it is set to False,
@@ -257,18 +274,23 @@ class VolumeOps(AbstractOps):
         else:
             cmd = f"gluster volume stop {volname} --mode=script --xml"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
         self.es.set_volume_start_status(volname, False)
 
         return ret
 
-    def volume_delete(self, volname: str, node: str = None):
+    def volume_delete(self, volname: str, node: str = None,
+                      excep: bool = True):
         """
         Deletes the gluster volume if given volume exists in
         gluster.
         Args:
             node (str): Node on which cmd has to be executed.
             volname (str): Name of the volume to delete
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -282,7 +304,7 @@ class VolumeOps(AbstractOps):
 
         cmd = f"gluster volume delete {volname} --mode=script --xml"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
         self.es.add_data_to_cleands(self.es.get_brickdata(volname))
         self.es.remove_volume_data(volname)
         return ret

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -17,7 +17,8 @@ class VolumeOps(AbstractOps):
 
     def setup_volume(self, volname: str, node: str, conf_hash: dict,
                      server_list: list, brick_root: list,
-                     force: bool = False, create_only: bool = False):
+                     force: bool = False, create_only: bool = False,
+                     excep: bool = True):
         """
         Setup the gluster volume with specified configuration
         Args:
@@ -33,7 +34,10 @@ class VolumeOps(AbstractOps):
                                 False, will do volume create, start, set
                                 operation if any provided in the volume_config
                                 By default, value is set to False.
-
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Returns:
             ret: A dictionary consisting
                 - Flag : Flag to check if connection failed
@@ -52,7 +56,7 @@ class VolumeOps(AbstractOps):
 
         # Create volume
         ret = self.volume_create(volname, node, conf_hash, server_list,
-                                 brick_root, force)
+                                 brick_root, force, excep)
         if create_only:
             return ret
 
@@ -60,7 +64,7 @@ class VolumeOps(AbstractOps):
         sleep(2)
 
         # Start volume
-        ret = self.volume_start(volname, node)
+        ret = self.volume_start(volname, node, excep)
         return ret
 
     def volume_mount(self, server: str, volname: str,

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -1,0 +1,223 @@
+#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+    Test Description:
+    Tests to check basic profile operations.
+"""
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.profile_ops import (profile_start, profile_info,
+                                            profile_stop)
+from glustolibs.misc.misc_libs import upload_scripts
+from glustolibs.io.utils import validate_io_procs
+from glustolibs.gluster.brick_libs import get_all_bricks
+from glustolibs.gluster.lib_utils import is_core_file_created
+from glustolibs.gluster.gluster_init import is_glusterd_running
+from glustolibs.gluster.volume_ops import (volume_stop, volume_start,
+                                           get_volume_list)
+from glustolibs.gluster.volume_libs import (cleanup_volume, setup_volume)
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
+class TestProfileOpeartions(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+
+        # Uploading file_dir script in all client direcotries
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", cls.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts to clients %s"
+                                 % cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+        # Creating Volume and mounting volume.
+        ret = self.setup_volume_and_mount_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Volume creation or mount failed: %s"
+                                 % self.volname)
+        g.log.info("Volme created and mounted successfully : %s",
+                   self.volname)
+
+    def tearDown(self):
+
+        # Unmounting and cleaning volume.
+        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Unable to delete volume % s" % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        # clean up all volumes
+        vol_list = get_volume_list(self.mnode)
+        if not vol_list:
+            raise ExecutionError("Failed to get the volume list")
+        for volume in vol_list:
+            ret = cleanup_volume(self.mnode, volume)
+            if not ret:
+                raise ExecutionError("Unable to delete volume % s" % volume)
+            g.log.info("Volume deleted successfully : %s", volume)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_profile_operations(self):
+
+        # pylint: disable=too-many-statements
+        """
+        Test Case:
+        1) Create a volume and start it.
+        2) Mount volume on client and start IO.
+        3) Start profile info on the volume.
+        4) Run profile info with different parameters
+           and see if all bricks are present or not.
+        5) Stop profile on the volume.
+        6) Create another volume.
+        7) Start profile without starting the volume.
+        """
+
+        # Timestamp of current test case of start time
+        ret, test_timestamp, _ = g.run_local('date +%s')
+        test_timestamp = test_timestamp.strip()
+
+        # Start IO on mount points.
+        g.log.info("Starting IO on all mounts...")
+        self.all_mounts_procs = []
+        counter = 1
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dir-depth 4 "
+                   "--dir-length 6 "
+                   "--dirname-start-num %d "
+                   "--max-num-of-dirs 3 "
+                   "--num-of-files 5 %s"
+                   % (self.script_upload_path, counter,
+                      mount_obj.mountpoint))
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+            counter += 1
+
+        # Start profile on volume.
+        ret, _, _ = profile_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start profile on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully started profile on volume: %s",
+                   self.volname)
+
+        # Getting and checking output of profile info.
+        ret, out, _ = profile_info(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to run profile info on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully executed profile info on volume: %s",
+                   self.volname)
+
+        # Checking if all bricks are present in profile info.
+        brick_list = get_all_bricks(self.mnode, self.volname)
+        for brick in brick_list:
+            self.assertTrue(brick in out,
+                            "Brick %s not a part of profile info output."
+                            % brick)
+            g.log.info("Brick %s showing in profile info output.",
+                       brick)
+
+        # Running profile info with different profile options.
+        profile_options = ['peek', 'incremental', 'clear',
+                           'incremental peek', 'cumulative']
+        for option in profile_options:
+
+            # Getting and checking output of profile info.
+            ret, out, _ = profile_info(self.mnode, self.volname,
+                                       options=option)
+            self.assertEqual(ret, 0,
+                             "Failed to run profile info %s on volume: %s"
+                             % (option, self.volname))
+            g.log.info("Successfully executed profile info %s on volume: %s",
+                       option, self.volname)
+
+            # Checking if all bricks are present in profile info peek.
+            for brick in brick_list:
+                self.assertTrue(brick in out,
+                                "Brick %s not a part of profile"
+                                " info %s output."
+                                % (brick, option))
+                g.log.info("Brick %s showing in profile info %s output.",
+                           brick, option)
+
+        # Stop profile on volume.
+        ret, _, _ = profile_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to stop profile on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully stopped profile on volume: %s", self.volname)
+
+        # Validate IO
+        self.assertTrue(
+            validate_io_procs(self.all_mounts_procs, self.mounts),
+            "IO failed on some of the clients"
+        )
+        g.log.info("IO validation complete.")
+
+        # Create and start a volume
+        self.volume['name'] = "volume_2"
+        self.volname = "volume_2"
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertTrue(ret, "Failed to create and start volume")
+        g.log.info("Successfully created and started volume_2")
+
+        # Stop volume
+        ret, _, _ = volume_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to stop the volume %s"
+                         % self.volname)
+        g.log.info("Volume %s stopped successfully", self.volname)
+
+        # Start profile on volume.
+        ret, _, _ = profile_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start profile on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully started profile on volume: %s",
+                   self.volname)
+
+        # Start volume
+        ret, _, _ = volume_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start the volume %s"
+                         % self.volname)
+        g.log.info("Volume %s started successfully", self.volname)
+
+        # Chekcing for core files.
+        ret = is_core_file_created(self.servers, test_timestamp)
+        self.assertTrue(ret, "glusterd service should not crash")
+        g.log.info("No core file found, glusterd service running "
+                   "successfully")
+
+        # Checking whether glusterd is running or not
+        ret = is_glusterd_running(self.servers)
+        self.assertEqual(ret, 0, "Glusterd has crashed on nodes.")
+        g.log.info("No glusterd crashes observed.")

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -85,6 +85,7 @@ class TestCase(DParentTest):
 
         # Getting and checking output of profile info.
         ret = redant.profile_info(self.vol_name, self.server_list[0])
+        output = " ".join(ret['msg'])
 
         # Checking if all bricks are present in profile info.
         brick_list = redant.get_all_bricks(self.vol_name, self.server_list[0])
@@ -92,7 +93,7 @@ class TestCase(DParentTest):
             raise Exception("Failed to get brick list from volume")
         else:
             for brick in brick_list:
-                if brick not in ret['msg']:
+                if brick not in output:
                     raise Exception(f"Brick {brick} not a part of profile"
                                     f" info output.")
 
@@ -104,10 +105,11 @@ class TestCase(DParentTest):
             # Getting and checking output of profile info.
             redant.profile_info(self.vol_name, self.server_list[0],
                                 option)
+            output = " ".join(ret['msg'])
 
             # Checking if all bricks are present in profile info peek.
             for brick in brick_list:
-                if brick not in ret['msg']:
+                if brick not in output:
                     raise Exception(f"Brick {brick} not a part of profile"
                                     f" info output.")
 
@@ -143,7 +145,7 @@ class TestCase(DParentTest):
 
         # Check profile info on volume without starting profile
         ret = redant.profile_info(self.volume_name1, self.server_list[0],
-                                  None, False)
+                                  '', False)
         if ret['error_code'] == 0:
             raise Exception(f"Unexpected:Successfully ran profile info"
                             f" on volume: {self.volume_name1}")

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -19,7 +19,10 @@
     Tests to check basic profile operations.
 """
 
+import sys
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.profile_ops import (profile_start, profile_info,
@@ -40,7 +43,7 @@ class TestProfileOpeartions(GlusterBaseClass):
 
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
 
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
@@ -57,8 +60,7 @@ class TestProfileOpeartions(GlusterBaseClass):
                    cls.clients)
 
     def setUp(self):
-
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         # Creating Volume and mounting volume.
         ret = self.setup_volume_and_mount_volume(self.mounts)
         if not ret:
@@ -85,7 +87,7 @@ class TestProfileOpeartions(GlusterBaseClass):
                 raise ExecutionError("Unable to delete volume % s" % volume)
             g.log.info("Volume deleted successfully : %s", volume)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_profile_operations(self):
 
@@ -113,14 +115,14 @@ class TestProfileOpeartions(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dir-depth 4 "
                    "--dir-length 6 "
                    "--dirname-start-num %d "
                    "--max-num-of-dirs 3 "
-                   "--num-of-files 5 %s"
-                   % (self.script_upload_path, counter,
-                      mount_obj.mountpoint))
+                   "--num-of-files 5 %s" % (
+                       sys.version_info.major, self.script_upload_path,
+                       counter, mount_obj.mountpoint))
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)
             self.all_mounts_procs.append(proc)

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -47,7 +47,7 @@ class TestCase(DParentTest):
             self.redant.logger.error(tb)
         super().terminate()
 
-    def test_profile_operations(self, redant):
+    def run_test(self, redant):
         """
         Test Case:
         1) Create a volume and start it.

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -48,11 +48,9 @@ class TestProfileOpeartions(GlusterBaseClass):
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                   "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, script_local_path)
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts to clients %s"
                                  % cls.clients)

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,8 +18,6 @@
     Test Description:
     Tests to check basic profile operations.
 """
-
-import sys
 
 from glusto.core import Glusto as g
 
@@ -113,13 +111,13 @@ class TestProfileOpeartions(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dir-depth 4 "
                    "--dir-length 6 "
                    "--dirname-start-num %d "
                    "--max-num-of-dirs 3 "
                    "--num-of-files 5 %s" % (
-                       sys.version_info.major, self.script_upload_path,
+                       self.script_upload_path,
                        counter, mount_obj.mountpoint))
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)


### PR DESCRIPTION
Migrated TC [test_profile_operations](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_profile_operations.py) and merged TC [test_profile_info_without_having_profile_started](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_profile_info_without_having_profile_started.py) into it.

Fixes: #486 and Fixes: #487 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>