### PR TITLE
Update volume_ops.py

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -55,6 +55,7 @@ class VolumeOps(AbstractOps):
             return True
 
         # Create volume
+        force = True
         ret = self.volume_create(volname, node, conf_hash, server_list,
                                  brick_root, force, excep)
         if create_only:

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -55,7 +55,6 @@ class VolumeOps(AbstractOps):
             return True
 
         # Create volume
-        force = True
         ret = self.volume_create(volname, node, conf_hash, server_list,
                                  brick_root, force, excep)
         if create_only:
@@ -142,6 +141,8 @@ class VolumeOps(AbstractOps):
         else:
             cmd = (f"gluster volume create {volname}{brick_cmd} "
                    "--mode=script")
+        # TODO: Needs to be changed once CI is mature enough
+        force = True
         if force:
             cmd = (f"{cmd} force")
 


### PR DESCRIPTION
Bypassing the force option in create_volume as the requirement is to setup the volume at any cost. Because gluster is snobby about creating bricks on root dir. 