### PR TITLE
Migrated TC test_peer_detach

### DIFF
--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -4,7 +4,6 @@ holds APIS related to peers which will be called
 from the test case.
 """
 
-import re
 import random
 from time import sleep
 import socket
@@ -164,10 +163,9 @@ class PeerOps(AbstractOps):
             servers.remove(node)
 
         for server in servers:
-            ret = self.peer_detach(server, node, force)
+            ret = self.peer_detach(server, node, force, False)
             if (ret['error_code'] != 0
-                    or re.search(r'^peer\sdetach\:\ssuccess(.*)',
-                                 ret['msg'][0].rstrip('\n')) is None):
+                    or ret['msg']['output'] != 'success'):
                 self.logger.error(f"Failed to detach the node {server}")
                 return False
 

--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -39,7 +39,8 @@ class PeerOps(AbstractOps):
 
         return ret
 
-    def peer_detach(self, server: str, node: str, force: bool = False) -> dict:
+    def peer_detach(self, server: str, node: str, force: bool = False,
+                    excep: bool = True) -> dict:
         """
         Detach the specified server.
         Args:
@@ -47,6 +48,10 @@ class PeerOps(AbstractOps):
             node (str): Node on which command has to be executed.
             force (bool): if set to true will exceute the peer
                           detach command with force option.
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
 
         Kwargs:
             force (bool): option to detach peer. Defaults to False.
@@ -67,7 +72,7 @@ class PeerOps(AbstractOps):
         else:
             cmd = f"gluster --xml peer detach {server} --mode=script"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
 
         return ret
 

--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -76,10 +76,9 @@ class PeerOps(AbstractOps):
 
         for server in servers:
             if server not in nodes_in_pool_list:
-                ret = self.peer_probe(server, node)
+                ret = self.peer_probe(server, node, False)
                 if (ret['error_code'] != 0
-                        or re.search(r'^peer\sprobe\:\ssuccess(.*)',
-                                     ret['msg'][0].rstrip('\n')) is None):
+                        or ret['msg']['output'] != 'success'):
                     self.logger.error("Failed to peer probe the node"
                                       f" {server}")
                     return False

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -98,8 +98,8 @@ class DParentTest(metaclass=abc.ABCMeta):
         # Validate that glusterd is up and running in the servers.
         self.redant.start_glusterd(self.server_list)
 
-        # Validate all peers are in connected state.
-        self.redant.wait_till_all_peers_connected(self.server_list)
+        # Peer probe and validate all peers are in connected state.
+        self.redant.peer_probe_servers(self.server_list, self.server_list[0])
 
         try:
             self.redant.reset_volume_option('all', 'all', self.server_list[0])

--- a/tests/functional/glusterd/test_brick_port_after_stop_glusterd_modify_volume.py
+++ b/tests/functional/glusterd/test_brick_port_after_stop_glusterd_modify_volume.py
@@ -86,8 +86,8 @@ class TestCase(DParentTest):
         redant.start_glusterd(self.server_list[1])
         redant.wait_for_glusterd_to_start(self.server_list[1])
 
-        ret = redant.wait_for_peers_to_connect(self.server_list[0],
-                                               self.server_list[1])
+        ret = redant.wait_for_peers_to_connect(self.server_list[1],
+                                               self.server_list[0])
         if not ret:
             raise Exception("glusterd is not connected "
                             f"{self.server_list[0]} with peer "

--- a/tests/functional/glusterd/test_ops_when_one_node_is_down.py
+++ b/tests/functional/glusterd/test_ops_when_one_node_is_down.py
@@ -72,8 +72,8 @@ class TestCase(DParentTest):
         redant.logger.info("Glusterd start on the nodes succeeded")
 
         # Checking if peer is connected.
-        ret = redant.wait_for_peers_to_connect(self.server_list[0],
-                                               self.server_list)
+        ret = redant.wait_for_peers_to_connect(self.server_list,
+                                               self.server_list[0])
         if not ret:
             raise Exception("Failed : All the peer are not connected")
         redant.logger.info("Peers is in connected state.")

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -122,6 +122,15 @@ class PeerDetachVerification(GlusterBaseClass):
                             % self.servers[1])
         msg = ('peer detach: failed: Brick(s) with the peer ' +
                self.servers[1] + ' ' + 'exist in cluster')
+        if msg not in err:
+            msg = ('peer detach: failed: Peer ' + self.servers[1] +
+                   ' hosts one or more bricks. ' +
+                   'If the peer is in not recoverable ' +
+                   'state then use either ' +
+                   'replace-brick or remove-brick command ' +
+                   'with force to remove ' +
+                   'all bricks from the peer and ' +
+                   'attempt the peer detach again.')
         self.assertIn(msg, err, "Peer detach not failed with "
                                 "proper error message")
 
