### PR TITLE
Migrated test_glusterd_quorum TC

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -522,16 +522,21 @@ class VolumeOps(AbstractOps):
         return volume_list
 
     def volume_reset(self, volname: str, node: str = None,
-                     force: bool = False):
+                     force: bool = False, excep: bool = True) -> dict:
         """
         Resets the gluster volume of all the reconfigured options.
         Args:
             node (str): Node on which cmd has to be executed.
             volname (str): Name of the volume to reset
-        Kwargs:
+
+        Optional:
             force (bool): If this option is set to True, then reset volume
                 will get executed with force option. If it is set to False,
                 then reset volume will get executed without force option
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
         Example:
             volume_reset("testvol",server)
 
@@ -550,7 +555,7 @@ class VolumeOps(AbstractOps):
         else:
             cmd = f"gluster volume reset {volname} --mode=script --xml"
 
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
 
         return ret
 

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -35,6 +35,7 @@ class DParentTest(metaclass=abc.ABCMeta):
         client_details = param_obj.get_client_config()
 
         self.TEST_RES = True
+        self.setup_done = False
         self.volume_type = volume_type
         self.vol_type_inf = param_obj.get_volume_types()
         self.test_name = mname
@@ -53,6 +54,10 @@ class DParentTest(metaclass=abc.ABCMeta):
         self.redant.establish_connection()
 
     @abc.abstractmethod
+    def setup_test(self):
+        pass
+
+    @abc.abstractmethod
     def run_test(self, redant):
         pass
 
@@ -65,7 +70,11 @@ class DParentTest(metaclass=abc.ABCMeta):
             self.redant.start_glusterd(self.server_list)
             self.redant.create_cluster(self.server_list)
 
-            if self.volume_type != "Generic":
+            # Call setup in case you want to override volume creation,
+            # start, mounting in the TC
+            self.setup_test()
+
+            if not self.setup_done and self.volume_type != "Generic":
                 self.redant.volume_create(
                     self.vol_name, self.server_list[0],
                     self.vol_type_inf[self.conv_dict[self.volume_type]],

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -53,7 +53,6 @@ class DParentTest(metaclass=abc.ABCMeta):
         self.redant.init_logger(mname, log_path, log_level)
         self.redant.establish_connection()
 
-    @abc.abstractmethod
     def setup_test(self):
         pass
 

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -37,7 +37,7 @@ class TestServerQuorum(GlusterBaseClass):
     @classmethod
     def setUpClass(cls):
         # Calling GlusterBaseClass setUpClass
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
         ret = volume_exists(cls.mnode, cls.volname)
         if ret:
             ret = cleanup_volume(cls.mnode, cls.volname)
@@ -90,7 +90,7 @@ class TestServerQuorum(GlusterBaseClass):
                         "Peer probe failed to one of the node")
                 g.log.info("Peer probe successful")
 
-        GlusterBaseClass.tearDownClass.im_func(cls)
+        cls.get_super_method(cls, 'tearDownClass')()
 
     @pytest.mark.test_glusterd_quorum_validation
     def test_glusterd_quorum_validation(self):

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -146,7 +146,7 @@ class TestCase(DParentTest):
         # Deleting a volume should fail. Deleting the second volume.
         ret = redant.volume_delete(self.volume_name1, self.server_list[0],
                                    False)
-        if ret['msg']['opRet'] == 0:
+        if ret['msg']['opRet'] == '0':
             raise Exception("Unexpected: Volume delete was "
                             "successful even when quourm is not met")
 

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -60,37 +60,36 @@ class TestServerQuorum(GlusterBaseClass):
             raise ExecutionError("Minimun four nodes required for this "
                                  " testcase to execute")
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
 
-        # Setting quorum ratio to 51%
-        ret = set_volume_options(cls.mnode, 'all',
-                                 {'cluster.server-quorum-ratio': '51%'})
-        if not ret:
-            raise ExecutionError("Failed to set server quorum ratio on %s"
-                                 % cls.volname)
-
-        vol_list = get_volume_list(cls.mnode)
+        vol_list = get_volume_list(self.mnode)
         if vol_list is None:
             raise ExecutionError("Failed to get volume list")
 
         for volume in vol_list:
-            ret = cleanup_volume(cls.mnode, volume)
+            ret = cleanup_volume(self.mnode, volume)
             if not ret:
                 raise ExecutionError("Failed Cleanup the volume")
             g.log.info("Volume deleted successfully %s", volume)
 
+        # Setting quorum ratio to 51%
+        ret = set_volume_options(self.mnode, 'all',
+                                 {'cluster.server-quorum-ratio': '51%'})
+        if not ret:
+            raise ExecutionError("Failed to set server quorum ratio on %s"
+                                 % self.volname)
+
         # Peer probe servers since we are doing peer detach in setUpClass
-        for server in cls.servers:
-            ret = is_peer_connected(server, cls.servers)
+        for server in self.servers:
+            ret = is_peer_connected(server, self.servers)
             if not ret:
-                ret = peer_probe_servers(server, cls.servers)
+                ret = peer_probe_servers(server, self.servers)
                 if not ret:
                     raise ExecutionError(
                         "Peer probe failed to one of the node")
                 g.log.info("Peer probe successful")
 
-        cls.get_super_method(cls, 'tearDownClass')()
+        self.get_super_method(self, 'tearDown')()
 
     @pytest.mark.test_glusterd_quorum_validation
     def test_glusterd_quorum_validation(self):

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -1,0 +1,301 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from time import sleep
+import pytest
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.brick_libs import wait_for_bricks_to_be_online
+from glustolibs.gluster.volume_libs import (setup_volume, volume_exists,
+                                            cleanup_volume)
+from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
+                                             is_glusterd_running)
+from glustolibs.gluster.volume_ops import (set_volume_options, volume_start,
+                                           volume_stop, volume_delete,
+                                           get_volume_list, volume_reset)
+from glustolibs.gluster.peer_ops import (is_peer_connected, peer_probe_servers,
+                                         peer_detach_servers, peer_probe)
+
+
+@runs_on([['distributed-replicated', 'replicated'], ['glusterfs']])
+class TestServerQuorum(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        # Calling GlusterBaseClass setUpClass
+        GlusterBaseClass.setUpClass.im_func(cls)
+        ret = volume_exists(cls.mnode, cls.volname)
+        if ret:
+            ret = cleanup_volume(cls.mnode, cls.volname)
+            if not ret:
+                raise ExecutionError("Unable to delete volume")
+            g.log.info("Successfully deleted volume % s", cls.volname)
+
+        # Check if peer is connected state or not and detach all the nodes
+        for server in cls.servers:
+            ret = is_peer_connected(server, cls.servers)
+            if ret:
+                ret = peer_detach_servers(server, cls.servers)
+                if not ret:
+                    raise ExecutionError(
+                        "Detach failed from all the servers from the node.")
+                g.log.info("Peer detach SUCCESSFUL.")
+
+        # Before starting the testcase, proceed only it has minimum of 4 nodes
+        if len(cls.servers) < 4:
+            raise ExecutionError("Minimun four nodes required for this "
+                                 " testcase to execute")
+
+    @classmethod
+    def tearDownClass(cls):
+
+        # Setting quorum ratio to 51%
+        ret = set_volume_options(cls.mnode, 'all',
+                                 {'cluster.server-quorum-ratio': '51%'})
+        if not ret:
+            raise ExecutionError("Failed to set server quorum ratio on %s"
+                                 % cls.volname)
+
+        vol_list = get_volume_list(cls.mnode)
+        if vol_list is None:
+            raise ExecutionError("Failed to get volume list")
+
+        for volume in vol_list:
+            ret = cleanup_volume(cls.mnode, volume)
+            if not ret:
+                raise ExecutionError("Failed Cleanup the volume")
+            g.log.info("Volume deleted successfully %s", volume)
+
+        # Peer probe servers since we are doing peer detach in setUpClass
+        for server in cls.servers:
+            ret = is_peer_connected(server, cls.servers)
+            if not ret:
+                ret = peer_probe_servers(server, cls.servers)
+                if not ret:
+                    raise ExecutionError(
+                        "Peer probe failed to one of the node")
+                g.log.info("Peer probe successful")
+
+        GlusterBaseClass.tearDownClass.im_func(cls)
+
+    @pytest.mark.test_glusterd_quorum_validation
+    def test_glusterd_quorum_validation(self):
+        """
+        -> Creating two volumes and starting them, stop the second volume
+        -> set the server quorum and set the ratio to 90
+        -> Stop the glusterd in one of the node, so the quorum won't meet
+        -> Peer probing a new node should fail
+        -> Volume stop will fail
+        -> volume delete will fail
+        -> volume reset will fail
+        -> Start the glusterd on the node where it is stopped
+        -> Volume stop, start, delete will succeed once quorum is met
+        """
+        # pylint: disable=too-many-statements, too-many-branches
+
+        # Peer probe first 3 servers
+        servers_info_from_three_nodes = {}
+        for server in self.servers[0:3]:
+            servers_info_from_three_nodes[
+                server] = self.all_servers_info[server]
+
+            # Peer probe the first 3 servers
+            ret, _, _ = peer_probe(self.mnode, server)
+            self.assertEqual(ret, 0,
+                             ("Peer probe failed to one of the server"))
+        g.log.info("Peer probe to first 3 nodes succeeded")
+
+        self.volume['servers'] = self.servers[0:3]
+        # Create a volume using the first 3 nodes
+        ret = setup_volume(self.mnode, servers_info_from_three_nodes,
+                           self.volume, force=True)
+        self.assertTrue(ret, ("Failed to create and start volume"))
+        g.log.info("Volume created and started successfully")
+
+        # Creating another volume and stopping it
+        second_volume = "second_volume"
+        self.volume['name'] = second_volume
+        ret = setup_volume(self.mnode, servers_info_from_three_nodes,
+                           self.volume, force=True)
+        self.assertTrue(ret, ("Failed to create and start volume"))
+        g.log.info("Volume created and started succssfully")
+
+        # stopping the second volume
+        g.log.info("Stopping the second volume %s", second_volume)
+        ret, _, _ = volume_stop(self.mnode, second_volume)
+        self.assertEqual(ret, 0, ("Failed to stop the volume"))
+        g.log.info("Successfully stopped second volume %s", second_volume)
+
+        # Setting the server-quorum-type as server
+        self.options = {"cluster.server-quorum-type": "server"}
+        vol_list = get_volume_list(self.mnode)
+        self.assertIsNotNone(vol_list, "Failed to get the volume list")
+        g.log.info("Fetched the volume list")
+        for volume in vol_list:
+            g.log.info("Setting the server-quorum-type as server"
+                       " on volume %s", volume)
+            ret = set_volume_options(self.mnode, volume, self.options)
+            self.assertTrue(ret, ("Failed to set the quorum type as a server"
+                                  " on volume %s", volume))
+        g.log.info("Server Quorum type is set as a server")
+
+        # Setting the server quorum ratio to 90
+        self.quorum_perecent = {'cluster.server-quorum-ratio': '90%'}
+        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
+        self.assertTrue(ret, ("Failed to set the server quorum ratio "
+                              "to 90 on servers"))
+        g.log.info("Successfully set server quorum ratio to 90% on servers")
+
+        # Stop glusterd on one of the node
+        ret = stop_glusterd(self.servers[2])
+        self.assertTrue(ret, ("Failed to stop glusterd on "
+                              "node %s", self.servers[2]))
+        g.log.info("Glusterd stop on the nodes : %s"
+                   " succeeded", self.servers[2])
+
+        # Check glusterd is stopped
+        ret = is_glusterd_running(self.servers[2])
+        self.assertEqual(ret, 1, "Unexpected: Glusterd is running on node")
+        g.log.info("Expected: Glusterd stopped on node %s", self.servers[2])
+
+        # Adding a new peer will fail as quorum not met
+        ret, _, _ = peer_probe(self.mnode, self.servers[3])
+        self.assertNotEqual(ret, 0, (
+            "Unexpected:"
+            "Succeeded to peer probe new node %s when quorum "
+            "is not met", self.servers[3]))
+        g.log.info("Failed to peer probe new node as expected"
+                   " when quorum not met")
+
+        # Stopping an already started volume should fail as quorum is not met
+        ret, _, _ = volume_start(self.mnode, second_volume)
+        self.assertNotEqual(ret, 0, "Unexpected: Successfuly started "
+                            "volume even when quorum not met.")
+        g.log.info("Volume start %s failed as expected when quorum "
+                   "is not met", second_volume)
+
+        # Stopping a volume should fail stop the first volume
+        ret, _, _ = volume_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 1, "Unexpected: Successfully stopped"
+                         " volume even when quourm is not met")
+        g.log.info("volume stop %s failed as expected when quorum "
+                   "is not met", self.volname)
+
+        # Stopping a volume with force option should fail
+        ret, _, _ = volume_stop(self.mnode, self.volname, force=True)
+        self.assertNotEqual(ret, 0, "Unexpected: Successfully "
+                            "stopped volume with force. Expected: "
+                            "Volume stop should fail when quourm is not met")
+        g.log.info("volume stop failed as expected when quorum is not met")
+
+        # Deleting a volume should fail. Deleting the second volume.
+        ret = volume_delete(self.mnode, second_volume)
+        self.assertFalse(ret, "Unexpected: Volume delete was "
+                         "successful even when quourm is not met")
+        g.log.info("volume delete failed as expected when quorum is not met")
+
+        # Volume reset should fail when quorum is not met
+        ret, _, _ = volume_reset(self.mnode, self.volname)
+        self.assertNotEqual(ret, 0, "Unexpected: Volume reset was "
+                            "successful even when quorum is not met")
+        g.log.info("volume reset failed as expected when quorum is not met")
+
+        # Volume reset should fail even with force when quourum is not met
+        ret, _, _ = volume_reset(self.mnode, self.volname, force=True)
+        self.assertNotEqual(ret, 0, "Unexpected: Volume reset was "
+                            "successful with force even "
+                            "when quourm is not met")
+        g.log.info("volume reset failed as expected when quorum is not met")
+
+        # Start glusterd on the node where glusterd is stopped
+        ret = start_glusterd(self.servers[2])
+        self.assertTrue(ret, "Failed to start glusterd on one node")
+        g.log.info("Started glusterd on server"
+                   " %s successfully", self.servers[2])
+
+        ret = is_glusterd_running(self.servers[2])
+        self.assertEqual(ret, 0, ("glusterd is not running on "
+                                  "node %s", self.servers[2]))
+        g.log.info("glusterd is running on node"
+                   " %s ", self.servers[2])
+
+        # Check peer status whether all peer are in connected state none of the
+        # nodes should be in peer rejected state
+        halt, counter, _rc = 30, 0, False
+        g.log.info("Wait for some seconds, right after glusterd start it "
+                   "will create two daemon process it need few seconds "
+                   "(like 3-5) to initialize the glusterd")
+        while counter < halt:
+            ret = is_peer_connected(self.mnode, self.servers[0:3])
+            if not ret:
+                g.log.info("Peers are not connected state,"
+                           " Retry after 2 seconds .......")
+                sleep(2)
+                counter = counter + 2
+            else:
+                _rc = True
+                g.log.info("Peers are in connected state in the cluster")
+                break
+
+        self.assertTrue(_rc, ("Peers are not connected state after "
+                              "bringing back glusterd online on the "
+                              "nodes in which previously glusterd "
+                              "had been stopped"))
+
+        # Check all bricks are online or wait for the bricks to be online
+        ret = wait_for_bricks_to_be_online(self.mnode, self.volname)
+        self.assertTrue(ret, "All bricks are not online")
+        g.log.info("All bricks of the volume %s are online", self.volname)
+
+        # Once quorum is met should be able to cleanup the volume
+        ret = volume_delete(self.mnode, second_volume)
+        self.assertTrue(ret, "Volume delete failed even when quorum is met")
+        g.log.info("volume delete succeed without any issues")
+
+        # Volume stop should succeed
+        ret, _, _ = volume_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Volume stop failed")
+        g.log.info("succeeded stopping the volume as expected")
+
+        # volume reset should succeed
+        ret, _, _ = volume_reset(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Volume reset failed ")
+        g.log.info("volume reset succeeded as expected when quorum is not met")
+
+        # Peer probe new node should succeed
+        ret, _, _ = peer_probe(self.mnode, self.servers[3])
+        self.assertEqual(ret, 0, (
+            "Failed to peer probe new node even when quorum is met"))
+        g.log.info("Succeeded to peer probe new node when quorum met")
+
+        # Check peer status whether all peer are in connected state none of the
+        # nodes should be in peer rejected state
+        halt, counter, _rc = 30, 0, False
+        g.log.info("Wait for some seconds, right after peer probe")
+        while counter < halt:
+            ret = is_peer_connected(self.mnode, self.servers[0:3])
+            if not ret:
+                g.log.info("Peers are not connected state,"
+                           " Retry after 2 seconds .......")
+                sleep(2)
+                counter = counter + 2
+            else:
+                _rc = True
+                g.log.info("Peers are in connected state in the cluster")
+                break
+
+        self.assertTrue(_rc, ("Peers are not connected state"))

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -1,98 +1,59 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 
-from time import sleep
-import pytest
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.brick_libs import wait_for_bricks_to_be_online
-from glustolibs.gluster.volume_libs import (setup_volume, volume_exists,
-                                            cleanup_volume)
-from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
-                                             is_glusterd_running)
-from glustolibs.gluster.volume_ops import (set_volume_options, volume_start,
-                                           volume_stop, volume_delete,
-                                           get_volume_list, volume_reset)
-from glustolibs.gluster.peer_ops import (is_peer_connected, peer_probe_servers,
-                                         peer_detach_servers, peer_probe)
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+    TC to check glusterd quorum
+"""
+
+import traceback
+from tests.d_parent_test import DParentTest
+
+# disruptive;rep,dist-rep
 
 
-@runs_on([['distributed-replicated', 'replicated'], ['glusterfs']])
-class TestServerQuorum(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-        # Calling GlusterBaseClass setUpClass
-        cls.get_super_method(cls, 'setUpClass')()
-        ret = volume_exists(cls.mnode, cls.volname)
-        if ret:
-            ret = cleanup_volume(cls.mnode, cls.volname)
-            if not ret:
-                raise ExecutionError("Unable to delete volume")
-            g.log.info("Successfully deleted volume % s", cls.volname)
+    def setup_test(self):
+        """
+        Override the volume create, start and mount in parent_run_test
+        """
+        self.setup_done = True
 
-        # Check if peer is connected state or not and detach all the nodes
-        for server in cls.servers:
-            ret = is_peer_connected(server, cls.servers)
-            if ret:
-                ret = peer_detach_servers(server, cls.servers)
-                if not ret:
-                    raise ExecutionError(
-                        "Detach failed from all the servers from the node.")
-                g.log.info("Peer detach SUCCESSFUL.")
+    def terminate(self):
+        """
+        Cleanup the volume created in the TC
+        """
+        try:
+            # Start glusterd on all servers
+            self.redant.start_glusterd(self.server_list)
+            if not self.redant.wait_for_glusterd_to_start(self.server_list):
+                raise Exception("Failed to start glusterd on all nodes")
 
-        # Before starting the testcase, proceed only it has minimum of 4 nodes
-        if len(cls.servers) < 4:
-            raise ExecutionError("Minimun four nodes required for this "
-                                 " testcase to execute")
+            if self.vol_exist:
+                self.redant.cleanup_volume(self.volume_name1,
+                                           self.server_list[0])
 
-    def tearDown(self):
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-        vol_list = get_volume_list(self.mnode)
-        if vol_list is None:
-            raise ExecutionError("Failed to get volume list")
-
-        for volume in vol_list:
-            ret = cleanup_volume(self.mnode, volume)
-            if not ret:
-                raise ExecutionError("Failed Cleanup the volume")
-            g.log.info("Volume deleted successfully %s", volume)
-
-        # Setting quorum ratio to 51%
-        ret = set_volume_options(self.mnode, 'all',
-                                 {'cluster.server-quorum-ratio': '51%'})
-        if not ret:
-            raise ExecutionError("Failed to set server quorum ratio on %s"
-                                 % self.volname)
-
-        # Peer probe servers since we are doing peer detach in setUpClass
-        for server in self.servers:
-            ret = is_peer_connected(server, self.servers)
-            if not ret:
-                ret = peer_probe_servers(server, self.servers)
-                if not ret:
-                    raise ExecutionError(
-                        "Peer probe failed to one of the node")
-                g.log.info("Peer probe successful")
-
-        self.get_super_method(self, 'tearDown')()
-
-    @pytest.mark.test_glusterd_quorum_validation
-    def test_glusterd_quorum_validation(self):
+    def run_test(self, redant):
         """
         -> Creating two volumes and starting them, stop the second volume
         -> set the server quorum and set the ratio to 90
@@ -104,197 +65,147 @@ class TestServerQuorum(GlusterBaseClass):
         -> Start the glusterd on the node where it is stopped
         -> Volume stop, start, delete will succeed once quorum is met
         """
-        # pylint: disable=too-many-statements, too-many-branches
+        self.vol_exist = False
+
+        # Exit if cluster size less than 4
+        if len(self.server_list) < 4:
+            raise Exception("Minimum 4 nodes required for this TC to run")
 
         # Peer probe first 3 servers
-        servers_info_from_three_nodes = {}
-        for server in self.servers[0:3]:
-            servers_info_from_three_nodes[
-                server] = self.all_servers_info[server]
+        redant.create_cluster(self.server_list[:3])
 
-            # Peer probe the first 3 servers
-            ret, _, _ = peer_probe(self.mnode, server)
-            self.assertEqual(ret, 0,
-                             ("Peer probe failed to one of the server"))
-        g.log.info("Peer probe to first 3 nodes succeeded")
-
-        self.volume['servers'] = self.servers[0:3]
         # Create a volume using the first 3 nodes
-        ret = setup_volume(self.mnode, servers_info_from_three_nodes,
-                           self.volume, force=True)
-        self.assertTrue(ret, ("Failed to create and start volume"))
-        g.log.info("Volume created and started successfully")
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        redant.setup_volume(self.vol_name, self.server_list[0],
+                            conf_dict, self.server_list,
+                            self.brick_roots)
 
         # Creating another volume and stopping it
-        second_volume = "second_volume"
-        self.volume['name'] = second_volume
-        ret = setup_volume(self.mnode, servers_info_from_three_nodes,
-                           self.volume, force=True)
-        self.assertTrue(ret, ("Failed to create and start volume"))
-        g.log.info("Volume created and started succssfully")
+        self.volume_type1 = 'dist'
+        self.volume_name1 = f"{self.test_name}-1"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        redant.setup_volume(self.volume_name1, self.server_list[0],
+                            conf_dict, self.server_list,
+                            self.brick_roots)
+        self.vol_exist = True
 
         # stopping the second volume
-        g.log.info("Stopping the second volume %s", second_volume)
-        ret, _, _ = volume_stop(self.mnode, second_volume)
-        self.assertEqual(ret, 0, ("Failed to stop the volume"))
-        g.log.info("Successfully stopped second volume %s", second_volume)
+        redant.volume_stop(self.volume_name1, self.server_list[0])
 
         # Setting the server-quorum-type as server
         self.options = {"cluster.server-quorum-type": "server"}
-        vol_list = get_volume_list(self.mnode)
-        self.assertIsNotNone(vol_list, "Failed to get the volume list")
-        g.log.info("Fetched the volume list")
+        vol_list = redant.get_volume_list(self.server_list[0])
+        if vol_list is None:
+            raise Exception("Failed to get the volume list")
+
         for volume in vol_list:
-            g.log.info("Setting the server-quorum-type as server"
-                       " on volume %s", volume)
-            ret = set_volume_options(self.mnode, volume, self.options)
-            self.assertTrue(ret, ("Failed to set the quorum type as a server"
-                                  " on volume %s", volume))
-        g.log.info("Server Quorum type is set as a server")
+            redant.set_volume_options(volume, self.options,
+                                      self.server_list[0])
 
         # Setting the server quorum ratio to 90
         self.quorum_perecent = {'cluster.server-quorum-ratio': '90%'}
-        ret = set_volume_options(self.mnode, 'all', self.quorum_perecent)
-        self.assertTrue(ret, ("Failed to set the server quorum ratio "
-                              "to 90 on servers"))
-        g.log.info("Successfully set server quorum ratio to 90% on servers")
+        redant.set_volume_options('all', self.quorum_perecent,
+                                  self.server_list[0])
 
         # Stop glusterd on one of the node
-        ret = stop_glusterd(self.servers[2])
-        self.assertTrue(ret, ("Failed to stop glusterd on "
-                              "node %s", self.servers[2]))
-        g.log.info("Glusterd stop on the nodes : %s"
-                   " succeeded", self.servers[2])
+        redant.stop_glusterd(self.server_list[2])
 
         # Check glusterd is stopped
-        ret = is_glusterd_running(self.servers[2])
-        self.assertEqual(ret, 1, "Unexpected: Glusterd is running on node")
-        g.log.info("Expected: Glusterd stopped on node %s", self.servers[2])
+        if not redant.wait_for_glusterd_to_stop(self.server_list[2]):
+            raise Exception("Unexpected: Glusterd is running on node")
 
         # Adding a new peer will fail as quorum not met
-        ret, _, _ = peer_probe(self.mnode, self.servers[3])
-        self.assertNotEqual(ret, 0, (
-            "Unexpected:"
-            "Succeeded to peer probe new node %s when quorum "
-            "is not met", self.servers[3]))
-        g.log.info("Failed to peer probe new node as expected"
-                   " when quorum not met")
+        ret = redant.peer_probe(self.server_list[3], self.server_list[0],
+                                False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Succeeded to peer probe new node"
+                            f" {self.server_list[3]} when quorum is not met")
 
         # Stopping an already started volume should fail as quorum is not met
-        ret, _, _ = volume_start(self.mnode, second_volume)
-        self.assertNotEqual(ret, 0, "Unexpected: Successfuly started "
+        ret = redant.volume_start(self.volume_name1, self.server_list[0],
+                                  False, False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Successfuly started "
                             "volume even when quorum not met.")
-        g.log.info("Volume start %s failed as expected when quorum "
-                   "is not met", second_volume)
 
         # Stopping a volume should fail stop the first volume
-        ret, _, _ = volume_stop(self.mnode, self.volname)
-        self.assertEqual(ret, 1, "Unexpected: Successfully stopped"
-                         " volume even when quourm is not met")
-        g.log.info("volume stop %s failed as expected when quorum "
-                   "is not met", self.volname)
+        ret = redant.volume_stop(self.vol_name, self.server_list[0], False,
+                                 False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Successfully stopped"
+                            " volume even when quourm is not met")
 
         # Stopping a volume with force option should fail
-        ret, _, _ = volume_stop(self.mnode, self.volname, force=True)
-        self.assertNotEqual(ret, 0, "Unexpected: Successfully "
+        ret = redant.volume_stop(self.vol_name, self.server_list[0], True,
+                                 False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Successfully "
                             "stopped volume with force. Expected: "
                             "Volume stop should fail when quourm is not met")
-        g.log.info("volume stop failed as expected when quorum is not met")
 
         # Deleting a volume should fail. Deleting the second volume.
-        ret = volume_delete(self.mnode, second_volume)
-        self.assertFalse(ret, "Unexpected: Volume delete was "
-                         "successful even when quourm is not met")
-        g.log.info("volume delete failed as expected when quorum is not met")
+        ret = redant.volume_delete(self.volume_name1, self.server_list[0],
+                                   False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Volume delete was "
+                            "successful even when quourm is not met")
 
         # Volume reset should fail when quorum is not met
-        ret, _, _ = volume_reset(self.mnode, self.volname)
-        self.assertNotEqual(ret, 0, "Unexpected: Volume reset was "
+        ret = redant.volume_reset(self.vol_name, self.server_list[0], False,
+                                  False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Volume reset was "
                             "successful even when quorum is not met")
-        g.log.info("volume reset failed as expected when quorum is not met")
 
         # Volume reset should fail even with force when quourum is not met
-        ret, _, _ = volume_reset(self.mnode, self.volname, force=True)
-        self.assertNotEqual(ret, 0, "Unexpected: Volume reset was "
-                            "successful with force even "
-                            "when quourm is not met")
-        g.log.info("volume reset failed as expected when quorum is not met")
+        ret = redant.volume_reset(self.vol_name, self.server_list[0], True,
+                                  False)
+        if ret['msg']['opRet'] == 0:
+            raise Exception("Unexpected: Volume reset was "
+                            "successful with force even when quorum is"
+                            " not met")
 
         # Start glusterd on the node where glusterd is stopped
-        ret = start_glusterd(self.servers[2])
-        self.assertTrue(ret, "Failed to start glusterd on one node")
-        g.log.info("Started glusterd on server"
-                   " %s successfully", self.servers[2])
+        redant.start_glusterd(self.server_list[2])
 
-        ret = is_glusterd_running(self.servers[2])
-        self.assertEqual(ret, 0, ("glusterd is not running on "
-                                  "node %s", self.servers[2]))
-        g.log.info("glusterd is running on node"
-                   " %s ", self.servers[2])
+        if not redant.wait_for_glusterd_to_start(self.server_list[2]):
+            raise Exception("glusterd is not running on "
+                            f"node: {self.server_list[2]}")
 
         # Check peer status whether all peer are in connected state none of the
         # nodes should be in peer rejected state
-        halt, counter, _rc = 30, 0, False
-        g.log.info("Wait for some seconds, right after glusterd start it "
-                   "will create two daemon process it need few seconds "
-                   "(like 3-5) to initialize the glusterd")
-        while counter < halt:
-            ret = is_peer_connected(self.mnode, self.servers[0:3])
-            if not ret:
-                g.log.info("Peers are not connected state,"
-                           " Retry after 2 seconds .......")
-                sleep(2)
-                counter = counter + 2
-            else:
-                _rc = True
-                g.log.info("Peers are in connected state in the cluster")
-                break
-
-        self.assertTrue(_rc, ("Peers are not connected state after "
-                              "bringing back glusterd online on the "
-                              "nodes in which previously glusterd "
-                              "had been stopped"))
+        if not redant.wait_till_all_peers_connected(self.server_list[:3], 30):
+            raise Exception("Peers are not connected state after "
+                            "bringing back glusterd online on the "
+                            "nodes in which previously glusterd "
+                            "had been stopped")
 
         # Check all bricks are online or wait for the bricks to be online
-        ret = wait_for_bricks_to_be_online(self.mnode, self.volname)
-        self.assertTrue(ret, "All bricks are not online")
-        g.log.info("All bricks of the volume %s are online", self.volname)
+        brick_list = redant.get_all_bricks(self.vol_name, self.server_list[0])
+        if brick_list is None:
+            raise Exception("Failed to get the brick list")
+        if not redant.wait_for_bricks_to_come_online(self.vol_name,
+                                                     self.server_list,
+                                                     brick_list):
+            raise Exception("All bricks are not online")
 
         # Once quorum is met should be able to cleanup the volume
-        ret = volume_delete(self.mnode, second_volume)
-        self.assertTrue(ret, "Volume delete failed even when quorum is met")
-        g.log.info("volume delete succeed without any issues")
+        redant.volume_delete(self.volume_name1, self.server_list[0])
+        self.vol_exist = False
 
         # Volume stop should succeed
-        ret, _, _ = volume_stop(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Volume stop failed")
-        g.log.info("succeeded stopping the volume as expected")
+        redant.volume_stop(self.vol_name, self.server_list[0])
 
         # volume reset should succeed
-        ret, _, _ = volume_reset(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Volume reset failed ")
-        g.log.info("volume reset succeeded as expected when quorum is not met")
+        redant.volume_reset(self.vol_name, self.server_list[0])
 
         # Peer probe new node should succeed
-        ret, _, _ = peer_probe(self.mnode, self.servers[3])
-        self.assertEqual(ret, 0, (
-            "Failed to peer probe new node even when quorum is met"))
-        g.log.info("Succeeded to peer probe new node when quorum met")
+        redant.peer_probe(self.server_list[3], self.server_list[0])
 
         # Check peer status whether all peer are in connected state none of the
         # nodes should be in peer rejected state
-        halt, counter, _rc = 30, 0, False
-        g.log.info("Wait for some seconds, right after peer probe")
-        while counter < halt:
-            ret = is_peer_connected(self.mnode, self.servers[0:3])
-            if not ret:
-                g.log.info("Peers are not connected state,"
-                           " Retry after 2 seconds .......")
-                sleep(2)
-                counter = counter + 2
-            else:
-                _rc = True
-                g.log.info("Peers are in connected state in the cluster")
-                break
-
-        self.assertTrue(_rc, ("Peers are not connected state"))
+        if not redant.wait_till_all_peers_connected(self.server_list[:3], 30):
+            raise Exception("Peers are not connected state after "
+                            "bringing back glusterd online on the "
+                            "nodes in which previously glusterd "
+                            "had been stopped")


### PR DESCRIPTION
Migrated TC [test_glusterd_quorum](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_glusterd_quorum.py)
Also, adds a `setup_test` abstract method for disruptive TCs, to
allow setup volumes in the TC and not in the parent_run_test itself.

Fixes: #553 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>