### PR TITLE
TestFix: Remove the None check for volume_status

### DIFF
--- a/tests/functional/glusterd/test_volume_set_when_glusterd_stopped_on_one_node.py
+++ b/tests/functional/glusterd/test_volume_set_when_glusterd_stopped_on_one_node.py
@@ -114,19 +114,11 @@ class TestCase(DParentTest):
             raise Exception("Failed to start glusterd on node"
                             f"{self.random_server}")
 
-        # Check volume state
-        ret = redant.wait_for_vol_to_come_online(self.vol_name,
-                                                 self.random_server)
-        if not ret:
-            raise Exception("Volume is not started, after starting glusterd")
-
         # Confirm if all the bricks are online or not
         count = 0
         while count < 10:
             list2 = redant.get_online_bricks_list(self.vol_name,
                                                   self.server_list[0])
-            if list2 is None:
-                raise Exception("Failed to get online brick list")
             if list1 == list2:
                 break
             sleep(2)


### PR DESCRIPTION
Remove the none check from the `get_online_bricks_list` return value so as to consider the race scenario while starting a volume immediately after the glusterd start.

Signed-off-by: nik-redhat <nladha@redhat.com>