### PR TITLE
Migrated test_profile_operations_with_one_node_down

### DIFF
--- a/tests/example/sample_component/test_profile_ops.py
+++ b/tests/example/sample_component/test_profile_ops.py
@@ -21,5 +21,5 @@ class TestCase(NdParentTest):
         profile_options = ['peek', 'incremental', 'clear',
                            'incremental peek', 'cumulative']
         for opt in profile_options:
-            redant.profile_info(self.vol_name, opt, self.server_list[0])
+            redant.profile_info(self.vol_name, self.server_list[0], opt)
         redant.profile_stop(self.vol_name, self.server_list[0])

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -28,12 +28,17 @@ class TestCase(DParentTest):
 
     def terminate(self):
         """
-        This function will start the glusterd
+        This function will validate IO, start glusterd
         on the random server chosen and check
         if all peers are connected
         """
         # Starting glusterd on node where stopped.
         try:
+            # Validate IO
+            ret = self.redant.validate_io_procs(self.list_of_procs,
+                                                self.mnt_list)
+            if not ret:
+                raise Exception("IO validation failed")
             self.redant.start_glusterd(self.server)
             self.redant.wait_for_glusterd_to_start(self.server)
             # Checking if peer is connected
@@ -74,11 +79,6 @@ class TestCase(DParentTest):
 
             self.list_of_procs.append(proc)
             self.counter += 10
-
-        # Validate IO
-        ret = redant.validate_io_procs(self.list_of_procs, self.mnt_list)
-        if not ret:
-            raise Exception("IO validation failed")
 
         # Start profile on volume.
         redant.profile_start(self.vol_name, self.server_list[0])
@@ -138,3 +138,7 @@ class TestCase(DParentTest):
         # Stop profile on volume.
         redant.profile_stop(self.vol_name,
                             self.server_list[0])
+        # Validate IO
+        ret = redant.validate_io_procs(self.list_of_procs, self.mnt_list)
+        if not ret:
+            raise Exception("IO validation failed")

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -20,7 +20,6 @@
 """
 
 from random import randint
-import sys
 
 from glusto.core import Glusto as g
 
@@ -111,13 +110,13 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
                    "--dir-depth 4 "
                    "--dirname-start-num %d "
                    "--dir-length 6 "
                    "--max-num-of-dirs 3 "
                    "--num-of-files 5 %s" % (
-                       sys.version_info.major, self.script_upload_path,
+                       self.script_upload_path,
                        counter, mount_obj.mountpoint))
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -34,17 +34,17 @@ class TestCase(DParentTest):
         """
         # Starting glusterd on node where stopped.
         try:
-            # Validate IO
-            ret = self.redant.validate_io_procs(self.list_of_procs,
-                                                self.mnt_list)
-            if not ret:
-                raise Exception("IO validation failed")
             self.redant.start_glusterd(self.server)
             self.redant.wait_for_glusterd_to_start(self.server)
             # Checking if peer is connected
             for ser in self.server_list[1:]:
                 self.redant.wait_for_peers_to_connect(self.server_list[0],
                                                       ser)
