### PR TITLE
Fix: Peer probe and detach TCs to check for 'opRet' value

### DIFF
--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -79,7 +79,8 @@ class PeerOps(AbstractOps):
                 if 'output' not in ret['msg']:
                     return False
                 if (ret['error_code'] != 0
-                        or ret['msg']['output'] != 'success'):
+                        or ret['msg']['output'] != 'success'
+                        or ret['msg']['opRet'] != '0'):
                     self.logger.error("Failed to peer probe the node"
                                       f" {server}")
                     return False
@@ -167,7 +168,8 @@ class PeerOps(AbstractOps):
         for server in servers:
             ret = self.peer_detach(server, node, force, False)
             if (ret['error_code'] != 0
-                    or ret['msg']['output'] != 'success'):
+                    or ret['msg']['output'] != 'success'
+                    or ret['msg']['opRet'] != '0'):
                 self.logger.error(f"Failed to detach the node {server}")
                 return False
 

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -19,35 +19,12 @@
    Test Cases in this module related to Glusterd peer detach.
 """
 
-import traceback
 from tests.d_parent_test import DParentTest
 
 # disruptive;
 
 
 class TestCase(DParentTest):
-
-    def terminate(self):
-        """
-        In case one of the peers get detached accidentally, we need to
-        re-probe it and delete the volumes created in the TC
-        """
-        try:
-            ret = self.redant.peer_probe_servers(self.server_list,
-                                                 self.server_list[0])
-            if not ret:
-                raise Exception("Peer probing failed on some of the servers")
-
-            # Cleanup volume, if created
-            if self.is_vol_created:
-                self.redant.cleanup_volume(self.volume_name,
-                                           self.server_list[0])
-
-        except Exception as error:
-            tb = traceback.format_exc()
-            self.redant.logger.error(error)
-            self.redant.logger.error(tb)
-        super().terminate()
 
     def _check_detach_error_message(self, use_force=True):
         """
@@ -79,7 +56,6 @@ class TestCase(DParentTest):
         - Peer detach one node which hosts bricks of offline volume
         - Peer detach force a node which hosts bricks of offline volume
         """
-        self.is_vol_created = False
 
         # Timestamp of current test case of start time
         ret = redant.execute_abstract_op_node('date +%s', self.server_list[0])
@@ -127,7 +103,6 @@ class TestCase(DParentTest):
         redant.setup_volume(self.volume_name, self.server_list[0],
                             self.vol_type_inf[self.conv_dict[volume_type]],
                             self.server_list, self.brick_roots)
-        self.is_vol_created = True
 
         # Peer detach one node which contains the bricks of the volume created
         self._check_detach_error_message(False)

--- a/tests/functional/glusterd/test_peer_status.py
+++ b/tests/functional/glusterd/test_peer_status.py
@@ -47,7 +47,7 @@ class TestPeerStatus(DParentTest):
         node1 = socket.getfqdn(self.server_list[1])
 
         # peer probe to a new node, N2 from N1
-        ret = redant.peer_probe(node1, self.server_list[0])
+        redant.peer_probe(node1, self.server_list[0])
 
         # checking if node1 is connected
         ret = redant.wait_for_peers_to_connect(node1,

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -98,7 +98,7 @@ class TestCase(DParentTest):
                 ret = redant.peer_probe(hostname, self.server_list[0],
                                         False)
 
-                if ret['error_code'] != 0:
+                if ret['msg']['opRet'] != '0':
                     raise Exception(f"Unable to peer probe to"
                                     f" the server {hostname}")
 


### PR DESCRIPTION
Fix:
Peer probe and detach operation updates the `opRet` and `opErrstr` value instead of
the `error_code` and `error_msg`, so updated the Tcs and the ops accordingly.

Fixes: #573 

Signed-off-by: nik-redhat <nladha@redhat.com>