@@ -133,5 +142,12 @@ class PeerDetachVerification(GlusterBaseClass):
                                     "option : %s" % self.servers[1])
         msg = ('peer detach: failed: Brick(s) with the peer ' +
                self.servers[1] + ' ' + 'exist in cluster')
-        self.assertIn(msg, err, "Peer detach not failed with proper "
-                                "error message with force option")
+        if msg not in err:
+            msg = ('peer detach: failed: Peer ' + self.servers[1] +
+                   ' hosts one or more bricks. ' +
+                   'If the peer is in not recoverable ' +
+                   'state then use either ' +
+                   'replace-brick or remove-brick command ' +
+                   'with force to remove ' +
+                   'all bricks from the peer and ' +
+                   'attempt the peer detach again.')

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -151,3 +151,5 @@ class PeerDetachVerification(GlusterBaseClass):
                    'with force to remove ' +
                    'all bricks from the peer and ' +
                    'attempt the peer detach again.')
+        self.assertIn(msg, err, "Peer detach not failed with "
+                                "proper error message")

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -68,7 +68,7 @@ class PeerDetachVerification(GlusterBaseClass):
         # Assigning non existing host to variable
         self.non_exist_host = '256.256.256.256'
 
-        # Assigning invalid ip to vaiable
+        # Assigning invalid ip to variable
         self.invalid_ip = '10.11.a'
 
         # Peer detach to specified server

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -1,98 +1,84 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-Test Cases in this module related to Glusterd peer detach.
+ Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+   Test Cases in this module related to Glusterd peer detach.
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.peer_ops import peer_detach
-from glustolibs.gluster.peer_ops import peer_probe_servers
-from glustolibs.gluster.lib_utils import is_core_file_created
-from glustolibs.gluster.volume_ops import volume_stop, volume_start
+
+import traceback
+from tests.d_parent_test import DParentTest
+
+# disruptive;
 
 
-@runs_on([['replicated', 'distributed-dispersed'], ['glusterfs']])
-class PeerDetachVerification(GlusterBaseClass):
-    """
-    Test that peer detach works as expected
-    """
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
+class TestCase(DParentTest):
 
-        # checking for peer status from every node
-        ret = cls.validate_peers_are_connected()
-        if not ret:
-            raise ExecutionError("Peer probe failed ")
-        else:
-            g.log.info("All server peers are already in connected state "
-                       "%s:", cls.servers)
+    def terminate(self):
+        """
+        In case one of the peers get detached accidentally, we need to
+        re-probe it and delete the volumes created in the TC
+        """
+        try:
+            # ret = self.redant.peer_probe_servers(self.server_list[0],
+            #                                     self.server_list)
+            # if not ret:
+            #    raise Exception("Peer probing failed on some of the servers")
+            self.redant.cleanup_volume(self.volume_name, self.server_list[0])
 
-    def tearDown(self):
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-        ret = peer_probe_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Failed to peer probe servers")
+    def _check_detach_error_message(self, use_force=True):
+        """
+        Check detach peer when volume exists
+        """
+        ret = self.redant.peer_detach(self.server_list[1],
+                                      self.server_list[0],
+                                      use_force, False)
+        if ret['error_code'] == 0:
+            raise Exception(f"Server detach should have failed: "
+                            f"{self.server_list[1]}")
+        err_msg = (f"peer detach: failed: Peer {self.server_list[1]} hosts"
+                   " one or more bricks. If the peer is in not recoverable"
+                   " state then use either replace-brick or remove-brick"
+                   " command with force to remove all bricks from the peer"
+                   " and attempt the peer detach again.")
+        if err_msg not in " ".join(ret['err_msg']):
+            raise Exception("Peer detach didn't fail with proper error msg")
 