+            # Validate IO
+            ret = self.redant.validate_io_procs(self.list_of_procs,
+                                                self.mnt_list)
+            if not ret:
+                raise Exception("IO validation failed")
         except Exception as error:
             tb = traceback.format_exc()
             self.redant.logger.error(error)

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -19,9 +19,12 @@
     Tests to check basic profile operations with one node down.
 """
 
-from time import sleep
 from random import randint
+import sys
+from time import sleep
+
 from glusto.core import Glusto as g
+
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.profile_ops import (profile_start, profile_info,
@@ -40,7 +43,7 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
 
     @classmethod
     def setUpClass(cls):
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
 
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
@@ -58,7 +61,7 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
 
     def setUp(self):
 
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         # Creating Volume and mounting volume.
         ret = self.setup_volume_and_mount_volume(self.mounts)
         if not ret:
@@ -93,7 +96,7 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
             raise ExecutionError("Unable to delete volume % s" % self.volname)
         g.log.info("Volume deleted successfully : %s", self.volname)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_profile_operations_with_one_node_down(self):
 
@@ -116,14 +119,14 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
         for mount_obj in self.mounts:
             g.log.info("Starting IO on %s:%s", mount_obj.client_system,
                        mount_obj.mountpoint)
-            cmd = ("python %s create_deep_dirs_with_files "
+            cmd = ("/usr/bin/env python%d %s create_deep_dirs_with_files "
                    "--dir-depth 4 "
                    "--dirname-start-num %d "
                    "--dir-length 6 "
                    "--max-num-of-dirs 3 "
-                   "--num-of-files 5 %s"
-                   % (self.script_upload_path, counter,
-                      mount_obj.mountpoint))
+                   "--num-of-files 5 %s" % (
+                       sys.version_info.major, self.script_upload_path,
+                       counter, mount_obj.mountpoint))
             proc = g.run_async(mount_obj.client_system, cmd,
                                user=mount_obj.user)
             self.all_mounts_procs.append(proc)

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -75,6 +75,11 @@ class TestCase(DParentTest):
             self.list_of_procs.append(proc)
             self.counter += 10
 
+        # Validate IO
+        ret = redant.validate_io_procs(self.list_of_procs, self.mnt_list)
+        if not ret:
+            raise Exception("IO validation failed")
+
         # Start profile on volume.
         redant.profile_start(self.vol_name, self.server_list[0])
 
@@ -133,8 +138,3 @@ class TestCase(DParentTest):
         # Stop profile on volume.
         redant.profile_stop(self.vol_name,
                             self.server_list[0])
-
-        # Validate IO
-        ret = redant.validate_io_procs(self.list_of_procs, self.mnt_list)
-        if not ret:
-            raise Exception("IO validation failed")

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -1,0 +1,220 @@
+#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+    Test Description:
+    Tests to check basic profile operations with one node down.
+"""
+
+from time import sleep
+from random import randint
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.profile_ops import (profile_start, profile_info,
+                                            profile_stop)
+from glustolibs.misc.misc_libs import upload_scripts
+from glustolibs.io.utils import validate_io_procs
+from glustolibs.gluster.brick_libs import get_online_bricks_list
+from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
+                                             is_glusterd_running)
+from glustolibs.gluster.peer_ops import is_peer_connected
+
+
+@runs_on([['distributed-replicated', 'dispersed', 'distributed-dispersed'],
+          ['glusterfs']])
+class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+        GlusterBaseClass.setUpClass.im_func(cls)
+
+        # Uploading file_dir script in all client direcotries
+        g.log.info("Upload io scripts to clients %s for running IO on "
+                   "mounts", cls.clients)
+        script_local_path = ("/usr/share/glustolibs/io/scripts/"
+                             "file_dir_ops.py")
+        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
+                                  "file_dir_ops.py")
+        ret = upload_scripts(cls.clients, script_local_path)
+        if not ret:
+            raise ExecutionError("Failed to upload IO scripts to clients %s"
+                                 % cls.clients)
+        g.log.info("Successfully uploaded IO scripts to clients %s",
+                   cls.clients)
+
+    def setUp(self):
+
+        GlusterBaseClass.setUp.im_func(self)
+        # Creating Volume and mounting volume.
+        ret = self.setup_volume_and_mount_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Volume creation or mount failed: %s"
+                                 % self.volname)
+        g.log.info("Volme created and mounted successfully : %s",
+                   self.volname)
+
+    def tearDown(self):
+
+        # Starting glusterd on node where stopped.
+        ret = start_glusterd(self.servers[self.random_server])
+        if ret:
+            ExecutionError("Failed to start glusterd.")
+        g.log.info("Successfully started glusterd.")
+
+        # Checking if peer is connected
+        counter = 0
+        while counter < 30:
+            ret = is_peer_connected(self.mnode, self.servers)
+            counter += 1
+            if ret:
+                break
+            sleep(3)
+        if not ret:
+            ExecutionError("Peers are not in connected state.")
+        g.log.info("Peers are in connected state.")
+
+        # Unmounting and cleaning volume.
+        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Unable to delete volume % s" % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_profile_operations_with_one_node_down(self):
+
+        # pylint: disable=too-many-statements
+        """
+        Test Case:
+        1) Create a volume and start it.
+        2) Mount volume on client and start IO.
+        3) Start profile info on the volume.
+        4) Stop glusterd on one node.
+        5) Run profile info with different parameters
+           and see if all bricks are present or not.
+        6) Stop profile on the volume.
+        """
+
+        # Start IO on mount points.
+        g.log.info("Starting IO on all mounts...")
+        self.all_mounts_procs = []
+        counter = 1
+        for mount_obj in self.mounts:
+            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
+                       mount_obj.mountpoint)
+            cmd = ("python %s create_deep_dirs_with_files "
+                   "--dir-depth 4 "
+                   "--dirname-start-num %d "
+                   "--dir-length 6 "
+                   "--max-num-of-dirs 3 "
+                   "--num-of-files 5 %s"
+                   % (self.script_upload_path, counter,
+                      mount_obj.mountpoint))
+            proc = g.run_async(mount_obj.client_system, cmd,
+                               user=mount_obj.user)
+            self.all_mounts_procs.append(proc)
+            counter += 1
+
+        # Start profile on volume.
+        ret, _, _ = profile_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start profile on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully started profile on volume: %s",
+                   self.volname)
+
+        # Fetching a random server from list.
+        self.random_server = randint(1, len(self.servers)-1)
+
+        # Stopping glusterd on one node.
+        ret = stop_glusterd(self.servers[self.random_server])
+        self.assertTrue(ret, "Failed to stop glusterd on one node.")
+        g.log.info("Successfully stopped glusterd on one node.")
+        counter = 0
+        while counter > 20:
+            ret = is_glusterd_running(self.servers[self.random_server])
+            if ret:
+                break
+            counter += 1
+            sleep(3)
+
+        # Getting and checking output of profile info.
+        ret, out, _ = profile_info(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to run profile info on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully executed profile info on volume: %s",
+                   self.volname)
+
+        # Checking if all bricks are present in profile info.
+        brick_list = get_online_bricks_list(self.mnode, self.volname)
+        for brick in brick_list:
+            self.assertTrue(brick in out,
+                            "Brick %s not a part of profile info output."
+                            % brick)
+            g.log.info("Brick %s showing in profile info output.",
+                       brick)
+
+        # Running profile info with different profile options.
+        profile_options = ['peek', 'incremental', 'clear', 'incremental peek',
+                           'cumulative']
+        for option in profile_options:
+
+            # Getting and checking output of profile info.
+            ret, out, _ = profile_info(self.mnode, self.volname,
+                                       options=option)
+            self.assertEqual(ret, 0,
+                             "Failed to run profile info %s on volume: %s"
+                             % (option, self.volname))
+            g.log.info("Successfully executed profile info %s on volume: %s",
+                       option, self.volname)
+
+            # Checking if all bricks are present in profile info peek.
+            for brick in brick_list:
+                self.assertTrue(brick in out,
+                                "Brick %s not a part of profile"
+                                " info %s output."
+                                % (brick, option))
+                g.log.info("Brick %s showing in profile info %s output.",
+                           brick, option)
+
+        # Starting glusterd on node where stopped.
+        ret = start_glusterd(self.servers[self.random_server])
+        self.assertTrue(ret, "Failed to start glusterd.")
+        g.log.info("Successfully started glusterd.")
+
+        # Checking if peer is connected
+        counter = 0
+        while counter < 30:
+            ret = is_peer_connected(self.mnode, self.servers)
+            counter += 1
+            if ret:
+                break
+            sleep(3)
+        self.assertTrue(ret, "Peers are not in connected state.")
+        g.log.info("Peers are in connected state.")
+
+        # Stop profile on volume.
+        ret, _, _ = profile_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to stop profile on volume: %s"
+                         % self.volname)
+        g.log.info("Successfully stopped profile on volume: %s", self.volname)
+
+        # Validate IO
+        self.assertTrue(
+            validate_io_procs(self.all_mounts_procs, self.mounts),
+            "IO failed on some of the clients"
+        )
+        g.log.info("IO validation complete.")

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -48,11 +48,9 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
         # Uploading file_dir script in all client direcotries
         g.log.info("Upload io scripts to clients %s for running IO on "
                    "mounts", cls.clients)
