### PR TITLE
Changing traceback fn call

### DIFF
--- a/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
+++ b/tests/functional/glusterd/test_volume_set_with_quorum_enabled.py
@@ -40,7 +40,7 @@ class TestCase(DParentTest):
             node = self.node_on_glusterd_to_stop
             self.redant.wait_for_glusterd_to_start(node)
         except Exception as error:
-            tb = traceback.format_exec()
+            tb = traceback.format_exc()
             self.redant.logger.error(error)
             self.redant.logger.error(tb)
         super().terminate()


### PR DESCRIPTION
Traceback has nothing called format_exec. It is format_exc




<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