-        # stopping the volume and Cleaning up the volume
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    # A local function to detach peer when volume exists
-    def check_detach_error_message(self, use_force=True):
-        ret, _, err = peer_detach(self.mnode, self.servers[1],
-                                  force=use_force)
-        self.assertNotEqual(ret, 0, "detach server should fail: %s"
-                            % self.servers[1])
-        msg = ('peer detach: failed: Brick(s) with the peer ' +
-               self.servers[1] + ' ' + 'exist in cluster')
-        if msg not in err:
-            msg = ('peer detach: failed: Peer ' + self.servers[1] +
-                   ' hosts one or more bricks. ' +
-                   'If the peer is in not recoverable ' +
-                   'state then use either ' +
-                   'replace-brick or remove-brick command ' +
-                   'with force to remove ' +
-                   'all bricks from the peer and ' +
-                   'attempt the peer detach again.')
-            self.assertIn(msg, err, "Peer detach not failed with "
-                          "proper error message")
-
-    def test_peer_detach_host(self):
-        # pylint: disable = too-many-statements
-        # peer Detaching specified server from cluster
-        # peer Detaching detached server again and checking the error msg
-        # peer Detaching invalid host
-        # peer Detaching Non exist host
-        # peer Checking Core file created or not
-        # Peer detach one node which contains the bricks of volume created
-        # Peer detach force a node which is hosting bricks of a volume
-        # Peer detach one node which hosts bricks of offline volume
-        # Peer detach force a node which hosts bricks of offline volume
+    def run_test(self, redant):
+        """
+        - peer Detaching specified server from cluster
+        - peer Detaching detached server again and checking the error msg
+        - peer Detaching invalid host
+        - peer Detaching Non exist host
+        - peer Checking Core file created or not
+        - Peer detach one node which contains the bricks of volume created
+        - Peer detach force a node which is hosting bricks of a volume
+        - Peer detach one node which hosts bricks of offline volume
+        - Peer detach force a node which hosts bricks of offline volume
+        """
 
         # Timestamp of current test case of start time
-        ret, test_timestamp, _ = g.run_local('date +%s')
-        test_timestamp = test_timestamp.strip()
+        ret = redant.execute_abstract_op_node('date +%s', self.server_list[0])
+        test_timestamp = ret['msg'][0].rstrip('\n')
 
         # Assigning non existing host to variable
         self.non_exist_host = '256.256.256.256'
@@ -101,78 +87,62 @@ class PeerDetachVerification(GlusterBaseClass):
         self.invalid_ip = '10.11.a'
 
         # Peer detach to specified server
-        g.log.info("Start detach specified server :%s", self.servers[1])
-        ret, _, _ = peer_detach(self.mnode, self.servers[1])
-        self.assertEqual(ret, 0, "Failed to detach server :%s"
-                         % self.servers[1])
+        redant.peer_detach(self.server_list[1], self.server_list[0])
 
         # Detached server detaching again, Expected to fail detach
-        g.log.info("Start detached server detaching "
-                   "again : %s", self.servers[1])
-        ret, _, err = peer_detach(self.mnode, self.servers[1])
-        self.assertNotEqual(ret, 0, "Detach server should "
-                                    "fail :%s" % self.servers[1])
-        self.assertEqual(err, "peer detach: failed: %s is not part of "
-                              "cluster\n" % self.servers[1], "Peer "
-                         "Detach didn't fail as expected")
+        ret = redant.peer_detach(self.server_list[1], self.server_list[0],
+                                 False, False)
+        if ret['error_code'] == 0:
+            raise Exception(f"Server detach should have failed: "
+                            f"{self.server_list[1]}")
+        err_msg = (f"peer detach: failed: {self.server_list[1]} is not part"
+                   "cluster\n")
+        if err_msg not in ret['err_msg'][0]:
+            raise Exception("Peer detach didn't fail as expected")
 
         # Probing detached server
-        g.log.info("Start probing detached server : %s", self.servers[1])
-        ret = peer_probe_servers(self.mnode, self.servers[1])
-        self.assertTrue(ret, "Peer probe failed from %s to other "
-                        "server : %s" % (self.mnode, self.servers[1]))
+        redant.peer_probe(self.server_list[1], self.server_list[0])
 
         # Detach invalid host
-        g.log.info("Start detaching invalid host :%s ", self.invalid_ip)
-        ret, _, _ = peer_detach(self.mnode, self.invalid_ip)
-        self.assertNotEqual(ret, 0, "Detach invalid host should "
-                                    "fail :%s" % self.invalid_ip)
+        ret = redant.peer_detach(self.invalid_ip, self.server_list[0],
+                                 False, False)
+        if ret['error_code'] == 0:
+            raise Exception(f"Server detach invalid host should have "
+                            f"failed: {self.invalid_ip}")
 
         # Detach non exist host
-        g.log.info("Start detaching non exist host : %s", self.non_exist_host)
-        ret, _, _ = peer_detach(self.mnode, self.non_exist_host)
-        self.assertNotEqual(ret, 0, "Detach non existing host "
-                                    "should fail :%s" % self.non_exist_host)
+        ret = redant.peer_detach(self.non_exist_host, self.server_list[0],
+                                 False, False)
+        if ret['error_code'] == 0:
+            raise Exception(f"Server detach non exist host should have "
+                            f"failed: {self.non_exist_host}")
 
         # Creating Volume