-        script_local_path = ("/usr/share/glustolibs/io/scripts/"
-                             "file_dir_ops.py")
         cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
                                   "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, script_local_path)
+        ret = upload_scripts(cls.clients, cls.script_upload_path)
         if not ret:
             raise ExecutionError("Failed to upload IO scripts to clients %s"
                                  % cls.clients)

--- a/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
+++ b/tests/functional/glusterd/test_profile_operations_with_one_node_down.py
@@ -1,97 +1,52 @@
-#  Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
 
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along`
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Test Description:
+Tests to check basic profile operations with one node down.
 """
-    Test Description:
-    Tests to check basic profile operations with one node down.
-"""
+# disruptive;dist-rep,disp,dist-disp
 
 from random import randint
-
-from glusto.core import Glusto as g
-
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.profile_ops import (profile_start, profile_info,
-                                            profile_stop)
-from glustolibs.misc.misc_libs import upload_scripts
-from glustolibs.io.utils import validate_io_procs
-from glustolibs.gluster.brick_libs import get_online_bricks_list
-from glustolibs.gluster.gluster_init import (stop_glusterd, start_glusterd,
-                                             wait_for_glusterd_to_start)
-from glustolibs.gluster.peer_ops import wait_for_peers_to_connect
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed-replicated', 'dispersed', 'distributed-dispersed'],
-          ['glusterfs']])
-class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.get_super_method(cls, 'setUpClass')()
-
-        # Uploading file_dir script in all client direcotries
-        g.log.info("Upload io scripts to clients %s for running IO on "
-                   "mounts", cls.clients)
-        cls.script_upload_path = ("/usr/share/glustolibs/io/scripts/"
-                                  "file_dir_ops.py")
-        ret = upload_scripts(cls.clients, cls.script_upload_path)
-        if not ret:
-            raise ExecutionError("Failed to upload IO scripts to clients %s"
-                                 % cls.clients)
-        g.log.info("Successfully uploaded IO scripts to clients %s",
-                   cls.clients)
-
-    def setUp(self):
-
-        self.get_super_method(self, 'setUp')()
-        # Creating Volume and mounting volume.
-        ret = self.setup_volume_and_mount_volume(self.mounts)
-        if not ret:
-            raise ExecutionError("Volume creation or mount failed: %s"
-                                 % self.volname)
-        g.log.info("Volme created and mounted successfully : %s",
-                   self.volname)
-
-    def tearDown(self):
-
+    def terminate(self):
+        """
+        This function will start the glusterd
+        on the random server chosen and check
+        if all peers are connected
+        """
         # Starting glusterd on node where stopped.
-        ret = start_glusterd(self.servers[self.random_server])
-        if ret:
-            ExecutionError("Failed to start glusterd.")
-        g.log.info("Successfully started glusterd.")
+        server = self.server_list[self.random_server]
+        try:
+            self.redant.start_glusterd(server)
+            self.redant.wait_for_glusterd_to_start(server)
+            # Checking if peer is connected
+            for ser in self.server_list[1:]:
+                self.redant.wait_for_peers_to_connect(self.server_list[0],
+                                                      ser)
+        except Exception:
+            pass
+        super().terminate()
 
-        # Checking if peer is connected
-        for server in self.servers:
-            ret = wait_for_peers_to_connect(self.mnode, server)
-            if not ret:
-                ExecutionError("Peers are not in connected state.")
-            g.log.info("Peers are in connected state.")
+    def run_test(self, redant):
 
-        # Unmounting and cleaning volume.
-        ret = self.unmount_volume_and_cleanup_volume(self.mounts)
-        if not ret:
-            raise ExecutionError("Unable to delete volume % s" % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_profile_operations_with_one_node_down(self):
-
-        # pylint: disable=too-many-statements
         """
         Test Case:
         1) Create a volume and start it.
@@ -104,60 +59,49 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
         """
 
         # Start IO on mount points.
-        g.log.info("Starting IO on all mounts...")
-        self.all_mounts_procs = []
-        counter = 1
-        for mount_obj in self.mounts:
-            g.log.info("Starting IO on %s:%s", mount_obj.client_system,
-                       mount_obj.mountpoint)
-            cmd = ("/usr/bin/env python %s create_deep_dirs_with_files "
-                   "--dir-depth 4 "
-                   "--dirname-start-num %d "
-                   "--dir-length 6 "
-                   "--max-num-of-dirs 3 "
-                   "--num-of-files 5 %s" % (
-                       self.script_upload_path,
-                       counter, mount_obj.mountpoint))
-            proc = g.run_async(mount_obj.client_system, cmd,
-                               user=mount_obj.user)
-            self.all_mounts_procs.append(proc)
-            counter += 1
+        redant.logger.info("Starting IO on all mounts...")
+        self.mnt_list = redant.es.get_mnt_pts_dict_in_list(self.vol_name)
+        self.list_of_procs = []
+        self.counter = 1
+        for mount_obj in self.mnt_list:
+            redant.logger.info(f"Starting IO on {mount_obj['client']}:"
+                               f"{mount_obj['mountpath']}")
+            proc = redant.create_deep_dirs_with_files(mount_obj['mountpath'],
+                                                      self.counter,
+                                                      4, 6, 3, 5,
+                                                      mount_obj['client'])
+
+            self.list_of_procs.append(proc)
+            self.counter += 10
 
         # Start profile on volume.
-        ret, _, _ = profile_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to start profile on volume: %s"
-                         % self.volname)
-        g.log.info("Successfully started profile on volume: %s",
-                   self.volname)
+        redant.profile_start(self.vol_name, self.server_list[0])
 
         # Fetching a random server from list.
-        self.random_server = randint(1, len(self.servers)-1)
+        self.random_server = randint(1, len(self.server_list)-1)
 
         # Stopping glusterd on one node.
-        ret = stop_glusterd(self.servers[self.random_server])
-        self.assertTrue(ret, "Failed to stop glusterd on one node.")
-        g.log.info("Successfully stopped glusterd on one node.")
-        ret = wait_for_glusterd_to_start(self.servers[self.random_server])
-        self.assertFalse(ret, "glusterd is still running on %s"
-                         % self.servers[self.random_server])
-        g.log.info("Glusterd stop on the nodes : %s "
-                   "succeeded", self.servers[self.random_server])
-
+        redant.stop_glusterd(self.server_list[self.random_server])
+        ret = (redant.
+               wait_for_glusterd_to_stop(
+                   self.server_list[self.random_server]))
+        if not ret:
+            raise Exception(f"Error: Glusterd is still running on "
+                            f"{self.server_list[self.random_server]}\n")
         # Getting and checking output of profile info.
-        ret, out, _ = profile_info(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to run profile info on volume: %s"
-                         % self.volname)
-        g.log.info("Successfully executed profile info on volume: %s",
-                   self.volname)
+        ret = redant.profile_info(self.vol_name,
+                                  self.server_list[0])
+        out = " ".join(ret['msg'])
 
         # Checking if all bricks are present in profile info.
-        brick_list = get_online_bricks_list(self.mnode, self.volname)
+        brick_list = redant.get_online_bricks_list(self.vol_name,
+                                                   self.server_list[0])
+        if brick_list is None:
+            raise Exception("Failed to get the online bricks list")
         for brick in brick_list:
-            self.assertTrue(brick in out,
-                            "Brick %s not a part of profile info output."
-                            % brick)
-            g.log.info("Brick %s showing in profile info output.",
-                       brick)
+            if brick not in out:
+                raise Exception(f"Brick {brick} not a part of profile"
+                                f" info output")
 
         # Running profile info with different profile options.
         profile_options = ['peek', 'incremental', 'clear', 'incremental peek',
@@ -165,42 +109,31 @@ class TestProfileOpeartionsWithOneNodeDown(GlusterBaseClass):
         for option in profile_options:
 
             # Getting and checking output of profile info.
-            ret, out, _ = profile_info(self.mnode, self.volname,
-                                       options=option)
-            self.assertEqual(ret, 0,
-                             "Failed to run profile info %s on volume: %s"
-                             % (option, self.volname))
-            g.log.info("Successfully executed profile info %s on volume: %s",
-                       option, self.volname)
+            ret = redant.profile_info(self.vol_name,
+                                      self.server_list[0],
+                                      option)
+            out = " ".join(ret['msg'])
 
             # Checking if all bricks are present in profile info peek.
             for brick in brick_list:
-                self.assertTrue(brick in out,
-                                "Brick %s not a part of profile"
-                                " info %s output."
-                                % (brick, option))
-                g.log.info("Brick %s showing in profile info %s output.",
-                           brick, option)
+                if brick not in out:
+                    raise Exception(f"Brick {brick} not a part of profile"
+                                    f" info {option} output")
 
+        server = self.server_list[self.random_server]
         # Starting glusterd on node where stopped.
-        ret = start_glusterd(self.servers[self.random_server])
-        self.assertTrue(ret, "Failed to start glusterd.")
-        g.log.info("Successfully started glusterd.")
+        redant.start_glusterd(server)
+        redant.wait_for_glusterd_to_start(server)
 
         # Checking if peer is connected
-        ret = wait_for_peers_to_connect(self.mnode, self.servers)
-        self.assertTrue(ret, "Peers are not in connected state.")
-        g.log.info("Peers are in connected state.")
-
+        for ser in self.server_list[1:]:
+            self.redant.wait_for_peers_to_connect(self.server_list[0],
+                                                  ser)
         # Stop profile on volume.
-        ret, _, _ = profile_stop(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to stop profile on volume: %s"
-                         % self.volname)
-        g.log.info("Successfully stopped profile on volume: %s", self.volname)
+        redant.profile_stop(self.vol_name,
+                            self.server_list[0])
 
         # Validate IO
-        self.assertTrue(
-            validate_io_procs(self.all_mounts_procs, self.mounts),
-            "IO failed on some of the clients"
-        )
-        g.log.info("IO validation complete.")
+        ret = redant.validate_io_procs(self.list_of_procs, self.mnt_list)
+        if not ret:
+            raise Exception("IO validation failed")


### PR DESCRIPTION

Migrated the [test
case](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_profile_operations_with_one_node_down.py)

Updates: #292

Fixes: #412

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
