### PR TITLE
Migration of test_rebalance_new_node.py from glusto to redant

### DIFF
--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2016-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@ import sys
 from glusto.core import Glusto as g
 
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.glusterdir import rmdir
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.volume_libs import (setup_volume, cleanup_volume)
 from glustolibs.gluster.volume_ops import (get_volume_list)
@@ -67,6 +68,12 @@ class TestRebalanceStatus(GlusterBaseClass):
         # unmount the volume
         ret = self.unmount_volume(self.mounts)
         self.assertTrue(ret, "Volume unmount failed for %s" % self.volname)
+        for mount_obj in self.mounts:
+            ret = rmdir(mount_obj.client_system, mount_obj.mountpoint)
+            if not ret:
+                raise ExecutionError("Failed to remove directory "
+                                     "mount directory.")
+            g.log.info("Mount directory is removed successfully")
 
         # get volumes list and clean up all the volumes
         vol_list = get_volume_list(self.mnode)

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -14,8 +14,6 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import sys
-
 from glusto.core import Glusto as g
 
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
@@ -126,13 +124,12 @@ class TestRebalanceStatus(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 10 "
                    "--dir-length 5 "
                    "--max-num-of-dirs 3 "
-                   "--num-of-files 100 %s" % (sys.version_info.major,
-                                              self.script_upload_path,
+                   "--num-of-files 100 %s" % (self.script_upload_path,
                                               self.counter,
                                               mount_obj.mountpoint))
             ret = g.run(mount_obj.client_system, cmd)

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -1,0 +1,162 @@
+#  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_libs import (setup_volume, cleanup_volume)
+from glustolibs.gluster.volume_ops import (get_volume_list)
+from glustolibs.gluster.peer_ops import (peer_probe_servers,
+                                         peer_detach_servers, peer_probe)
+from glustolibs.misc.misc_libs import upload_scripts
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.brick_ops import add_brick
+from glustolibs.gluster.rebalance_ops import (rebalance_start,
+                                              get_rebalance_status)
+from glustolibs.gluster.mount_ops import is_mounted
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestRebalanceStatus(GlusterBaseClass):
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+
+        # check whether peers are in connected state
+        ret = self.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+        # detach all the nodes
+        ret = peer_detach_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Peer detach failed to all the servers from "
+                                 "the node.")
+        g.log.info("Peer detach SUCCESSFUL.")
+
+        # Uploading file_dir script in all client direcotries
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", self.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        self.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                   "file_dir_ops.py")
+        ret = upload_scripts(self.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts to clients %s" %
+                                 self.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   self.clients)
+
+    def tearDown(self):
+
+        # unmount the volume
+        ret = self.unmount_volume(self.mounts)
+        self.assertTrue(ret, "Volume unmount failed for %s" % self.volname)
+
+        # get volumes list and clean up all the volumes
+        vol_list = get_volume_list(self.mnode)
+        if vol_list is None:
+            raise ExecutionError("Error while getting vol list")
+        else:
+            for volume in vol_list:
+                ret = cleanup_volume(self.mnode, volume)
+                if ret is True:
+                    g.log.info("Volume deleted successfully : %s", volume)
+                else:
+                    raise ExecutionError("Failed Cleanup the"
+                                         " Volume %s" % volume)
+
+        # peer probe all the servers
+        ret = peer_probe_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Peer probe failed to all the servers from "
+                                 "the node.")
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    @classmethod
+    def tearDownClass(cls):
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDownClass.im_func(cls)
+
+    def test_rebalance_status_from_newly_probed_node(self):
+
+        # Peer probe first 3 servers
+        servers_info_from_three_nodes = {}
+        for server in self.servers[0:3]:
+            servers_info_from_three_nodes[
+                server] = self.all_servers_info[server]
+            # Peer probe the first 3 servers
+            ret, _, _ = peer_probe(self.mnode, server)
+            self.assertEqual(ret, 0, "Peer probe failed to %s" % server)
+
+        self.volume['servers'] = self.servers[0:3]
+        # create a volume using the first 3 nodes
+        ret = setup_volume(self.mnode, servers_info_from_three_nodes,
+                           self.volume, force=True)
+        self.assertTrue(ret, "Failed to create"
+                        "and start volume %s" % self.volname)
+
+        # Mounting a volume
+        ret = self.mount_volume(self.mounts)
+        self.assertTrue(ret, "Volume mount failed for %s" % self.volname)
+
+        # Checking volume mounted or not
+        ret = is_mounted(self.volname, self.mounts[0].mountpoint, self.mnode,
+                         self.mounts[0].client_system, self.mount_type)
+        self.assertTrue(ret, "Volume not mounted on mount point: %s"
+                        % self.mounts[0].mountpoint)
+        g.log.info("Volume %s mounted on %s", self.volname,
+                   self.mounts[0].mountpoint)
+
+        # run IOs
+        g.log.info("Starting IO on all mounts...")
+        self.counter = 1
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dirname-start-num %d "
+                   "--dir-depth 10 "
+                   "--dir-length 5 "
+                   "--max-num-of-dirs 3 "
+                   "--num-of-files 100 %s" % (self.script_upload_path,
+                                              self.counter,
+                                              mount_obj.mountpoint))
+            ret = g.run(mount_obj.client_system, cmd)
+            self.assertEqual(ret, 0, "IO failed on %s"
+                             % mount_obj.client_system)
+            self.counter = self.counter + 10
+
+        # add a brick to the volume and start rebalance
+        brick_to_add = form_bricks_list(self.mnode, self.volname, 1,
+                                        self.servers[0:3],
+                                        servers_info_from_three_nodes)
+        ret, _, _ = add_brick(self.mnode, self.volname, brick_to_add)
+        self.assertEqual(ret, 0, "Failed to add a brick to %s" % self.volname)
+
+        ret, _, _ = rebalance_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start rebalance")
+
+        # peer probe a new node from existing cluster
+        ret, _, _ = peer_probe(self.mnode, self.servers[3])
+        self.assertEqual(ret, 0, "Peer probe failed")
+
+        ret = get_rebalance_status(self.servers[3], self.volname)
+        self.assertIsNone(ret, "Failed to get rebalance status")

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -53,11 +53,9 @@ class TestRebalanceStatus(GlusterBaseClass):
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", self.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         self.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                    "file_dir_ops.py")
-        ret = upload_scripts(self.clients, script_local_path)
+        ret = upload_scripts(self.clients, self.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts to clients %s" %
                                  self.clients)

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -1,155 +1,90 @@
-#  Copyright (C) 2016-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2016-2020  Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
 
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.volume_libs import (setup_volume, cleanup_volume)
-from glustolibs.gluster.volume_ops import (get_volume_list)
-from glustolibs.gluster.peer_ops import (peer_probe_servers,
-                                         peer_detach_servers, peer_probe)
-from glustolibs.misc.misc_libs import upload_scripts
-from glustolibs.gluster.lib_utils import form_bricks_list
-from glustolibs.gluster.brick_ops import add_brick
-from glustolibs.gluster.rebalance_ops import (rebalance_start,
-                                              get_rebalance_status)
-from glustolibs.gluster.mount_ops import is_mounted
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+  Testing rebalance operations when io operations are performed
+  and an extra brick is added.
+"""
+
+import traceback
+from tests.d_parent_test import DParentTest
+
+# disruptive;
 
 
-@runs_on([['distributed'], ['glusterfs']])
-class TestRebalanceStatus(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    def setUp(self):
-        self.get_super_method(self, 'setUp')()
+    def terminate(self):
+        try:
+            self.redant.cleanup_volume(self.volume_name1, self.server_list[0])
+        except Exception as e:
+            tb = traceback.format_exc()
+            self.redant.logger.error(e)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-        # check whether peers are in connected state
-        ret = self.validate_peers_are_connected()
-        if not ret:
-            raise ExecutionError("Peers are not in connected state")
-
-        # detach all the nodes
-        ret = peer_detach_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Peer detach failed to all the servers from "
-                                 "the node.")
-        g.log.info("Peer detach SUCCESSFUL.")
-
-        # Uploading file_dir script in all client direcotries
-        g.log.info("Upload io scripts to clients %s for running IO on "
-                   "mounts", self.clients)
-        self.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                   "file_dir_ops.py")
-        ret = upload_scripts(self.clients, self.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts to clients %s" %
-                                 self.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   self.clients)
-
-    def tearDown(self):
-
-        # unmount the volume
-        ret = self.unmount_volume(self.mounts)
-        self.assertTrue(ret, "Volume unmount failed for %s" % self.volname)
-        g.log.info("Volume unmounted successfully : %s", self.volname)
-
-        # get volumes list and clean up all the volumes
-        vol_list = get_volume_list(self.mnode)
-        if vol_list is None:
-            raise ExecutionError("Error while getting vol list")
-        else:
-            for volume in vol_list:
-                ret = cleanup_volume(self.mnode, volume)
-                if ret is True:
-                    g.log.info("Volume deleted successfully : %s", volume)
-                else:
-                    raise ExecutionError("Failed Cleanup the"
-                                         " Volume %s" % volume)
-
-        # peer probe all the servers
-        ret = peer_probe_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Peer probe failed to all the servers from "
-                                 "the node.")
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_rebalance_status_from_newly_probed_node(self):
-
-        # Peer probe first 3 servers
-        servers_info_from_three_nodes = {}
-        for server in self.servers[0:3]:
-            servers_info_from_three_nodes[
-                server] = self.all_servers_info[server]
-            # Peer probe the first 3 servers
-            ret, _, _ = peer_probe(self.mnode, server)
-            self.assertEqual(ret, 0, "Peer probe failed to %s" % server)
-
-        self.volume['servers'] = self.servers[0:3]
-        # create a volume using the first 3 nodes
-        ret = setup_volume(self.mnode, servers_info_from_three_nodes,
-                           self.volume, force=True)
-        self.assertTrue(ret, "Failed to create"
-                        "and start volume %s" % self.volname)
-
-        # Mounting a volume
-        ret = self.mount_volume(self.mounts)
-        self.assertTrue(ret, "Volume mount failed for %s" % self.volname)
-
-        # Checking volume mounted or not
-        ret = is_mounted(self.volname, self.mounts[0].mountpoint, self.mnode,
-                         self.mounts[0].client_system, self.mount_type)
-        self.assertTrue(ret, "Volume not mounted on mount point: %s"
-                        % self.mounts[0].mountpoint)
-        g.log.info("Volume %s mounted on %s", self.volname,
-                   self.mounts[0].mountpoint)
+    def run_test(self, redant):
+        """
+        Steps:
+        1) Create a distributed volume
+        2) Perform io operations
+        3) Add brick
+        4) Start Rebalance
+        5) Peer Probe new node
+        6) Get rebalance status
+        """
+        self.volume_type1 = 'dist'
+        self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,
+                            self.server_list[0:2], self.brick_roots, True)
+        self.mountpoint = (f"/mnt/{self.volume_name1}")
+        self.redant.execute_abstract_op_node(f"mkdir -p "
+                                             f"{self.mountpoint}",
+                                             self.client_list[0])
+        redant.volume_mount(self.server_list[0], self.volume_name1,
+                            self.mountpoint, self.client_list[0])
 
         # run IOs
-        g.log.info("Starting IO on all mounts...")
-        self.counter = 1
-        for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dirname-start-num %d "
-                   "--dir-depth 10 "
-                   "--dir-length 5 "
-                   "--max-num-of-dirs 3 "
-                   "--num-of-files 100 %s" % (self.script_upload_path,
-                                              self.counter,
-                                              mount_obj.mountpoint))
-            ret = g.run(mount_obj.client_system, cmd)
-            self.assertEqual(ret, 0, "IO failed on %s"
-                             % mount_obj.client_system)
-            self.counter = self.counter + 10
+        redant.logger.info("Starting IO on all mounts...")
+        all_mounts_procs = []
+        counter = 1
+        mounts = redant.es.get_mnt_pts_dict_in_list(self.volume_name1)
+        for mount in mounts:
+            redant.logger.info(f"Starting IO on {mount['client']}:"
+                               f"{mount['mountpath']}")
+            proc = redant.create_deep_dirs_with_files(mount['mountpath'],
+                                                      counter, 2, 3, 4, 10,
+                                                      mount['client'])
+            all_mounts_procs.append(proc)
+            counter = counter + 10
+
+        if not redant.validate_io_procs(all_mounts_procs, mounts):
+            raise Exception("IO operations failed on some"
+                            " or all of the clients")
 
         # add a brick to the volume and start rebalance
-        brick_to_add = form_bricks_list(self.mnode, self.volname, 1,
-                                        self.servers[0:3],
-                                        servers_info_from_three_nodes)
-        ret, _, _ = add_brick(self.mnode, self.volname, brick_to_add)
-        self.assertEqual(ret, 0, "Failed to add a brick to %s" % self.volname)
+        redant.add_brick(self.volume_name1, self.server_list[0],
+                         self.vol_type_inf[self.conv_dict['dist']],
+                         self.server_list, self.brick_roots, True)
 
-        ret, _, _ = rebalance_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to start rebalance")
+        redant.rebalance_start(self.volume_name1, self.server_list[0])
 
         # peer probe a new node from existing cluster
-        ret, _, _ = peer_probe(self.mnode, self.servers[3])
-        self.assertEqual(ret, 0, "Peer probe failed")
+        redant.peer_probe(self.server_list[2], self.server_list[0])
 
-        ret = get_rebalance_status(self.servers[3], self.volname)
-        self.assertIsNone(ret, "Failed to get rebalance status")
+        redant.get_rebalance_status(self.volume_name1, self.server_list[0])

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -19,7 +19,6 @@ import sys
 from glusto.core import Glusto as g
 
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.glusterdir import rmdir
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.volume_libs import (setup_volume, cleanup_volume)
 from glustolibs.gluster.volume_ops import (get_volume_list)
@@ -68,12 +67,7 @@ class TestRebalanceStatus(GlusterBaseClass):
         # unmount the volume
         ret = self.unmount_volume(self.mounts)
         self.assertTrue(ret, "Volume unmount failed for %s" % self.volname)
-        for mount_obj in self.mounts:
-            ret = rmdir(mount_obj.client_system, mount_obj.mountpoint)
-            if not ret:
-                raise ExecutionError("Failed to remove directory "
-                                     "mount directory.")
-            g.log.info("Mount directory is removed successfully")
+        g.log.info("Volume unmounted successfully : %s", self.volname)
 
         # get volumes list and clean up all the volumes
         vol_list = get_volume_list(self.mnode)

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -14,7 +14,10 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import sys
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.volume_libs import (setup_volume, cleanup_volume)
@@ -33,8 +36,7 @@ from glustolibs.gluster.mount_ops import is_mounted
 class TestRebalanceStatus(GlusterBaseClass):
 
     def setUp(self):
-
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # check whether peers are in connected state
         ret = self.validate_peers_are_connected()
@@ -87,13 +89,7 @@ class TestRebalanceStatus(GlusterBaseClass):
             raise ExecutionError("Peer probe failed to all the servers from "
                                  "the node.")
 
-        GlusterBaseClass.tearDown.im_func(self)
-
-    @classmethod
-    def tearDownClass(cls):
-
-        # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDownClass.im_func(cls)
+        self.get_super_method(self, 'tearDown')()
 
     def test_rebalance_status_from_newly_probed_node(self):
 
@@ -131,12 +127,13 @@ class TestRebalanceStatus(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dirname-start-num %d "
                    "--dir-depth 10 "
                    "--dir-length 5 "
                    "--max-num-of-dirs 3 "
-                   "--num-of-files 100 %s" % (self.script_upload_path,
+                   "--num-of-files 100 %s" % (sys.version_info.major,
+                                              self.script_upload_path,
                                               self.counter,
                                               mount_obj.mountpoint))
             ret = g.run(mount_obj.client_system, cmd)


### PR DESCRIPTION
Migration of [test_rebalance_new_node.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_rebalance_new_node.py) from glusto to redant
    
Fixes: #292
Fixes: #492
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>