-        g.log.info("Started creating volume: %s", self.volname)
-        ret = self.setup_volume()
-        self.assertTrue(ret, "Volume creation failed: %s" % self.volname)
+        volume_type = 'dist'
+        self.volume_name = f"{self.test_name}-{volume_type}-1"
+        redant.setup_volume(self.volume_name, self.server_list[0],
+                            self.vol_type_inf[self.conv_dict[volume_type]],
+                            self.server_list, self.brick_roots)
 
         # Peer detach one node which contains the bricks of the volume created
-        g.log.info("Start detaching server %s which is hosting "
-                   "bricks of a volume", self.servers[1])
-        self.check_detach_error_message(use_force=False)
+        self._check_detach_error_message(False)
 
         #  Peer detach force a node which is hosting bricks of a volume
-        g.log.info("Start detaching server using force %s which is hosting "
-                   "bricks of a volume", self.servers[1])
-        self.check_detach_error_message()
+        self._check_detach_error_message()
 
         # Peer detach one node which contains bricks of an offline volume
-        g.log.info("stopping the volume")
-        ret, _, err = volume_stop(self.mnode, self.volname)
-        msg = ('volume stop: ' + 'self.volname' + ': failed: Volume ' +
-               'self.volname' + ' is not in the started state\n')
-        if msg not in err:
-            self.assertEqual(ret, 0, "stopping volume %s failed"
-                             % self.volname)
-        g.log.info("Start to detach server %s which is hosting "
-                   "bricks of an offline volume", self.servers[1])
-        self.check_detach_error_message(use_force=False)
+        redant.volume_stop(self.volume_name, self.server_list[0])
+
+        self._check_detach_error_message(use_force=False)
 
         # Forceful Peer detach node which hosts bricks of offline volume
-        g.log.info("start detaching server %s with force option "
-                   "which is hosting bricks of a volume", self.servers[1])
-        self.check_detach_error_message()
+        self._check_detach_error_message()
 
         # starting volume for proper cleanup
-        ret, _, _ = volume_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "volume start failed")
+        redant.volume_start(self.volume_name, self.server_list[0])
 
         # Checking core. file created or not in "/", "/tmp", "/log/var/core
         # directory
