### PR TITLE
Migration of test_xml_dump_of_gluster_volume_status_during_rebalance

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -650,6 +650,18 @@ class VolumeOps(AbstractOps):
                             else:
                                 node_info[n_key] = n_val
                         ret_dict[volname]['node'].append(node_info)
+                elif key=='tasks':
+                    nodename = 'task_status'
+                    if not isinstance(val,list):
+                        tasks = [val]
+                    for task in tasks:
+                        if 'task' in list(task.keys()):
+                            if nodename not in list(ret_dict[volname].keys()):
+                                ret_dict[volname][nodename] = [task['task']]
+                            else:
+                                ret_dict[volname][nodename].append(task['task'])
+                        else:
+                            ret_dict[volname][nodename] = [task]
                 else:
                     ret_dict[volname][key] = val
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -650,16 +650,17 @@ class VolumeOps(AbstractOps):
                             else:
                                 node_info[n_key] = n_val
                         ret_dict[volname]['node'].append(node_info)
-                elif key=='tasks':
+                elif key == 'tasks':
                     nodename = 'task_status'
-                    if not isinstance(val,list):
+                    if not isinstance(val, list):
                         tasks = [val]
                     for task in tasks:
                         if 'task' in list(task.keys()):
                             if nodename not in list(ret_dict[volname].keys()):
                                 ret_dict[volname][nodename] = [task['task']]
                             else:
-                                ret_dict[volname][nodename].append(task['task'])
+                                ret_dict[volname][nodename].append(
+                                    task['task'])
                         else:
                             ret_dict[volname][nodename] = [task]
                 else:
@@ -846,7 +847,7 @@ class VolumeOps(AbstractOps):
         for vol_type, count in volume_dict['voltype'].items():
             if vol_type != "transport":
                 if ((vol_type != "dist_count" and count > 0)
-                   or (vol_type == "dist_count" and count == 0)):
+                        or (vol_type == "dist_count" and count == 0)):
                     is_only_distribute = False
                     break
 
@@ -879,9 +880,9 @@ class VolumeOps(AbstractOps):
             return False
 
         # Wait for bricks to be online
-        bricks_online_status = (self.wait_for_bricks_to_come_online(volname,
-                                server_list,
-                                brick_list))
+        bricks_online_status = (
+            self.wait_for_bricks_to_come_online(volname, server_list,
+                                                brick_list))
         if not bricks_online_status:
             self.logger.error(f"Failed to wait for the volume {volname} "
                               "processes to be online")

