### PR TITLE
Migrated TC test_volume_status_show_bricks_online_though_brickpath_deleted

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -337,6 +337,50 @@ class BrickOps:
         self.logger.info(f"All bricks are offline: {bricks_list}")
         return ret
 
+    def are_bricks_online(self, volname: str,
+                          bricks_list: list, node: str,
+                          strict: bool = True) -> bool:
+        """
+        This function checks if the given list of
+        bricks are online.
+
+        Args:
+            volname (str) : Volume name
+            bricks_list (list) : list of bricks to check
+            node (str) : the node on which comparison has to be done
+            strict (bool) : To check strictly if all bricks are offline
+        Returns:
+            boolean value: True, if bricks are offline
+                           False if online
+        """
+        vol_status = self.get_volume_status(volname, node)
+
+        vol_status_brick_list = []
+        for brick in vol_status[volname]['node']:
+            if brick['status'] == 1:
+                brick_path = f"{brick['hostname']}:{brick['path']}"
+                vol_status_brick_list.append(brick_path)
+
+        offline_brick_list = []
+        ret = True
+
+        for brick in bricks_list:
+            if strict and brick not in vol_status_brick_list:
+                offline_brick_list.append(brick)
+                self.logger.error(f"Brick: {brick} is not online")
+                ret = False
+            elif brick not in vol_status_brick_list:
+                self.logger.error(f"Brick: {brick} is not online")
+                return False
+
+        if not ret:
+            self.logger.error(f"Some of the bricks are not "
+                              f"offline: {offline_brick_list}")
+            return ret
+
+        self.logger.info(f"All bricks are online: {bricks_list}")
+        return ret
+
     def check_if_bricks_list_changed(self,
                                      bricks_list: list,
                                      volname: str,

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -357,7 +357,7 @@ class BrickOps:
 
         vol_status_brick_list = []
         for brick in vol_status[volname]['node']:
-            if brick['status'] == 1:
+            if int(brick['status']) == 1:
                 brick_path = f"{brick['hostname']}:{brick['path']}"
                 vol_status_brick_list.append(brick_path)
 
@@ -374,8 +374,8 @@ class BrickOps:
                 return False
 
         if not ret:
-            self.logger.error(f"Some of the bricks are not "
-                              f"offline: {offline_brick_list}")
+            self.logger.error(f"Some of the bricks are "
+                              f"not online: {offline_brick_list}")
             return ret
 
         self.logger.info(f"All bricks are online: {bricks_list}")

--- a/core/parsing/params_handler.py
+++ b/core/parsing/params_handler.py
@@ -152,6 +152,8 @@ class ParamsHandler:
         Get the mapping of server ip to their brick roots
         Returns:
            Dict
+        TODO: Update the values in the dict to be a list of bricks, instead
+              of the first brick of the list.
         """
         brick_roots = {}
         for server in self.server_config:

--- a/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
+++ b/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
@@ -22,19 +22,21 @@ import random
 from glusto.core import Glusto as g
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.brick_libs import (are_bricks_online, get_all_bricks)
+from glustolibs.gluster.brick_libs import (are_bricks_online, get_all_bricks,
+                                           bring_bricks_online,
+                                           bring_bricks_offline,
+                                           are_bricks_offline)
+from glustolibs.gluster.volume_ops import (volume_start)
 
 
 @runs_on([['distributed', 'replicated', 'distributed-replicated',
            'dispersed', 'distributed-dispersed', 'arbiter',
            'distributed-arbiter'], ['glusterfs']])
 class TestVolumeStatusShowBrickOnlineThoughBrickpathDeleted(GlusterBaseClass):
-
     def setUp(self):
         # calling GlusterBaseClass setUp
         self.get_super_method(self, 'setUp')()
 
-        # Creating and starting Volume
         ret = self.setup_volume()
         if not ret:
             raise ExecutionError("Volume creation failed: %s"
@@ -43,6 +45,13 @@ class TestVolumeStatusShowBrickOnlineThoughBrickpathDeleted(GlusterBaseClass):
 
     def tearDown(self):
         # Stopping the volume and Cleaning up the volume
+        if self.check_for_remount:
+            ret, _, _ = g.run(self.brick_node, 'mount %s' % self.node_brick)
+            if ret:
+                raise ExecutionError('Failed to remount brick %s'
+                                     % self.node_brick)
+            g.log.info('Successfully remounted %s with read-write option',
+                       self.node_brick)
         ret = self.cleanup_volume()
         if not ret:
             raise ExecutionError("Failed to cleanup the volume %s"
@@ -57,23 +66,71 @@ class TestVolumeStatusShowBrickOnlineThoughBrickpathDeleted(GlusterBaseClass):
         Test Case:
         1) Create a volume and start it.
         2) Fetch the brick list
-        3) Remove any brickpath
-        4) Check number of bricks online is equal to number of bricks in volume
+        3) Bring any one brick down umount the brick
+        4) Force start the volume and check that all the bricks are not online
+        5) Remount the removed brick and bring back the brick online
+        6) Force start the volume and check if all the bricks are online
         """
         # Fetching the brick list
         brick_list = get_all_bricks(self.mnode, self.volname)
         self.assertIsNotNone(brick_list, "Failed to get the bricks in"
                              " the volume")
 
-        # Command for removing brick directory
+        # Bringing one brick down
         random_brick = random.choice(brick_list)
-        node, brick_path = random_brick.split(r':')
-        cmd = 'rm -rf ' + brick_path
+        ret = bring_bricks_offline(self.volname, random_brick)
+        self.assertTrue(ret, "Failed to bring offline")
 
-        # Removing brick directory of one node
-        ret, _, _ = g.run(node, cmd)
-        self.assertEqual(ret, 0, "Failed to remove brick dir")
-        g.log.info("Brick directory removed successfully")
+        # Creating a list of bricks to be removed
+        remove_bricks_list = []
+        remove_bricks_list.append(random_brick)
+
+        # Checking if the brick is offline or not
+        ret = are_bricks_offline(self.mnode, self.volname,
+                                 remove_bricks_list)
+        self.assertTrue(ret, 'Bricks %s are not offline'
+                        % random_brick)
+        g.log.info('Brick %s is offline as expected', random_brick)
+
+        # umounting the brick which was made offline
+        self.brick_node, volume_brick = random_brick.split(':')
+        self.node_brick = '/'.join(volume_brick.split('/')[0:3])
+        g.log.info('Start umount brick %s...', self.node_brick)
+        ret, _, _ = g.run(self.brick_node, 'umount %s' % self.node_brick)
+        self.assertFalse(ret, 'Failed to umount brick %s' % self.node_brick)
+        g.log.info('Successfully umounted brick %s', self.node_brick)
+
+        self.check_for_remount = True
+
+        # Force starting the volume
+        ret, _, _ = volume_start(self.mnode, self.volname, True)
+        self.assertEqual(ret, 0, "Faile to force start volume")
+        g.log.info("Successfully force start volume")
+
+        # remounting the offline brick
+        g.log.info('Start remount brick %s with read-write option...',
+                   self.node_brick)
+        ret, _, _ = g.run(self.brick_node, 'mount %s' % self.node_brick)
+        self.assertFalse(ret, 'Failed to remount brick %s' % self.node_brick)
+        g.log.info('Successfully remounted %s with read-write option',
+                   self.node_brick)
+
+        self.check_for_remount = False
+
+        # Checking that all the bricks shouldn't be online
+        ret = are_bricks_online(self.mnode, self.volname, brick_list)
+        self.assertFalse(ret, "Unexpected: All the bricks are online")
+        g.log.info("Expected: All the bricks are not online")
+
+        # Bringing back the offline brick online
+        ret = bring_bricks_online(self.mnode, self.volname, remove_bricks_list)
+        self.assertTrue(ret, "Failed to bring bricks online")
+        g.log.info("Successfully brought bricks online")
+
+        # Force starting the volume
+        ret, _, _ = volume_start(self.mnode, self.volname, True)
+        self.assertEqual(ret, 0, "Faile to force start volume")
+        g.log.info("Successfully force start volume")
 
         # Checking if all the bricks are online or not
         ret = are_bricks_online(self.mnode, self.volname, brick_list)

--- a/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
+++ b/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
@@ -96,7 +96,7 @@ class TestCase(DParentTest):
             raise Exception("Unexpected: Bricks are online")
 
         # Bringing back the offline brick online
-        if not redant.bring_bricks_online(self.vol_name, self.server_list[0],
+        if not redant.bring_bricks_online(self.vol_name, self.server_list,
                                           remove_bricks_list):
             raise Exception("Failed to bring bricks online")
 

--- a/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
+++ b/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
@@ -54,6 +54,11 @@ class TestCase(DParentTest):
         """
         self.check_for_remount = False
 
+        # TODO: Update this check when get_brick_roots is fixed
+        # Exit if server/brick requirements not met
+        if len(self.server_list) < 6:
+            raise Exception("Server/Brick requirements not met")
+
         # Fetching the brick list
         brick_list = redant.get_all_bricks(self.vol_name, self.server_list[0])
         if brick_list is None:

--- a/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
+++ b/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
@@ -1,67 +1,48 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
 
-""" Description:
-      Volume status when one of the brickpath is not available.
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    Volume status when one of the brickpath is not available.
 """
 
+import traceback
 import random
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.brick_libs import (are_bricks_online, get_all_bricks,
-                                           bring_bricks_online,
-                                           bring_bricks_offline,
-                                           are_bricks_offline)
-from glustolibs.gluster.volume_ops import (volume_start)
+from tests.d_parent_test import DParentTest
+
+# disruptive;dist,rep,arb,dist-rep,disp,dist-arb,dist-disp
 
 
-@runs_on([['distributed', 'replicated', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed', 'arbiter',
-           'distributed-arbiter'], ['glusterfs']])
-class TestVolumeStatusShowBrickOnlineThoughBrickpathDeleted(GlusterBaseClass):
-    def setUp(self):
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
+class TestCase(DParentTest):
 
-        ret = self.setup_volume()
-        if not ret:
-            raise ExecutionError("Volume creation failed: %s"
-                                 % self.volname)
-        g.log.info("Volume created successfully : %s", self.volname)
+    def terminate(self):
+        # Remount the brick in case things fail midway
+        try:
+            if self.check_for_remount:
+                self.redant.execute_abstract_op_node(f"mount "
+                                                     f"{self.brick_path}",
+                                                     self.brick_node)
 
-    def tearDown(self):
-        # Stopping the volume and Cleaning up the volume
-        if self.check_for_remount:
-            ret, _, _ = g.run(self.brick_node, 'mount %s' % self.node_brick)
-            if ret:
-                raise ExecutionError('Failed to remount brick %s'
-                                     % self.node_brick)
-            g.log.info('Successfully remounted %s with read-write option',
-                       self.node_brick)
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Failed to cleanup the volume %s"
-                                 % self.volname)
-        g.log.info("Volume deleted successfully: %s", self.volname)
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
-
-    def test_volume_status_show_brick_online_though_brickpath_deleted(self):
+    def run_test(self, redant):
         """
         Test Case:
         1) Create a volume and start it.
@@ -71,68 +52,58 @@ class TestVolumeStatusShowBrickOnlineThoughBrickpathDeleted(GlusterBaseClass):
         5) Remount the removed brick and bring back the brick online
         6) Force start the volume and check if all the bricks are online
         """
+        self.check_for_remount = False
+
         # Fetching the brick list
-        brick_list = get_all_bricks(self.mnode, self.volname)
-        self.assertIsNotNone(brick_list, "Failed to get the bricks in"
-                             " the volume")
+        brick_list = redant.get_all_bricks(self.vol_name, self.server_list[0])
+        if brick_list is None:
+            raise Exception("Failed to get the bricks in"
+                            " the volume")
 
         # Bringing one brick down
         random_brick = random.choice(brick_list)
-        ret = bring_bricks_offline(self.volname, random_brick)
-        self.assertTrue(ret, "Failed to bring offline")
+        if not redant.bring_bricks_offline(self.vol_name, random_brick):
+            raise Exception("Failed to bring brick offline")
 
         # Creating a list of bricks to be removed
         remove_bricks_list = []
         remove_bricks_list.append(random_brick)
 
         # Checking if the brick is offline or not
-        ret = are_bricks_offline(self.mnode, self.volname,
-                                 remove_bricks_list)
-        self.assertTrue(ret, 'Bricks %s are not offline'
-                        % random_brick)
-        g.log.info('Brick %s is offline as expected', random_brick)
+        if not redant.are_bricks_offline(self.vol_name, remove_bricks_list,
+                                         self.server_list[0]):
+            raise Exception(f"Bricks {remove_bricks_list} are not offline")
 
         # umounting the brick which was made offline
         self.brick_node, volume_brick = random_brick.split(':')
-        self.node_brick = '/'.join(volume_brick.split('/')[0:3])
-        g.log.info('Start umount brick %s...', self.node_brick)
-        ret, _, _ = g.run(self.brick_node, 'umount %s' % self.node_brick)
-        self.assertFalse(ret, 'Failed to umount brick %s' % self.node_brick)
-        g.log.info('Successfully umounted brick %s', self.node_brick)
-
+        redant.logger.info("Brick: %s", volume_brick)
+        self.brick_path = '/'.join(volume_brick.split('/')[0:3])
+        redant.execute_abstract_op_node(f"umount {self.brick_path}",
+                                        self.brick_node)
         self.check_for_remount = True
 
         # Force starting the volume
-        ret, _, _ = volume_start(self.mnode, self.volname, True)
-        self.assertEqual(ret, 0, "Faile to force start volume")
-        g.log.info("Successfully force start volume")
+        redant.volume_start(self.vol_name, self.server_list[0], True)
 
         # remounting the offline brick
-        g.log.info('Start remount brick %s with read-write option...',
-                   self.node_brick)
-        ret, _, _ = g.run(self.brick_node, 'mount %s' % self.node_brick)
-        self.assertFalse(ret, 'Failed to remount brick %s' % self.node_brick)
-        g.log.info('Successfully remounted %s with read-write option',
-                   self.node_brick)
-
+        redant.execute_abstract_op_node(f"mount {self.brick_path}",
+                                        self.brick_node)
         self.check_for_remount = False
 
         # Checking that all the bricks shouldn't be online
-        ret = are_bricks_online(self.mnode, self.volname, brick_list)
-        self.assertFalse(ret, "Unexpected: All the bricks are online")
-        g.log.info("Expected: All the bricks are not online")
+        if redant.are_bricks_online(self.vol_name, brick_list,
+                                    self.server_list[0]):
+            raise Exception("Unexpected: Bricks are online")
 
         # Bringing back the offline brick online
-        ret = bring_bricks_online(self.mnode, self.volname, remove_bricks_list)
-        self.assertTrue(ret, "Failed to bring bricks online")
-        g.log.info("Successfully brought bricks online")
+        if not redant.bring_bricks_online(self.vol_name, self.server_list[0],
+                                          remove_bricks_list):
+            raise Exception("Failed to bring bricks online")
 
         # Force starting the volume
-        ret, _, _ = volume_start(self.mnode, self.volname, True)
-        self.assertEqual(ret, 0, "Faile to force start volume")
-        g.log.info("Successfully force start volume")
+        redant.volume_start(self.vol_name, self.server_list[0], True)
 
         # Checking if all the bricks are online or not
-        ret = are_bricks_online(self.mnode, self.volname, brick_list)
-        self.assertTrue(ret, "Unexpected: All the bricks are not online")
-        g.log.info("Expected: All the bricks are online")
+        if not redant.are_bricks_online(self.vol_name, brick_list,
+                                        self.server_list[0]):
+            raise Exception("All the bricks are not online")

--- a/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
+++ b/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py
@@ -1,0 +1,81 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+      Volume status when one of the brickpath is not available.
+"""
+
+import random
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.brick_libs import (are_bricks_online, get_all_bricks)
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed', 'arbiter',
+           'distributed-arbiter'], ['glusterfs']])
+class TestVolumeStatusShowBrickOnlineThoughBrickpathDeleted(GlusterBaseClass):
+
+    def setUp(self):
+        # calling GlusterBaseClass setUp
+        self.get_super_method(self, 'setUp')()
+
+        # Creating and starting Volume
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Volume creation failed: %s"
+                                 % self.volname)
+        g.log.info("Volume created successfully : %s", self.volname)
+
+    def tearDown(self):
+        # Stopping the volume and Cleaning up the volume
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to cleanup the volume %s"
+                                 % self.volname)
+        g.log.info("Volume deleted successfully: %s", self.volname)
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()
+
+    def test_volume_status_show_brick_online_though_brickpath_deleted(self):
+        """
+        Test Case:
+        1) Create a volume and start it.
+        2) Fetch the brick list
+        3) Remove any brickpath
+        4) Check number of bricks online is equal to number of bricks in volume
+        """
+        # Fetching the brick list
+        brick_list = get_all_bricks(self.mnode, self.volname)
+        self.assertIsNotNone(brick_list, "Failed to get the bricks in"
+                             " the volume")
+
+        # Command for removing brick directory
+        random_brick = random.choice(brick_list)
+        node, brick_path = random_brick.split(r':')
+        cmd = 'rm -rf ' + brick_path
+
+        # Removing brick directory of one node
+        ret, _, _ = g.run(node, cmd)
+        self.assertEqual(ret, 0, "Failed to remove brick dir")
+        g.log.info("Brick directory removed successfully")
+
+        # Checking if all the bricks are online or not
+        ret = are_bricks_online(self.mnode, self.volname, brick_list)
+        self.assertTrue(ret, "Unexpected: All the bricks are not online")
+        g.log.info("Expected: All the bricks are online")


### PR DESCRIPTION
Migrated TC [test_volume_status_show_bricks_online_though_brickpath_deleted](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_volume_status_show_bricks_online_though_brickpath_deleted.py)
Also, added the op `are_bricks_online`

Fixes: #534 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>