-        ret = is_core_file_created(self.servers, test_timestamp)
-        self.assertTrue(ret, "glusterd service should not crash")
-        g.log.info("No core file found, glusterd service running "
-                   "successfully")
+        ret = redant.check_core_file_exists(self.server_list, test_timestamp)
+        if ret:
+            raise Exception("glusterd service should not have crashed")

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -14,8 +14,8 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-""" Description:
-        Test Cases in this module related to Glusterd peer detach.
+"""
+Test Cases in this module related to Glusterd peer detach.
 """
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
@@ -28,6 +28,9 @@ from glustolibs.gluster.lib_utils import is_core_file_created
 @runs_on([['distributed', 'replicated', 'distributed-replicated',
            'dispersed', 'distributed-dispersed'], ['glusterfs']])
 class PeerDetachVerification(GlusterBaseClass):
+    """
+    Test that peer detach works as expected
+    """
     @classmethod
     def setUpClass(cls):
         GlusterBaseClass.setUpClass.im_func(cls)
@@ -38,14 +41,14 @@ class PeerDetachVerification(GlusterBaseClass):
             raise ExecutionError("Peer probe failed ")
         else:
             g.log.info("All server peers are already in connected state "
-                       "%s:" % cls.servers)
+                       "%s:", cls.servers)
 
     @classmethod
     def tearDownClass(cls):
         # stopping the volume and Cleaning up the volume
         ret = cls.cleanup_volume()
         if ret:
-            g.log.info("Volume deleted successfully : %s" % cls.volname)
+            g.log.info("Volume deleted successfully : %s", cls.volname)
         else:
             raise ExecutionError("Failed Cleanup the Volume %s" % cls.volname)
 
@@ -69,33 +72,33 @@ class PeerDetachVerification(GlusterBaseClass):
         self.invalid_ip = '10.11.a'
 
         # Peer detach to specified server
-        g.log.info("Start detach specified server :%s" % self.servers[1])
-        ret, out, _ = peer_detach(self.mnode, self.servers[1])
+        g.log.info("Start detach specified server :%s", self.servers[1])
+        ret, _, _ = peer_detach(self.mnode, self.servers[1])
         self.assertEqual(ret, 0, "Failed to detach server :%s"
                          % self.servers[1])
 
         # Detached server detaching again, Expected to fail detach
         g.log.info("Start detached server detaching "
-                   "again : %s" % self.servers[1])
-        ret, out, _ = peer_detach(self.mnode, self.servers[1])
+                   "again : %s", self.servers[1])
+        ret, _, _ = peer_detach(self.mnode, self.servers[1])
         self.assertNotEqual(ret, 0, "Detach server should "
                                     "fail :%s" % self.servers[1])
 
         # Probing detached server
-        g.log.info("Start probing detached server : %s" % self.servers[1])
+        g.log.info("Start probing detached server : %s", self.servers[1])
         ret = peer_probe_servers(self.mnode, self.servers[1])
         self.assertTrue(ret, "Peer probe failed from %s to other "
                         "server : %s" % (self.mnode, self.servers[1]))
 
         # Detach invalid host
-        g.log.info("Start detaching invalid host :%s " % self.invalid_ip)
-        ret, out, _ = peer_detach(self.mnode, self.invalid_ip)
+        g.log.info("Start detaching invalid host :%s ", self.invalid_ip)
+        ret, _, _ = peer_detach(self.mnode, self.invalid_ip)
         self.assertNotEqual(ret, 0, "Detach invalid host should "
                                     "fail :%s" % self.invalid_ip)
 
         # Detach non exist host
-        g.log.info("Start detaching non exist host : %s" % self.non_exist_host)
-        ret, out, _ = peer_detach(self.mnode, self.non_exist_host)
+        g.log.info("Start detaching non exist host : %s", self.non_exist_host)
+        ret, _, _ = peer_detach(self.mnode, self.non_exist_host)
         self.assertNotEqual(ret, 0, "Detach non existing host "
                                     "should fail :%s" % self.non_exist_host)
 
@@ -107,14 +110,14 @@ class PeerDetachVerification(GlusterBaseClass):
                    "successfully")
 
         # Creating Volume
-        g.log.info("Started creating volume: %s" % self.volname)
+        g.log.info("Started creating volume: %s", self.volname)
         ret = self.setup_volume()
         self.assertTrue(ret, "Volume creation failed: %s" % self.volname)
 
         # Peer detach one node which contains the bricks of the volume created
         g.log.info("Start detaching server %s which is hosting "
-                   "bricks of a volume" % self.servers[1])
-        ret, out, err = peer_detach(self.mnode, self.servers[1])
+                   "bricks of a volume", self.servers[1])
+        ret, _, err = peer_detach(self.mnode, self.servers[1])
         self.assertNotEqual(ret, 0, "detach server should fail: %s"
                             % self.servers[1])
         msg = ('peer detach: failed: Brick(s) with the peer ' +
@@ -124,8 +127,8 @@ class PeerDetachVerification(GlusterBaseClass):
 
         #  Peer detach force a node which is hosting bricks of a volume
         g.log.info("start detaching server %s with force option "
-                   "which is hosting bricks of a volume" % self.servers[1])
-        ret, out, err = peer_detach(self.mnode, self.servers[1], force=True)
+                   "which is hosting bricks of a volume", self.servers[1])
+        ret, _, err = peer_detach(self.mnode, self.servers[1], force=True)
         self.assertNotEqual(ret, 0, "detach server should fail with force "
                                     "option : %s" % self.servers[1])
         msg = ('peer detach: failed: Brick(s) with the peer ' +

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -33,10 +33,10 @@ class TestCase(DParentTest):
         re-probe it and delete the volumes created in the TC
         """
         try:
-            # ret = self.redant.peer_probe_servers(self.server_list[0],
-            #                                     self.server_list)
-            # if not ret:
-            #    raise Exception("Peer probing failed on some of the servers")
+            ret = self.redant.peer_probe_servers(self.server_list,
+                                                 self.server_list[0])
+            if not ret:
+                raise Exception("Peer probing failed on some of the servers")
             self.redant.cleanup_volume(self.volume_name, self.server_list[0])
 
         except Exception as error:
@@ -60,7 +60,7 @@ class TestCase(DParentTest):
                    " state then use either replace-brick or remove-brick"
                    " command with force to remove all bricks from the peer"
                    " and attempt the peer detach again.")
-        if err_msg not in " ".join(ret['err_msg']):
+        if err_msg not in " ".join(ret['error_msg']):
             raise Exception("Peer detach didn't fail with proper error msg")
 
     def run_test(self, redant):
@@ -97,7 +97,7 @@ class TestCase(DParentTest):
                             f"{self.server_list[1]}")
         err_msg = (f"peer detach: failed: {self.server_list[1]} is not part"
                    "cluster\n")