--- a/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
+++ b/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
@@ -1,103 +1,57 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along`
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+  Stopping glusterd while doing rebalance operations and
+  fetch volume status.
+"""
+
+import traceback
+from tests.d_parent_test import DParentTest
+
+# disruptive;dist-rep
 
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.gluster_init import (
-    stop_glusterd, start_glusterd,
-    is_glusterd_running
-)
-from glustolibs.gluster.lib_utils import form_bricks_list
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
-from glustolibs.gluster.rebalance_ops import (
-    get_rebalance_status,
-    rebalance_start
-)
-from glustolibs.gluster.volume_libs import (
-    cleanup_volume
-)
-from glustolibs.gluster.volume_ops import (
-    volume_stop, volume_create, volume_start, get_volume_status
-)
-from glustolibs.io.utils import (
-    list_all_files_and_dirs_mounts,
-    wait_for_io_to_complete
-)
-from glustolibs.misc.misc_libs import upload_scripts
-
-
-@runs_on([['distributed-replicated'], ['glusterfs']])
-class XmlDumpGlusterVolumeStatus(GlusterBaseClass):
+class TestCase(DParentTest):
     """
     xml Dump of gluster volume status during rebalance, when one gluster
     node is down
     """
 
-    @classmethod
-    def setUpClass(cls):
-        # Calling GlusterBaseClass setUpClass
-        cls.get_super_method(cls, 'setUpClass')()
-
-        # Setup Volume and Mount Volume
-        ret = cls.setup_volume_and_mount_volume(mounts=cls.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
-
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts to clients %s" %
-                                 cls.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   cls.clients)
-
-        # Start IO on mounts
-        cls.all_mounts_procs = []
-        for index, mount_obj in enumerate(cls.mounts, start=1):
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dirname-start-num %d "
-                   "--dir-depth 1 "
-                   "--dir-length 5 "
-                   "--max-num-of-dirs 10 "
-                   "--num-of-files 60 %s" % (
-                       cls.script_upload_path,
-                       index + 10, mount_obj.mountpoint))
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
-            cls.all_mounts_procs.append(proc)
-        cls.io_validation_complete = False
-
-        # Wait for IO to complete
-        if not cls.io_validation_complete:
-            g.log.info("Wait for IO to complete")
-            ret = wait_for_io_to_complete(cls.all_mounts_procs, cls.mounts)
+    def terminate(self):
+        """
+        The voume created in the test case is destroyed.
+        """
+        try:
+            ret = self.redant.wait_for_io_to_complete(self.all_mounts_procs,
+                                                      self.mounts)
             if not ret:
-                raise ExecutionError("IO failed on some of the clients")
+                raise Exception("IO failed on some of the clients")
+            self.redant.cleanup_volume(self.volume_name1, self.server_list[0])
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-            ret = list_all_files_and_dirs_mounts(cls.mounts)
-            if not ret:
-                raise ExecutionError("Failed to list all files and dirs")
-
-    def test_xml_dump_of_gluster_volume_status_during_rebalance(self):
+    def run_test(self, redant):
         """
         1. Create a trusted storage pool by peer probing the node
-        2.  Create a distributed-replicated volume
+        2. Create a distributed-replicated volume
         3. Start the volume and fuse mount the volume and start IO
         4. Create another replicated volume and start it and stop it
         5. Start rebalance on the volume
@@ -105,81 +59,54 @@ class XmlDumpGlusterVolumeStatus(GlusterBaseClass):
             in the Trusted Storage pool.
         7. Get the status of the volumes with --xml dump
         """
-        self.volname_2 = "test_volume_2"
 
-        # create volume
-        # Fetching all the parameters for volume_create
-        list_of_three_servers = []
-        server_info_for_three_nodes = {}
-        for server in self.servers[:3]:
-            list_of_three_servers.append(server)
-            server_info_for_three_nodes[server] = self.all_servers_info[
-                server]
+        self.volume_type1 = 'rep'
+        self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        redant.setup_volume(self.volume_name1, self.server_list[0],
+                            conf_dict, self.server_list,
+                            self.brick_roots, True)
 
-        bricks_list = form_bricks_list(self.mnode, self.volname,
-                                       3, list_of_three_servers,
-                                       server_info_for_three_nodes)
-        # Creating volumes using 3 servers
-        ret, _, _ = volume_create(self.mnode, self.volname_2,
-                                  bricks_list, force=True)
-        self.assertFalse(ret, "Volume creation failed")
-        g.log.info("Volume %s created successfully", self.volname_2)
-        ret, _, _ = volume_start(self.mnode, self.volname_2)
-        self.assertFalse(
-            ret, "Failed to start volume {}".format(self.volname_2))
-        ret, _, _ = volume_stop(self.mnode, self.volname_2)
-        self.assertFalse(
-            ret, "Failed to stop volume {}".format(self.volname_2))
+        # Start IO on mounts
+        counter = 1
+        self.all_mounts_procs = []
+        self.mounts = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
+        for mount in self.mounts:
+            redant.logger.info(f"Starting IO on {mount['client']}:"
+                               f"{mount['mountpath']}")
+            proc = redant.create_deep_dirs_with_files(mount['mountpath'],
+                                                      counter, 2, 3, 4, 10,
+                                                      mount['client'])
+            self.all_mounts_procs.append(proc)
+            counter = counter + 10
+
+        # Validate IO
+        if not redant.validate_io_procs(self.all_mounts_procs, self.mounts):
+            raise Exception("IO failed on some of the clients")
+
+        ret = redant.volume_stop(self.volume_name1, self.server_list[0])
 
         # Start Rebalance
-        ret, _, _ = rebalance_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, ("Failed to start rebalance on the volume "
-                                  "%s", self.volname))
+        ret = redant.rebalance_start(self.vol_name, self.server_list[0])
 
         # Get rebalance status
-        status_info = get_rebalance_status(self.mnode, self.volname)
+        status_info = redant.get_rebalance_status(self.vol_name,
+                                                  self.server_list[0])
         status = status_info['aggregate']['statusStr']
 
-        self.assertIn('in progress', status,
-                      "Rebalance process is not running")
-        g.log.info("Rebalance process is running")
+        if 'in progress' not in status:
+            raise Exception("Rebalance process is not running")
+
+        redant.logger.info("Rebalance process is running")
 
         # Stop glusterd
-        ret = stop_glusterd(self.servers[2])
-        self.assertTrue(ret, "Failed to stop glusterd")
+        redant.stop_glusterd(self.server_list[2])
 
-        ret, out, _ = g.run(
-            self.mnode,
-            "gluster v status  | grep -A 4 'Rebalance' | awk 'NR==3{print "
-            "$3,$4}'")
-
-        ret = get_volume_status(self.mnode, self.volname, options="tasks")
-        rebalance_status = ret[self.volname]['task_status'][0]['statusStr']
-        self.assertIn(rebalance_status, out.replace("\n", ""))
-
-    def tearDown(self):
-        ret = is_glusterd_running(self.servers)
-        if ret:
-            ret = start_glusterd(self.servers)
-            if not ret:
-                raise ExecutionError("Failed to start glusterd on %s"
-                                     % self.servers)
-        g.log.info("Glusterd started successfully on %s", self.servers)
-
-        # Checking for peer status from every node
-        for server in self.servers:
-            ret = wait_for_peers_to_connect(server, self.servers)
-            if not ret:
-                raise ExecutionError("Servers are not in peer probed state")
-
-        ret = cleanup_volume(self.mnode, self.volname_2)
-        if not ret:
-            raise ExecutionError(
-                "Unable to delete volume % s" % self.volname_2)
-        # Unmount and cleanup original volume
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to umount the vol & cleanup Volume")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        cmd = ("gluster v status  | grep -A 4 'Rebalance' | awk 'NR==3{print "
+               "$3,$4}'")
+        ret = redant.execute_abstract_op_node(cmd, self.server_list[0])
+        ret1 = redant.get_volume_status(self.vol_name, self.server_list[0],
+                                        options="tasks")
+        rebalance_status = ret1[self.vol_name]['task_status'][0]['statusStr']
+        if rebalance_status not in " ".join(ret['msg']).replace("\n", ""):
+            raise Exception("rebalance status is not in volume status")

--- a/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
+++ b/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
@@ -1,0 +1,185 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.gluster_init import (
+    stop_glusterd, start_glusterd,
+    is_glusterd_running
+)
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
+from glustolibs.gluster.rebalance_ops import (
+    get_rebalance_status,
+    rebalance_start
+)
+from glustolibs.gluster.volume_libs import (
+    cleanup_volume
+)
+from glustolibs.gluster.volume_ops import (
+    volume_stop, volume_create, volume_start, get_volume_status
+)
+from glustolibs.io.utils import (
+    list_all_files_and_dirs_mounts,
+    wait_for_io_to_complete
+)
+from glustolibs.misc.misc_libs import upload_scripts
+
+
+@runs_on([['distributed-replicated'], ['glusterfs']])
+class XmlDumpGlusterVolumeStatus(GlusterBaseClass):
+    """
+    xml Dump of gluster volume status during rebalance, when one gluster
+    node is down
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Calling GlusterBaseClass setUpClass
+        cls.get_super_method(cls, 'setUpClass')()
+
+        # Setup Volume and Mount Volume
+        ret = cls.setup_volume_and_mount_volume(mounts=cls.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
+
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts to clients %s" %
+                                 cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+        # Start IO on mounts
+        cls.all_mounts_procs = []
+        for index, mount_obj in enumerate(cls.mounts, start=1):
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
+                   "--dirname-start-num %d "
+                   "--dir-depth 1 "
+                   "--dir-length 5 "
+                   "--max-num-of-dirs 10 "
+                   "--num-of-files 60 %s" % (
+                       cls.script_upload_path,
+                       index + 10, mount_obj.mountpoint))
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            cls.all_mounts_procs.append(proc)
+        cls.io_validation_complete = False
+
+        # Wait for IO to complete
+        if not cls.io_validation_complete:
+            g.log.info("Wait for IO to complete")
+            ret = wait_for_io_to_complete(cls.all_mounts_procs, cls.mounts)
+            if not ret:
+                raise ExecutionError("IO failed on some of the clients")
+
+            ret = list_all_files_and_dirs_mounts(cls.mounts)
+            if not ret:
+                raise ExecutionError("Failed to list all files and dirs")
+
+    def test_xml_dump_of_gluster_volume_status_during_rebalance(self):
+        """
+        1. Create a trusted storage pool by peer probing the node
+        2.  Create a distributed-replicated volume
+        3. Start the volume and fuse mount the volume and start IO
+        4. Create another replicated volume and start it and stop it
+        5. Start rebalance on the volume
+        6. While rebalance in progress, stop glusterd on one of the nodes
+            in the Trusted Storage pool.
+        7. Get the status of the volumes with --xml dump
+        """
+        self.volname_2 = "test_volume_2"
+
+        # create volume
+        # Fetching all the parameters for volume_create
+        list_of_three_servers = []
+        server_info_for_three_nodes = {}
+        for server in self.servers[:3]:
+            list_of_three_servers.append(server)
+            server_info_for_three_nodes[server] = self.all_servers_info[
+                server]
+
+        bricks_list = form_bricks_list(self.mnode, self.volname,
+                                       3, list_of_three_servers,
+                                       server_info_for_three_nodes)
+        # Creating volumes using 3 servers
+        ret, _, _ = volume_create(self.mnode, self.volname_2,
+                                  bricks_list, force=True)
+        self.assertFalse(ret, "Volume creation failed")
+        g.log.info("Volume %s created successfully", self.volname_2)
+        ret, _, _ = volume_start(self.mnode, self.volname_2)
+        self.assertFalse(
+            ret, "Failed to start volume {}".format(self.volname_2))
+        ret, _, _ = volume_stop(self.mnode, self.volname_2)
+        self.assertFalse(
+            ret, "Failed to stop volume {}".format(self.volname_2))
+
+        # Start Rebalance
+        ret, _, _ = rebalance_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, ("Failed to start rebalance on the volume "
+                                  "%s", self.volname))
+
+        # Get rebalance status
+        status_info = get_rebalance_status(self.mnode, self.volname)
+        status = status_info['aggregate']['statusStr']
+
+        self.assertIn('in progress', status,
+                      "Rebalance process is not running")
+        g.log.info("Rebalance process is running")
+
+        # Stop glusterd
+        ret = stop_glusterd(self.servers[2])
+        self.assertTrue(ret, "Failed to stop glusterd")
+
+        ret, out, _ = g.run(
+            self.mnode,
+            "gluster v status  | grep -A 4 'Rebalance' | awk 'NR==3{print "
+            "$3,$4}'")
+
+        ret = get_volume_status(self.mnode, self.volname, options="tasks")
+        rebalance_status = ret[self.volname]['task_status'][0]['statusStr']
+        self.assertIn(rebalance_status, out.replace("\n", ""))
+
+    def tearDown(self):
+        ret = is_glusterd_running(self.servers)
+        if ret:
+            ret = start_glusterd(self.servers)
+            if not ret:
+                raise ExecutionError("Failed to start glusterd on %s"
+                                     % self.servers)
+        g.log.info("Glusterd started successfully on %s", self.servers)
+
+        # Checking for peer status from every node
+        for server in self.servers:
+            ret = wait_for_peers_to_connect(server, self.servers)
+            if not ret:
+                raise ExecutionError("Servers are not in peer probed state")
+
+        ret = cleanup_volume(self.mnode, self.volname_2)
+        if not ret:
+            raise ExecutionError(
+                "Unable to delete volume % s" % self.volname_2)
+        # Unmount and cleanup original volume
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to umount the vol & cleanup Volume")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
+++ b/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
@@ -27,10 +27,6 @@ from tests.d_parent_test import DParentTest
 
 
 class TestCase(DParentTest):
-    """
-    xml Dump of gluster volume status during rebalance, when one gluster
-    node is down
-    """
 
     def terminate(self):
         """
@@ -84,14 +80,16 @@ class TestCase(DParentTest):
         if not redant.validate_io_procs(self.all_mounts_procs, self.mounts):
             raise Exception("IO failed on some of the clients")
 
-        ret = redant.volume_stop(self.volume_name1, self.server_list[0])
+        redant.volume_stop(self.volume_name1, self.server_list[0])
 
         # Start Rebalance
-        ret = redant.rebalance_start(self.vol_name, self.server_list[0])
+        redant.rebalance_start(self.vol_name, self.server_list[0])
 
         # Get rebalance status
         status_info = redant.get_rebalance_status(self.vol_name,
                                                   self.server_list[0])
+        if status_info is None:
+            raise Exception("Rebalance status returned None")
         status = status_info['aggregate']['statusStr']
 
         if 'in progress' not in status:
@@ -110,6 +108,8 @@ class TestCase(DParentTest):
         ret = redant.execute_abstract_op_node(cmd, self.server_list[0])
         ret1 = redant.get_volume_status(self.vol_name, self.server_list[0],
                                         options="tasks")
+        if ret1 is None:
+            raise Exception("Volume status returned None")
         rebalance_status = ret1[self.vol_name]['task_status'][0]['statusStr']
         if rebalance_status not in " ".join(ret['msg']).replace("\n", ""):
             raise Exception("rebalance status is not in volume status")

--- a/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
+++ b/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
@@ -101,6 +101,9 @@ class TestCase(DParentTest):
 
         # Stop glusterd
         redant.stop_glusterd(self.server_list[2])
+        if not redant.wait_for_glusterd_to_stop(self.server_list[2]):
+            raise Exception("glusterd has not stopped on "
+                            f"{self.server_list[2]}")
 
         cmd = ("gluster v status  | grep -A 4 'Rebalance' | awk 'NR==3{print "
                "$3,$4}'")


### PR DESCRIPTION
[test case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py) is migrated from glusto to redant and get_volume_status is modified in volume_ops to accomodate the tasks option in status

Updates: #292
Fixes: #536
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>