### PR TITLE
Migrated TC test_glusterd_default_volume_behaviour_quorum_options

### DIFF
--- a/common/mixin.py
+++ b/common/mixin.py
@@ -14,11 +14,12 @@ from .ops.gluster_ops.brick_ops import BrickOps
 from .ops.gluster_ops.profile_ops import ProfileOps
 from .ops.gluster_ops.rebalance_ops import RebalanceOps
 from .ops.gluster_ops.mount_ops import MountOps
+from .ops.gluster_ops.heal_ops import HealOps
 
 
 class RedantMixin(GlusterOps, VolumeOps, BrickOps, PeerOps,
                   IoOps, MachineOps, MountOps, ProfileOps, RebalanceOps,
-                  Rexe, Logger):
+                  HealOps, Rexe, Logger):
     """
     A mixin class for redant project to encompass all ops, support
     modules and encapsulates the object responsible for the framework

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -708,3 +708,23 @@ class BrickOps:
         # Wait till all said bricks are online.
         return self.wait_for_bricks_to_come_online(volname, server_list,
                                                    brick_list, timeout)
+
+    def get_brick_processes_count(self, node: str) -> int:
+        """
+        Get the brick process count for a given node.
+
+        Args:
+            node (str): Node on which brick process has to be counted.
+
+        Returns:
+            int: Number of brick processes running on the node.
+            None: If the command fails to execute.
+        """
+        ret = self.execute_abstract_op_node("pgrep -x glusterfsd", node,
+                                            False)
+        if ret['error_code'] == 0:
+            list_of_pids = ret['msg']
+            list_of_pids = [pid.rstrip('\n') for pid in list_of_pids]
+            return len(list_of_pids)
+        else:
+            return None

--- a/common/ops/gluster_ops/gluster_ops.py
+++ b/common/ops/gluster_ops/gluster_ops.py
@@ -236,7 +236,7 @@ class GlusterOps(AbstractOps):
         it till the timeout is reached.
 
         Args:
-            node (str): Node on which this is to be executed.
+            node (str|list): Node on which this is to be executed.
             timeout (int) : We cannot wait till eternity right :p
 
         Returns:

--- a/common/ops/gluster_ops/heal_ops.py
+++ b/common/ops/gluster_ops/heal_ops.py
@@ -1,0 +1,107 @@
+"""
+Heal ops module deals with the functions related to heal related operations.
+"""
+
+from time import sleep
+
+
+class HealOps:
+    """
+    Class which is responsible for methods for heal related operations.
+    """
+
+    def wait_for_self_heal_daemons_to_be_online(self, volname: str, node: str,
+                                                timeout: int = 300) -> bool:
+        """
+        Waits for the volume self-heal-daemons to be online until timeout
+
+        Args:
+            volname (str): Name of the volume.
+            node (str): Node on which commands will be executed.
+
+        Kwargs:
+            timeout (int): timeout value in seconds to wait for
+                           self-heal-daemons to be online.
+
+        Returns:
+            bool : True if all self-heal-daemons are online within timeout,
+                   False otherwise
+        """
+        # Return True if the volume is pure distribute
+        if self.is_distribute_volume(volname):
+            self.logger.info(f"Volume {volname} is a distribute volume. "
+                             "Hence not waiting for self-heal daemons "
+                             "to be online")
+            return True
+
+        counter = 0
+        flag = 0
+        while counter < timeout:
+            status = self.are_all_self_heal_daemons_online(volname, node)
+            if status:
+                flag = 1
+                break
+            if not status:
+                sleep(10)
+                counter = counter + 10
+
+        if not flag:
+            self.logger.error(f"All self-heal-daemons of the volume {volname}"
+                              f" are not online even after {timeout//60}"
+                              " minutes")
+            return False
+        else:
+            self.logger.info(f"All self-heal-daemons of the volume {volname}"
+                             " are online")
+        return True
+
+    def are_all_self_heal_daemons_online(self, volname: str,
+                                         node: str) -> bool:
+        """
+        Verifies whether all the self-heal-daemons are online for the
+        specified
+        volume.
+
+        Args:
+            volname (str): volume name
+            mnode (str): Node on which cmd has to be executed.
+
+        Returns:
+            bool : True if all the self-heal-daemons are online for the volume.
+                   False otherwise.
+            NoneType: None if unable to get the volume status
+        """
+        if self.is_distribute_volume(volname):
+            self.logger.info(f"Volume {volname} is a distribute volume. "
+                             "Hence not waiting for self-heal daemons "
+                             "to be online")
+            return True
+
+        service = 'shd'
+        failure_msg = ("Verifying all self-heal-daemons are online failed for "
+                       f"volume {volname}")
+        # Get volume status
+        vol_status = self.get_volume_status(volname, node, service)
+        if vol_status is None:
+            self.logger.error(failure_msg)
+            return None
+
+        # Get all nodes from pool list
+        all_nodes = self.nodes_from_pool_list(node)
+        if not all_nodes:
+            self.logger.error(failure_msg)
+            return False
+
+        online_status = True
+        if 'node' in vol_status[volname]:
+            for brick in vol_status[volname]['node']:
+                if brick['hostname'] == "Self-heal Daemon":
+                    if brick['status'] != '1':
+                        online_status = False
+
+        if online_status:
+            self.logger.info("All self-heal Daemons are online")
+            return True
+        else:
+            self.logger.error("Some of the self-heal Daemons are offline")
+            return False

--- a/common/ops/gluster_ops/heal_ops.py
+++ b/common/ops/gluster_ops/heal_ops.py
@@ -19,7 +19,7 @@ class HealOps:
             volname (str): Name of the volume.
             node (str): Node on which commands will be executed.
 
-        Kwargs:
+        Optional:
             timeout (int): timeout value in seconds to wait for
                            self-heal-daemons to be online.
 
@@ -64,7 +64,7 @@ class HealOps:
 
         Args:
             volname (str): volume name
-            mnode (str): Node on which cmd has to be executed.
+            node (str): Node on which cmd has to be executed.
 
         Returns:
             bool : True if all the self-heal-daemons are online for the volume.
@@ -98,6 +98,7 @@ class HealOps:
                 if brick['hostname'] == "Self-heal Daemon":
                     if brick['status'] != '1':
                         online_status = False
+                        break
 
         if online_status:
             self.logger.info("All self-heal Daemons are online")

--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -215,13 +215,16 @@ class PeerOps(AbstractOps):
 
         Returns:
             list: List of nodes in pool on Success, Empty list on failure.
+            None on failure
         """
         pool_list_data = self.get_pool_list(node)
 
         if pool_list_data is None:
-            self.logger.info("Unable to get Nodes")
+            self.logger.error("Unable to get Nodes")
+            return None
 
         nodes = []
+
         # WHY?
         # The pool_list_data is a simple dict of the form
         # {'uuid' : 'val', 'hostname' : 'val',...} when the node isn't

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -847,7 +847,7 @@ class VolumeOps(AbstractOps):
             volname (str): Name of the volume.
             node (str): Node on which commands will be executed.
 
-        Kwargs:
+        Optional:
             timeout (int): timeout value in seconds to wait for all volume
                            processes to be online.
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -839,7 +839,6 @@ class VolumeOps(AbstractOps):
         return is_only_distribute
 
     def wait_for_volume_process_to_be_online(self, volname: str, node: str,
-                                             brick_list: list,
                                              timeout: int = 300) -> bool:
         """
         Waits for the volume's processes to be online until timeout
@@ -847,7 +846,6 @@ class VolumeOps(AbstractOps):
         Args:
             volname (str): Name of the volume.
             node (str): Node on which commands will be executed.
-            brick_list (list): List of bricks of the respective volume
 
         Kwargs:
             timeout (int): timeout value in seconds to wait for all volume
@@ -857,6 +855,12 @@ class VolumeOps(AbstractOps):
             bool: True if the volume's processes are online within timeout,
                   False otherwise
         """