-        if err_msg not in ret['err_msg'][0]:
+        if err_msg not in " ".join(ret['error_msg'][0]):
             raise Exception("Peer detach didn't fail as expected")
 
         # Probing detached server

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -43,14 +43,20 @@ class PeerDetachVerification(GlusterBaseClass):
             g.log.info("All server peers are already in connected state "
                        "%s:", cls.servers)
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
+
+        ret = peer_probe_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Failed to peer probe servers")
+
         # stopping the volume and Cleaning up the volume
-        ret = cls.cleanup_volume()
-        if ret:
-            g.log.info("Volume deleted successfully : %s", cls.volname)
-        else:
-            raise ExecutionError("Failed Cleanup the Volume %s" % cls.volname)
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed Cleanup the Volume %s" % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()
 
     def test_peer_detach_host(self):
         # peer Detaching specified server from cluster

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -1,0 +1,134 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+        Test Cases in this module related to Glusterd peer detach.
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.peer_ops import peer_detach
+from glustolibs.gluster.peer_ops import peer_probe_servers
+from glustolibs.gluster.lib_utils import is_core_file_created
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
+class PeerDetachVerification(GlusterBaseClass):
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+
+        # checking for peer status from every node
+        ret = cls.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peer probe failed ")
+        else:
+            g.log.info("All server peers are already in connected state "
+                       "%s:" % cls.servers)
+
+    @classmethod
+    def tearDownClass(cls):
+        # stopping the volume and Cleaning up the volume
+        ret = cls.cleanup_volume()
+        if ret:
+            g.log.info("Volume deleted successfully : %s" % cls.volname)
+        else:
+            raise ExecutionError("Failed Cleanup the Volume %s" % cls.volname)
+
+    def test_peer_detach_host(self):
+        # peer Detaching specified server from cluster
+        # peer Detaching detached server again
+        # peer Detaching invalid host
+        # peer Detaching Non exist host
+        # peer Checking Core file created or not
+        # Peer detach one node which contains the bricks of volume created
+        # Peer detach force a node which is hosting bricks of a volume
+
+        # Timestamp of current test case of start time
+        ret, test_timestamp, _ = g.run_local('date +%s')
+        test_timestamp = test_timestamp.strip()
+
+        # Assigning non existing host to variable
+        self.non_exist_host = '256.256.256.256'
+
+        # Assigning invalid ip to vaiable
+        self.invalid_ip = '10.11.a'
+
+        # Peer detach to specified server
+        g.log.info("Start detach specified server :%s" % self.servers[1])
+        ret, out, _ = peer_detach(self.mnode, self.servers[1])
+        self.assertEqual(ret, 0, "Failed to detach server :%s"
+                         % self.servers[1])
+
+        # Detached server detaching again, Expected to fail detach
+        g.log.info("Start detached server detaching "
+                   "again : %s" % self.servers[1])
+        ret, out, _ = peer_detach(self.mnode, self.servers[1])
+        self.assertNotEqual(ret, 0, "Detach server should "
+                                    "fail :%s" % self.servers[1])
+
+        # Probing detached server
+        g.log.info("Start probing detached server : %s" % self.servers[1])
+        ret = peer_probe_servers(self.mnode, self.servers[1])
+        self.assertTrue(ret, "Peer probe failed from %s to other "
+                        "server : %s" % (self.mnode, self.servers[1]))
+
+        # Detach invalid host
+        g.log.info("Start detaching invalid host :%s " % self.invalid_ip)
+        ret, out, _ = peer_detach(self.mnode, self.invalid_ip)
+        self.assertNotEqual(ret, 0, "Detach invalid host should "
+                                    "fail :%s" % self.invalid_ip)
+
+        # Detach non exist host
+        g.log.info("Start detaching non exist host : %s" % self.non_exist_host)
+        ret, out, _ = peer_detach(self.mnode, self.non_exist_host)
+        self.assertNotEqual(ret, 0, "Detach non existing host "
+                                    "should fail :%s" % self.non_exist_host)
+
+        # Chekcing core. file created or not in "/", "/tmp", "/log/var/core
+        # directory
+        ret = is_core_file_created(self.servers, test_timestamp)
+        self.assertTrue(ret, "glusterd service should not crash")
+        g.log.info("No core file found, glusterd service running "
+                   "successfully")
+
+        # Creating Volume
+        g.log.info("Started creating volume: %s" % self.volname)
+        ret = self.setup_volume()
+        self.assertTrue(ret, "Volume creation failed: %s" % self.volname)
+
+        # Peer detach one node which contains the bricks of the volume created
+        g.log.info("Start detaching server %s which is hosting "
+                   "bricks of a volume" % self.servers[1])
+        ret, out, err = peer_detach(self.mnode, self.servers[1])
+        self.assertNotEqual(ret, 0, "detach server should fail: %s"
+                            % self.servers[1])
+        msg = ('peer detach: failed: Brick(s) with the peer ' +
+               self.servers[1] + ' ' + 'exist in cluster')
+        self.assertIn(msg, err, "Peer detach not failed with "
+                                "proper error message")
+
+        #  Peer detach force a node which is hosting bricks of a volume
+        g.log.info("start detaching server %s with force option "
+                   "which is hosting bricks of a volume" % self.servers[1])
+        ret, out, err = peer_detach(self.mnode, self.servers[1], force=True)
+        self.assertNotEqual(ret, 0, "detach server should fail with force "
+                                    "option : %s" % self.servers[1])
+        msg = ('peer detach: failed: Brick(s) with the peer ' +
+               self.servers[1] + ' ' + 'exist in cluster')
+        self.assertIn(msg, err, "Peer detach not failed with proper "
+                                "error message with force option")

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -33,7 +33,7 @@ class PeerDetachVerification(GlusterBaseClass):
     """
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
 
         # checking for peer status from every node
         ret = cls.validate_peers_are_connected()

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -85,13 +85,7 @@ class TestCase(DParentTest):
 
         # Perform peer probe from N1 to N2
         try:
-            ret = redant.peer_probe(self.server_list[1], self.server_list[0])
-            raise Exception("peer probe is success from "
-                            f"{self.server_list[0]} to "
-                            f"{self.server_list[1]} even if "
-                            f"{self.server_list[1]} "
-                            " is a part of another cluster or having "
-                            "volumes  configured")
+            redant.peer_probe(self.server_list[1], self.server_list[0])
         except Exception:
             redant.logger.info("Expected: peer probe failed from "
                                f"{self.server_list[0]} "
@@ -105,13 +99,13 @@ class TestCase(DParentTest):
             redant.cleanup_volume(volname, volume_nodes[0])
 
         # Perform peer probe from N1 to N2 should success
-        ret = redant.peer_probe(self.server_list[1], self.server_list[0])
+        redant.peer_probe(self.server_list[1], self.server_list[0])
 
         # Checking if peer is connected
         counter = 0
         while counter < 30:
-            ret = redant.is_peer_connected(self.server_list[0],
-                                           self.server_list[1])
+            ret = redant.is_peer_connected(self.server_list[1],
+                                           self.server_list[0])
             counter += 1
             if ret:
                 break
@@ -121,12 +115,7 @@ class TestCase(DParentTest):
 
         # Perform peer probe from N3 to N2 should fail
         try:
-            ret = redant.peer_probe(self.server_list[2], self.server_list[1])
-            raise Exception("peer probe is success from "
-                            f"{self.server_list[2]} "
-                            f"to {self.server_list[1]} even if "
-                            f"{self.server_list[1]} is a part of another "
-                            "cluster or having volumes configured")
+            redant.peer_probe(self.server_list[2], self.server_list[1])
         except Exception:
             redant.logger.info("Expected: peer probe failed from "
                                f"{self.server_list[2]} to "
@@ -143,25 +132,20 @@ class TestCase(DParentTest):
 
         # Perform peer probe from N3 to N1 should fail
         try:
-            ret = redant.peer_probe(self.server_list[0], self.server_list[2])
-            raise Exception("peer probe is success from "
-                            f"{self.server_list[2]} "
-                            f"to {self.server_list[0]} even if "
-                            f"{self.server_list[0]} is a part of another "
-                            "cluster or having volumes configured")
+            redant.peer_probe(self.server_list[0], self.server_list[2])
         except Exception:
             redant.logger.info("Expected: peer probe failed from "
                                f"{self.server_list[2]} to "
                                f"{self.server_list[0]} as expected")
 
         # Perform peer probe from N1 to N3 should succed
-        ret = redant.peer_probe(self.server_list[2], self.server_list[0])
+        redant.peer_probe(self.server_list[2], self.server_list[0])
 
         # Checking if peer is connected
         counter = 0
         while counter < 30:
-            ret = redant.is_peer_connected(self.server_list[0],
-                                           self.server_list[:3])
+            ret = redant.is_peer_connected(self.server_list[:3],
+                                           self.server_list[0])
             counter += 1
             if ret:
                 break

--- a/tests/functional/glusterd/test_probe_glusterd.py
+++ b/tests/functional/glusterd/test_probe_glusterd.py
@@ -46,22 +46,19 @@ class TestCase(NdParentTest):
 
         # Peer probe checks for non existing host
         try:
-            ret = redant.peer_probe(non_exist_host, self.server_list[0])
-        except Exception as error:
+            redant.peer_probe(non_exist_host, self.server_list[0])
+        except Exception:
             redant.logger.info("Peer probe failed for non-existing server")
-            redant.logger.info(f"Error: {error}")
 
         try:
-            ret = redant.peer_probe(invalid_ip, self.server_list[0])
-        except Exception as error:
+            redant.peer_probe(invalid_ip, self.server_list[0])
+        except Exception:
             redant.logger.info("Peer probe failed for invalid IP")
-            redant.logger.info(f"Error: {error}")
 
         try:
-            ret = redant.peer_probe(non_exist_ip, self.server_list[0])
-        except Exception as error:
+            redant.peer_probe(non_exist_ip, self.server_list[0])
+        except Exception:
             redant.logger.info("Peer probe failed for non-existing IP")
-            redant.logger.info(f"Error: {error}")
 
         # Checks Glusterd services running or not after peer probe
         # to invalid host and non existing host

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -88,16 +88,17 @@ class TestCase(DParentTest):
             ret = redant.execute_abstract_op_node("hostname -s", server)
             hostname = ret['msg'][0].rstrip('\n')
 
-            ret = redant.peer_probe(hostname, self.server_list[0])
+            redant.peer_probe(hostname, self.server_list[0], False)
 
-            if not ret:
+            if ret['error_code'] != 0:
                 ret = redant.execute_abstract_op_node("hostname",
                                                       server)
                 hostname = ret['msg'][0].rstrip('\n')
                 hostname = hostname.split(".")[0]+"."+hostname.split(".")[1]
-                ret = redant.peer_probe(hostname, self.server_list[0])
+                ret = redant.peer_probe(hostname, self.server_list[0],
+                                        False)
 
-                if not ret:
+                if ret['error_code'] != 0:
                     raise Exception(f"Unable to peer probe to"
                                     f" the server {hostname}")
 

--- a/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_level_option_to_cluster.py
@@ -58,7 +58,7 @@ class TestCase(NdParentTest):
         redant.logger.info("Glusterd is running on all the servers")
 
         # Checking if all the peers are in connected state or not.
-        ret = redant.is_peer_connected(self.server_list[0], self.server_list)
+        ret = redant.is_peer_connected(self.server_list, self.server_list[0])
         if not ret:
             raise Exception("All peers are not in connected state.")
 
@@ -84,7 +84,7 @@ class TestCase(NdParentTest):
         redant.logger.info("Glusterd is running on all the servers")
 
         # Checking if all the peers are in connected state or not.
-        ret = redant.is_peer_connected(self.server_list[0], self.server_list)
+        ret = redant.is_peer_connected(self.server_list, self.server_list[0])
         if not ret:
             raise Exception("All peers are not in connected state.")
 

--- a/tests/functional/glusterd/test_validate_peer_probe_ip_fqdn_hostname.py
+++ b/tests/functional/glusterd/test_validate_peer_probe_ip_fqdn_hostname.py
@@ -99,7 +99,7 @@ class TestPeerProbeScenarios(DParentTest):
             redant.peer_probe(host_node[self.by_type], self.server_list[0])
 
             # Verify Peer pool list and check whether the node exists or not
-            redant.is_peer_connected(host_node['ip'], self.server_list[0])
+            redant.is_peer_connected(self.server_list[0], host_node['ip'])
 
             # Verify command history for successful peer probe status
             self._verify_cmd_history(redant, host_node[self.by_type])

--- a/tests/nd_parent_test.py
+++ b/tests/nd_parent_test.py
@@ -82,8 +82,8 @@ class NdParentTest(metaclass=abc.ABCMeta):
         # Validate that glusterd is up and running in the servers.
         self.redant.start_glusterd(self.server_list)
 
-        # Validate all peers are in connected state.
-        self.redant.wait_till_all_peers_connected(self.server_list)
+        # Peer probe and validate all peers are in connected state.
+        self.redant.peer_probe_servers(self.server_list, self.server_list[0])
 
         if self.volume_type != "Generic":
             try:


### PR DESCRIPTION
Migrated TC [test_peer_detach](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_peer_detach.py)
Also, added the ops `peer_probe_servers` and `peer_detach_servers`.
Updated the peer ops to follow the same pattern of params declaration, i.e, first the list/str of servers and then the node to perform the operation.

Fixes: #505 and Fixes: #480
Updates: #292 

Signed-off-by: nik-redhat <nladha@redhat.com>