### PR TITLE
Migrated TC test_glusterd_replace_brick

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -110,7 +110,8 @@ class BrickOps(AbstractOps):
         return ret
 
     def replace_brick(self, node: str, volname: str,
-                      src_brick: str, dest_brick: str):
+                      src_brick: str, dest_brick: str,
+                      excep: bool = True) -> dict:
         """
         This function replaces one brick(source brick)
         with the another brick(destination brick) on the volume.
@@ -120,6 +121,10 @@ class BrickOps(AbstractOps):
             volname (str): The volume on which the bricks have to be replaced.
             src_brick (str) : The source brick name
             dest_brick (str) : The destination brick name
+            excep (bool): exception flag to bypass the exception if the
+                          volume status command fails. If set to False
+                          the exception is bypassed and value from remote
+                          executioner is returned. Defaults to True
 
         Returns:
             ret: A dictionary consisting
@@ -135,9 +140,81 @@ class BrickOps(AbstractOps):
                f"{volname} {src_brick} {dest_brick} "
                f"commit force --xml")
 
-        ret = self.execute_abstract_op_node(node=node, cmd=cmd)
+        ret = self.execute_abstract_op_node(cmd, node, excep)
 
         return ret
+
+    def replace_brick_from_volume(self, volname: str, node: str,
+                                  servers: list, src_brick: str = None,
+                                  dst_brick: str = None,
+                                  delete_brick: bool = True) -> bool:
+        """
+        Replace faulty brick from a volume
+
+        Args:
+            volname (str): Volume in which the brick has to be replaced
+            node (str): Node on which command has to be executed
+            server_list (list): List of servers in the cluster
+
+        Optional:
+            src_brick (str): Brick to be replaced
+            dst_brick (str): New brick which will replace the old one
+            delete_brick (bool): True, if the old brick should be deleted
+                                 otherwise False. (Default is True)
+
+        Returns:
+            bool: True if the replace brick operation was successful,
+                  False if the operation failed.
+        """
+        if not isinstance(servers, list):
+            servers = [servers]
+
+        # Check if volume exists
+        if not self.does_volume_exists(volname):
+            self.logger.error(f"Volume {volname} does not exist")
+            return False
+
+        # subvols_info = self.get_subvols(volname, node)
+
+        if not dst_brick:
+            _, dst_brick = self.form_brick_cmd(servers, self.brick_roots,
+                                               self.vol_name, 1)
+
+            if not dst_brick:
+                self.logger.error("Failed to get a new brick to replace")
+
+        # if not src_brick:
+        #     # Randomly select a brick to replace
+        #     subvols_list = subvols_info['volume_subvols']
+        #     src_brick = (choice(choice(subvols_list)))
+
+        # Bring src brick offline
+        if not self.bring_bricks_offline(volname, src_brick):
+            self.logger.error("Failed to bring source brick offline")
+
+        # Wait for src brick to go offline
+        if not self.wait_for_bricks_to_go_offline(volname, src_brick):
+            self.logger.error("Brick is still not offline for replace brick"
+                              " operation")
+            return False
+
+        # Check volume status before replace brick operation
+        ret = self.get_volume_status(volname, node)
+        if ret is None:
+            self.logger.error("Failed to get volume status")
+            return False
+
+        # Perform replace brick
+        ret = self.replace_brick(volname, src_brick, dst_brick, False)
+        if ret['msg']['opRet'] != 0:
+            self.logger.error(f"Failed to replace brick: {src_brick}")
+
+        # Delete old brick
+        if delete_brick:
+            brick_node, brick_path = src_brick.split(':')
+            self.execute_abstract_op_node(f"rm -rf {brick_path}", brick_node)
+
+        return True
 
     def reset_brick(self, node: str, volname: str, src_brick: str,
                     option: str, dst_brick=None, force=False):
@@ -206,6 +283,9 @@ class BrickOps(AbstractOps):
             brick_cmd (str) : Command which contains the brick
                               paths.
         """
+        if not isinstance(server_list, list):
+            server_list = [server_list]
+
         brick_dict = {}
         brick_cmd = ""
         server_iter = 0

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -170,7 +170,7 @@ class BrickOps(AbstractOps):
             servers = [servers]
 
         # Check if volume exists
-        if not self.does_volume_exists(volname):
+        if not self.es.does_volume_exists(volname):
             self.logger.error(f"Volume {volname} does not exist")
             return False
 