+
+        # Fetch the brick list of the volume
+        brick_list = self.get_all_bricks(volname, node)
+        if brick_list is None:
+            self.logger.error(f"Failed to get brick list of volume {volname}")
+            return False
 
         # Wait for bricks to be online
         bricks_online_status = (self.wait_for_bricks_to_come_online(volname,

--- a/core/environ.py
+++ b/core/environ.py
@@ -183,7 +183,7 @@ class FrameworkEnv:
             volds dictionary specific to given volume.
         """
         self._validate_volname(volname)
-        return list(self.volds[volname])
+        return self.volds[volname]
 
     def get_volds(self) -> dict:
         """

--- a/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
+++ b/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
@@ -58,7 +58,8 @@ class TestGlusterDDefaultVolumeBehaviorQuorumOptions(GlusterBaseClass):
         else:
             ret = get_volume_options(self.mnode, 'all', option_name)
         self.assertIsNotNone(ret, "The %s option is not present" % option_name)
-        self.assertEqual(ret[option_name], option_value,
+        value = (ret[option_name]).split()
+        self.assertEqual(value[0], option_value,
                          ("Volume option for %s is not equal to %s"
                           % (option_name, option_value)))
         g.log.info("Volume option %s is equal to the expected value %s",
@@ -84,10 +85,10 @@ class TestGlusterDDefaultVolumeBehaviorQuorumOptions(GlusterBaseClass):
         4. There shouldn't be any effect to the running glusterfsd
         processes.
         """
-        # Check that quorum options are not set by default.
+        # Check the default quorum options are correct.
         self._validate_vol_options('cluster.server-quorum-type', 'off')
         self._validate_vol_options('cluster.server-quorum-ratio',
-                                   '51 (DEFAULT)', True)
+                                   '51', True)
 
         # Get the count of number of glusterfsd processes running.
         count_before_glusterd_kill = self._get_total_brick_processes_count()

--- a/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
+++ b/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
@@ -1,0 +1,129 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Description:
+    Test Default volume behavior and quorum options
+"""
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import get_volume_options
+from glustolibs.gluster.gluster_init import (
+    stop_glusterd,
+    start_glusterd,
+    is_glusterd_running,
+    wait_for_glusterd_to_start)
+from glustolibs.gluster.brick_libs import get_all_bricks
+from glustolibs.gluster.brickmux_ops import get_brick_processes_count
+
+
+@runs_on([['replicated', 'arbiter', 'dispersed', 'distributed',
+           'distributed-replicated', 'distributed-arbiter'],
+          ['glusterfs']])
+class TestGlusterDDefaultVolumeBehaviorQuorumOptions(GlusterBaseClass):
+    """ Testing default volume behavior and Quorum options """
+
+    def setUp(self):
+        """Setup Volume"""
+        # Calling GlusterBaseClass setUp
+        self.get_super_method(self, 'setUp')()
+
+        # Setup and mount the volume
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume and mount it")
+
+    def _validate_vol_options(self, option_name, option_value, for_all=False):
+        """ Function to validate default vol options """
+        if not for_all:
+            ret = get_volume_options(self.mnode, self.volname, option_name)
+        else:
+            ret = get_volume_options(self.mnode, 'all', option_name)
+        self.assertIsNotNone(ret, "The %s option is not present" % option_name)
+        self.assertEqual(ret[option_name], option_value,
+                         ("Volume option for %s is not equal to %s"
+                          % (option_name, option_value)))
+        g.log.info("Volume option %s is equal to the expected value %s",
+                   option_name, option_value)
+
+    def _get_total_brick_processes_count(self):
+        """
+        Function to find the total number of brick processes in the cluster
+        """
+        count = 0
+        self.brick_list = get_all_bricks(self.mnode, self.volname)
+        for brick in self.brick_list:
+            server = brick.split(":")[0]
+            count += get_brick_processes_count(server)
+        return count
+
+    def test_glusterd_default_vol_behavior_and_quorum_options(self):
+        """
+        Test default volume behavior and quorum options
+        1. Create a volume and start it.
+        2. Check that no quorum options are found in vol info.
+        3. Kill two glusterd processes.
+        4. There shouldn't be any effect to the running glusterfsd
+        processes.
+        """
+        # Check that quorum options are not set by default.
+        self._validate_vol_options('cluster.server-quorum-type', 'off')
+        self._validate_vol_options('cluster.server-quorum-ratio',
+                                   '51 (DEFAULT)', True)
+
+        # Get the count of number of glusterfsd processes running.
+        count_before_glusterd_kill = self._get_total_brick_processes_count()
+
+        # Kill two glusterd processes.
+        server_list = [self.servers[1], self.servers[2]]
+        ret = stop_glusterd(server_list)
+        self.assertTrue(ret, "Failed to stop glusterd on the specified nodes.")
+        ret = is_glusterd_running(server_list)
+        self.assertNotEqual(ret, 0, ("Glusterd is not stopped on the servers"
+                                     " where it was desired to be stopped."))
+        g.log.info("Glusterd processes stopped in the desired servers.")
+
+        # Get the count of number of glusterfsd processes running.
+        count_after_glusterd_kill = self._get_total_brick_processes_count()
+
+        # The count of glusterfsd processes should match
+        self.assertEqual(count_before_glusterd_kill, count_after_glusterd_kill,
+                         ("Glusterfsd processes are affected."))
+        g.log.info("Glusterd processes are not affected.")
+
+        # Start glusterd on all servers.
+        ret = start_glusterd(self.servers)
+        self.assertTrue(ret, "Failed to Start glusterd on the specified"
+                             " nodes")
+        g.log.info("Started glusterd on all nodes.")
+
+        # Wait for glusterd to restart.
+        ret = wait_for_glusterd_to_start(self.servers)
+        self.assertTrue(ret, "Glusterd not up on all nodes.")
+        g.log.info("Glusterd is up and running on all nodes.")
+
+    def tearDown(self):
+        """tear Down Callback"""
+        # Unmount volume and cleanup.
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to Unmount and Cleanup volume")
+        g.log.info("Successful in unmount and cleanup operations")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
+++ b/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
@@ -30,12 +30,12 @@ class TestCase(DParentTest):
         """ Function to validate default vol options """
         if not for_all:
             ret = self.redant.get_volume_options(self.vol_name, option_name,
-                                                 self.server_list)
+                                                 self.server_list[0])
         else:
             ret = self.redant.get_volume_options('all', option_name,
-                                                 self.server_list)
+                                                 self.server_list[0])
 
-        value = ret[option_name]
+        value = ret[option_name].split()[0]
         if value != option_value:
             raise Exception(f"Volume option {option_name} is not equal to "
                             f"{option_value}")

--- a/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
+++ b/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
@@ -1,82 +1,58 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
+ Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 Description:
     Test Default volume behavior and quorum options
 """
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import (
-    get_volume_options,
-    volume_reset)
-from glustolibs.gluster.gluster_init import (
-    stop_glusterd,
-    start_glusterd,
-    is_glusterd_running,
-    wait_for_glusterd_to_start)
-from glustolibs.gluster.brick_libs import get_all_bricks
-from glustolibs.gluster.brickmux_ops import get_brick_processes_count
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
+from tests.d_parent_test import DParentTest
+
+# disruptive;dist,rep,arb,dist-rep,disp,dist-arb
 
 
-@runs_on([['replicated', 'arbiter', 'dispersed', 'distributed',
-           'distributed-replicated', 'distributed-arbiter'],
-          ['glusterfs']])
-class TestGlusterDDefaultVolumeBehaviorQuorumOptions(GlusterBaseClass):
-    """ Testing default volume behavior and Quorum options """
-
-    def setUp(self):
-        """Setup Volume"""
-        # Calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        # Setup and mount the volume
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to setup volume and mount it")
+class TestCase(DParentTest):
 
     def _validate_vol_options(self, option_name, option_value, for_all=False):
         """ Function to validate default vol options """
         if not for_all:
-            ret = get_volume_options(self.mnode, self.volname, option_name)
+            ret = self.redant.get_volume_options(self.vol_name, option_name,
+                                                 self.server_list)
         else:
-            ret = get_volume_options(self.mnode, 'all', option_name)
-        self.assertIsNotNone(ret, "The %s option is not present" % option_name)
-        value = (ret[option_name]).split()
-        self.assertEqual(value[0], option_value,
-                         ("Volume option for %s is not equal to %s"
-                          % (option_name, option_value)))
-        g.log.info("Volume option %s is equal to the expected value %s",
-                   option_name, option_value)
+            ret = self.redant.get_volume_options('all', option_name,
+                                                 self.server_list)
+
+        value = ret[option_name]
+        if value != option_value:
+            raise Exception(f"Volume option {option_name} is not equal to "
+                            f"{option_value}")
 
     def _get_total_brick_processes_count(self):
         """
         Function to find the total number of brick processes in the cluster
         """
         count = 0
-        self.brick_list = get_all_bricks(self.mnode, self.volname)
-        for brick in self.brick_list:
+        brick_list = self.redant.get_all_bricks(self.vol_name,
+                                                self.server_list[0])
+        for brick in brick_list:
             server = brick.split(":")[0]
-            count += get_brick_processes_count(server)
+            count += self.redant.get_brick_processes_count(server)
         return count
 
-    def test_glusterd_default_vol_behavior_and_quorum_options(self):
+    def run_test(self, redant):
         """
         Test default volume behavior and quorum options
         1. Create a volume and start it.
@@ -94,51 +70,25 @@ class TestGlusterDDefaultVolumeBehaviorQuorumOptions(GlusterBaseClass):
         count_before_glusterd_kill = self._get_total_brick_processes_count()
 
         # Kill two glusterd processes.
-        server_list = [self.servers[1], self.servers[2]]
-        ret = stop_glusterd(server_list)
-        self.assertTrue(ret, "Failed to stop glusterd on the specified nodes.")
-        ret = is_glusterd_running(server_list)
-        self.assertNotEqual(ret, 0, ("Glusterd is not stopped on the servers"
-                                     " where it was desired to be stopped."))
-        g.log.info("Glusterd processes stopped in the desired servers.")
+        servers_list = [self.server_list[1], self.server_list[2]]
+        redant.stop_glusterd(servers_list)
+
+        ret = redant.is_glusterd_running(servers_list)
+        if ret == 1:
+            raise Exception("Glusterd is not stopped on the servers where it"
+                            " was desired to be stopped.")
 
         # Get the count of number of glusterfsd processes running.
         count_after_glusterd_kill = self._get_total_brick_processes_count()
 
         # The count of glusterfsd processes should match
-        self.assertEqual(count_before_glusterd_kill, count_after_glusterd_kill,
-                         ("Glusterfsd processes are affected."))
-        g.log.info("Glusterd processes are not affected.")
+        if count_before_glusterd_kill != count_after_glusterd_kill:
+            raise Exception("Glusterfsd processes are affected.")
 
         # Start glusterd on all servers.
-        ret = start_glusterd(self.servers)
-        self.assertTrue(ret, "Failed to Start glusterd on the specified"
-                             " nodes")
-        g.log.info("Started glusterd on all nodes.")
+        redant.start_glusterd(self.server_list)
 
         # Wait for glusterd to restart.
-        ret = wait_for_glusterd_to_start(self.servers)
-        self.assertTrue(ret, "Glusterd not up on all nodes.")
-        g.log.info("Glusterd is up and running on all nodes.")
-
-    def tearDown(self):
-        """tear Down Callback"""
-        # Wait for peers to connect.
-        ret = wait_for_peers_to_connect(self.mnode, self.servers, 50)
+        ret = redant.wait_for_glusterd_to_start(self.server_list)
         if not ret:
-            raise ExecutionError("Peers are not in connected state.")
-
-        # Unmount volume and cleanup.
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to Unmount and Cleanup volume")
-        g.log.info("Successful in unmount and cleanup operations")
-
-        # Reset the cluster options.
-        ret = volume_reset(self.mnode, "all")
-        if not ret:
-            raise ExecutionError("Failed to Reset the cluster options.")
-        g.log.info("Successfully reset cluster options.")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+            raise Exception("Glusterd not up on all nodes.")

--- a/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
+++ b/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
@@ -74,7 +74,7 @@ class TestCase(DParentTest):
         redant.stop_glusterd(servers_list)
 
         ret = redant.wait_for_glusterd_to_stop(servers_list)
-        if ret == 1:
+        if ret:
             raise Exception("Glusterd is not stopped on the servers where it"
                             " was desired to be stopped.")
 

--- a/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
+++ b/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py
@@ -73,7 +73,7 @@ class TestCase(DParentTest):
         servers_list = [self.server_list[1], self.server_list[2]]
         redant.stop_glusterd(servers_list)
 
-        ret = redant.is_glusterd_running(servers_list)
+        ret = redant.wait_for_glusterd_to_stop(servers_list)
         if ret == 1:
             raise Exception("Glusterd is not stopped on the servers where it"
                             " was desired to be stopped.")


### PR DESCRIPTION
Migrated TC [test_glusterd_default_volume_behaviour_quorum_options](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_glusterd_default_volume_behavior_quorum_options.py)
And, added brick and volume ops.

Fixes: #511 and Fixes: #516 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>