### PR TITLE
[TestFix] Fixing the brick_ops condition

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -507,7 +507,8 @@ class BrickOps(AbstractOps):
             random_node = random.choice(nd_list)
             offline_brick_list = self.get_offline_bricks_list(volname,
                                                               random_node)
-            if set(brick_list).issubset(set(offline_brick_list)):
+            if offline_brick_list is not None and\
+                    set(brick_list).issubset(set(offline_brick_list)):
                 return True
             itr += 5
             sleep(5)
@@ -543,7 +544,8 @@ class BrickOps(AbstractOps):
             random_node = random.choice(server_list)
             online_brick_list = self.get_online_bricks_list(volname,
                                                             random_node)
-            if set(brick_list).issubset(set(online_brick_list)):
+            if online_brick_list is not None and\
+                    set(brick_list).issubset(set(online_brick_list)):
                 return True
             itr += 5
             sleep(5)


### PR DESCRIPTION
The brick list when no bricks are
offline are online is None rather than an empty list
and hence an exception is thrown when it is converted
to a set.

Fixes: #574

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