@@ -205,7 +205,7 @@ class BrickOps(AbstractOps):
             return False
 
         # Perform replace brick
-        ret = self.replace_brick(volname, src_brick, dst_brick, False)
+        ret = self.replace_brick(node, volname, src_brick, dst_brick, False)
         if ret['msg']['opRet'] != 0:
             self.logger.error(f"Failed to replace brick: {src_brick}")
 
@@ -272,8 +272,8 @@ class BrickOps(AbstractOps):
             mul_fac (int) : Stores the number of bricks
                             needed to form the brick command
             add_flag (bool): Indicates whether the command creation is for
-                             add brick scenario or volume creation. Optional
-                             parameter which by default is False.
+                             add/replace brick scenario or volume creation.
+                             Optional parameter which by default is False.
 
         Returns:
 
@@ -306,6 +306,8 @@ class BrickOps(AbstractOps):
             brick_dict[server_val].append(brick_path_val)
             brick_cmd = (f"{brick_cmd} {server_val}:{brick_path_val}")
             server_iter += 1
+
+        brick_cmd = brick_cmd.lstrip(" ")
 
         return (brick_dict, brick_cmd)
 

--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -174,6 +174,7 @@ class BrickOps(AbstractOps):
             self.logger.error(f"Volume {volname} does not exist")
             return False
 
+        # TODO: Update when we have get_subvols function
         # subvols_info = self.get_subvols(volname, node)
 
         if not dst_brick:
@@ -183,6 +184,7 @@ class BrickOps(AbstractOps):
             if not dst_brick:
                 self.logger.error("Failed to get a new brick to replace")
 
+        # TODO: Update when we have get_subvols function
         # if not src_brick:
         #     # Randomly select a brick to replace
         #     subvols_list = subvols_info['volume_subvols']
@@ -212,7 +214,8 @@ class BrickOps(AbstractOps):
         # Delete old brick
         if delete_brick:
             brick_node, brick_path = src_brick.split(':')
-            self.execute_abstract_op_node(f"rm -rf {brick_path}", brick_node)
+            brick_dict_remove = {brick_node: [brick_path]}
+            self.es.add_data_to_cleands(brick_dict_remove)
 
         return True
 

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -126,21 +126,21 @@ class VolumeOps(AbstractOps):
             if "arbiter_count" in conf_hash:
                 cmd = (f"gluster volume create {volname} "
                        f"replica {conf_hash['replica_count']} "
-                       f"arbiter {conf_hash['arbiter_count']}{brick_cmd} "
+                       f"arbiter {conf_hash['arbiter_count']} {brick_cmd} "
                        "--mode=script")
             # replicated vol
             else:
                 cmd = (f"gluster volume create {volname} "
                        f"replica {conf_hash['replica_count']}"
-                       f"{brick_cmd} --mode=script")
+                       f" {brick_cmd} --mode=script")
         # dispersed vol and distributed-dispersed vol
         elif "disperse_count" in conf_hash:
             cmd = (f"gluster volume create {volname} disperse {mul_fac} "
-                   f"redundancy {conf_hash['redundancy_count']}{brick_cmd} "
+                   f"redundancy {conf_hash['redundancy_count']} {brick_cmd} "
                    f"--mode=script")
         # distributed vol
         else:
-            cmd = (f"gluster volume create {volname}{brick_cmd} "
+            cmd = (f"gluster volume create {volname} {brick_cmd} "
                    "--mode=script")
         # TODO: Needs to be changed once CI is mature enough
         force = True
@@ -150,7 +150,7 @@ class VolumeOps(AbstractOps):
         ret = self.execute_abstract_op_node(cmd, node, excep)
 
         # Don't add data in case volume creation fails
-        if ret['msg']['error_code'] == 0:
+        if ret['error_code'] == 0:
             self.es.set_new_volume(volname, brick_dict)
             self.es.set_vol_type(volname, conf_hash)
 
@@ -190,7 +190,7 @@ class VolumeOps(AbstractOps):
 
         ret = self.execute_abstract_op_node(cmd, node, excep)
 
-        if ret['msg']['opRet'] == 0:
+        if ret['msg']['opRet'] == '0':
             self.es.set_volume_start_status(volname, True)
 
         return ret
@@ -228,7 +228,7 @@ class VolumeOps(AbstractOps):
 
         ret = self.execute_abstract_op_node(cmd, node, excep)
 
-        if ret['msg']['opRet'] == 0:
+        if ret['msg']['opRet'] == '0':
             self.es.set_volume_start_status(volname, False)
 
         return ret

--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -932,6 +932,7 @@ class VolumeOps(AbstractOps):
         self.logger.info(f"Volume {volname} processes are all online")
         return True
 
+    # TODO: Update when we have updated the get_volinfo() to get the subvols
     # def get_subvols(self, volname: str, node: str) -> list:
     #     """
     #     Get the subvolumes in the given volume

--- a/tests/example/sample_component/test_brick_ops.py
+++ b/tests/example/sample_component/test_brick_ops.py
@@ -94,14 +94,14 @@ class TestCase(DParentTest):
             _, br_cmd = redant.form_brick_cmd(self.server_list,
                                               self.brick_roots,
                                               self.vol_name, mul_factor, True)
-            redant.add_brick(self.vol_name, br_cmd[1:], self.server_list[0],
+            redant.add_brick(self.vol_name, br_cmd, self.server_list[0],
                              replica_count=3)
         else:
             mul_factor = 1
             _, br_cmd = redant.form_brick_cmd(self.server_list,
                                               self.brick_roots,
                                               self.vol_name, mul_factor, True)
-            redant.add_brick(self.vol_name, br_cmd[1:],
+            redant.add_brick(self.vol_name, br_cmd,
                              self.server_list[0])
         redant.es.set_vol_type_param(self.vol_name, 'dist_count', 1)
 

--- a/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_add_brick_when_quorum_not_met.py
@@ -97,8 +97,7 @@ class TestCase(DParentTest):
             _, br_cmd = redant.form_brick_cmd(self.server_list,
                                               self.brick_roots, self.vol_name,
                                               mul_factor, True)
-            redant.add_brick(self.vol_name, br_cmd[1:],
-                             self.server_list)
+            redant.add_brick(self.vol_name, br_cmd, self.server_list)
         except Exception as error:
             redant.logger.info(f"Add brick failed as expected: {error}")
 

--- a/tests/functional/glusterd/test_create_vol_with_used_bricks.py
+++ b/tests/functional/glusterd/test_create_vol_with_used_bricks.py
@@ -70,7 +70,7 @@ class TestCase(NdParentTest):
                                           self.volume_name1,
                                           mul_factor, True)
         redant.add_brick(self.volume_name1,
-                         br_cmd[1:], self.server_list[0],
+                         br_cmd, self.server_list[0],
                          replica_count=3)
 
         mountpoint = f"/mnt/{self.volume_name1}"

--- a/tests/functional/glusterd/test_glusterd_replace_brick.py
+++ b/tests/functional/glusterd/test_glusterd_replace_brick.py
@@ -27,7 +27,7 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
-    def test_glusterd_replace_brick(self, redant):
+    def run_test(self, redant):
         """
         Create a volume and start it.
         - Get list of all the bricks which are online

--- a/tests/functional/glusterd/test_glusterd_replace_brick.py
+++ b/tests/functional/glusterd/test_glusterd_replace_brick.py
@@ -30,7 +30,7 @@ from glustolibs.gluster.brick_libs import are_bricks_online
 @runs_on([['replicated', 'distributed-replicated', 'dispersed',
            'distributed-dispersed'], ['glusterfs']])
 class TestReplaceBrick(GlusterBaseClass):
-    def setup(self):
+    def setUp(self):
         GlusterBaseClass.setUp.im_func(self)
         self.test_method_complete = False
         # Creating a volume and starting it

--- a/tests/functional/glusterd/test_glusterd_replace_brick.py
+++ b/tests/functional/glusterd/test_glusterd_replace_brick.py
@@ -31,7 +31,7 @@ from glustolibs.gluster.brick_libs import are_bricks_online
            'distributed-dispersed'], ['glusterfs']])
 class TestReplaceBrick(GlusterBaseClass):
     def setUp(self):
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         self.test_method_complete = False
         # Creating a volume and starting it
         ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
@@ -40,7 +40,7 @@ class TestReplaceBrick(GlusterBaseClass):
         g.log.info("Volume created successfully")
 
     def tearDown(self):
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'tearDown')()
         self.test_method_complete = False
         ret = self.cleanup_volume()
         if not ret:

--- a/tests/functional/glusterd/test_glusterd_replace_brick.py
+++ b/tests/functional/glusterd/test_glusterd_replace_brick.py
@@ -47,16 +47,18 @@ class TestCase(DParentTest):
         node_of_brick_replace = brick_to_replace.split(':')[0]
         _, new_brick_to_replace = redant.form_brick_cmd(node_of_brick_replace,
                                                         self.brick_roots,
-                                                        self.vol_name, 1)
+                                                        self.vol_name, 1,
+                                                        True)
 
         # performing replace brick with non-existing brick path
         path = ":/brick/non_existing_path"
         non_existing_path = node_of_brick_replace + path
 
         # Replace brick for non-existing path
-        ret = redant.replace_brick(self.vol_name, brick_to_replace,
-                                   non_existing_path, False)
-        if ret['error_code'] == 0:
+        ret = redant.replace_brick(self.server_list[0], self.vol_name,
+                                   brick_to_replace, non_existing_path,
+                                   False)
+        if ret['msg']['opRet'] == '0':
             raise Exception("Replace brick with commit force"
                             " on a non-existing brick passed")
 

--- a/tests/functional/glusterd/test_glusterd_replace_brick.py
+++ b/tests/functional/glusterd/test_glusterd_replace_brick.py
@@ -1,0 +1,114 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import random
+import time
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_libs import (setup_volume,
+                                            replace_brick_from_volume)
+from glustolibs.gluster.brick_libs import get_online_bricks_list
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.brick_ops import replace_brick
+from glustolibs.gluster.brick_libs import are_bricks_online
+
+
+@runs_on([['replicated', 'distributed-replicated', 'dispersed',
+           'distributed-dispersed'], ['glusterfs']])
+class TestReplaceBrick(GlusterBaseClass):
+    def setup(self):
+        GlusterBaseClass.setUp.im_func(self)
+        self.test_method_complete = False
+        # Creating a volume and starting it
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        if not ret:
+            raise ExecutionError("Failed to create volume")
+        g.log.info("Volume created successfully")
+
+    def tearDown(self):
+        GlusterBaseClass.setUp.im_func(self)
+        self.test_method_complete = False
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Failed to cleanup volume")
+        g.log.info("Successful in Unmount Volume and Cleanup Volume")
+
+    def test_glusterd_replace_brick(self):
+        """
+        Create a volume and start it.
+        - Get list of all the bricks which are online
+        - Select a brick randomly from the bricks which are online
+        - Form a non-existing brick path on node where the brick has to replace
+        - Perform replace brick and it should fail
+        - Form a new brick which valid brick path replace brick should succeed
+        """
+        # pylint: disable=too-many-function-args
+        # Getting all the bricks which are online
+        bricks_online = get_online_bricks_list(self.mnode, self.volname)
+        self.assertIsNotNone(bricks_online, None, (
+            "Unable to get the online bricks"))
+        g.log.info("got the brick list from the volume")
+
+        # Getting one random brick from the online bricks to be replaced
+        brick_to_replace = random.choice(bricks_online)
+        g.log.info("Brick to replace %s", brick_to_replace)
+        node_for_brick_replace = brick_to_replace.split(':')[0]
+        new_brick_to_replace = form_bricks_list(
+            self.mnode, self.volname, 1,
+            node_for_brick_replace, self.all_servers_info)
+
+        # performing replace brick with non-existing brick path
+        path = ":/brick/non_existing_path"
+        non_existing_path = node_for_brick_replace + path
+
+        # Replace brick for non-existing path
+        ret, _, _ = replace_brick(self.mnode, self.volname,
+                                  brick_to_replace, non_existing_path)
+        self.assertNotEqual(ret, 0, ("Replace brick with commit force"
+                                     " on a non-existing brick passed"))
+        g.log.info("Replace brick with non-existing brick with commit"
+                   "force failed as expected")
+
+        # calling replace brick by passing brick_to_replace and
+        # new_brick_to_replace with valid brick path
+        ret = replace_brick_from_volume(self.mnode, self.volname,
+                                        self.servers, self.all_servers_info,
+                                        brick_to_replace,
+                                        new_brick_to_replace[0],
+                                        delete_brick=True)
+        self.assertTrue(ret, ("Replace brick with commit force failed"))
+
+        # Validating whether the brick replaced is online
+        halt = 20
+        counter = 0
+        _rc = False
+        g.log.info("Wait for some seconds for the replaced brick "
+                   "to get online")
+        while counter < halt:
+            ret = are_bricks_online(self.mnode, self.volname,
+                                    new_brick_to_replace)
+            if not ret:
+                g.log.info("The replaced brick isn't online, "
+                           "Retry after 2 seconds .......")
+                time.sleep(2)
+                counter = counter + 2
+            else:
+                _rc = True
+                g.log.info("The replaced brick is online after being replaced")
+                break
+        if not _rc:
+            raise ExecutionError("The replaced brick isn't online")

--- a/tests/functional/glusterd/test_glusterd_replace_brick.py
+++ b/tests/functional/glusterd/test_glusterd_replace_brick.py
@@ -59,8 +59,7 @@ class TestReplaceBrick(GlusterBaseClass):
         # pylint: disable=too-many-function-args
         # Getting all the bricks which are online
         bricks_online = get_online_bricks_list(self.mnode, self.volname)
-        self.assertIsNotNone(bricks_online, None, (
-            "Unable to get the online bricks"))
+        self.assertIsNotNone(bricks_online, "Unable to get the online bricks")
         g.log.info("got the brick list from the volume")
 
         # Getting one random brick from the online bricks to be replaced

--- a/tests/functional/glusterd/test_peer_status.py
+++ b/tests/functional/glusterd/test_peer_status.py
@@ -93,8 +93,7 @@ class TestPeerStatus(DParentTest):
         _, br_cmd = redant.form_brick_cmd([self.server_list[2]],
                                           self.brick_roots, self.vol_name,
                                           mul_factor, True)
-        redant.add_brick(self.vol_name, br_cmd[1:],
-                         self.server_list[0], True)
+        redant.add_brick(self.vol_name, br_cmd, self.server_list[0], True)
 
         # get volume info, it should have correct brick information
         ret = redant.get_volume_info(self.server_list[0], self.vol_name)

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -21,7 +21,6 @@ This test deals with testing peer probe
 using hostnames.
 """
 
-import traceback
 import socket
 from tests.d_parent_test import DParentTest
 
@@ -29,20 +28,6 @@ from tests.d_parent_test import DParentTest
 
 
 class TestCase(DParentTest):
-
-    def terminate(self):
-        """
-        Cleanup volume if TC failed before deleting it
-        """
-        try:
-            if not self.vol_deleted:
-                self.redant.cleanup_volume("test-vol", self.server_list[0])
-
-        except Exception as error:
-            tb = traceback.format_exc()
-            self.redant.logger.error(error)
-            self.redant.logger.error(tb)
-        super().terminate()
 
     def _vol_operations(self, redant, volname: str):
         """
@@ -91,7 +76,6 @@ class TestCase(DParentTest):
             -> gluster volume status <vol>
             -> gluster volume stop <vol>
         '''
-        self.vol_deleted = True
 
         # detaching all the peers first
         for server in self.server_list[1:]:
@@ -124,7 +108,6 @@ class TestCase(DParentTest):
         redant.volume_create("test-vol", self.server_list[0],
                              self.vol_type_inf[self.conv_dict['dist']],
                              self.server_list, self.brick_roots, True)
-        self.vol_deleted = False
 
         redant.logger.info("Volume: test-vol created successfully")
 
@@ -155,7 +138,6 @@ class TestCase(DParentTest):
 
         # perform the set of volume operations
         self._vol_operations(redant, "test-vol-fqdn")
-        self.vol_deleted = True
 
         # creating the cluster back again
         ret = redant.create_cluster(self.server_list)

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -87,8 +87,7 @@ class TestCase(DParentTest):
                                              self.brick_roots,
                                              self.volume_name1, mul_factor,
                                              True)
-        redant.add_brick(self.volume_name1, brick_cmd[1:],
-                         self.server_list[0])
+        redant.add_brick(self.volume_name1, brick_cmd, self.server_list[0])
         redant.es.set_vol_type_param(self.volume_name1, 'dist_count', 1)
 
         redant.rebalance_start(self.volume_name1, self.server_list[0])


### PR DESCRIPTION
Migrated TC [test_glusterd_remove_brick](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_glusterd_replace_brick.py)

Also, added the `replace_brick_from_volume` op.

Fixes: #559 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>