### PR TITLE
[Testfix] Changing the key value

### DIFF
--- a/tests/functional/glusterd/test_rebalance_when_quorum_not_met.py
+++ b/tests/functional/glusterd/test_rebalance_when_quorum_not_met.py
@@ -72,7 +72,7 @@ class TestCase(DParentTest):
                             f" {self.vol_name}")
 
         ret = redant.get_volume_status(self.vol_name, self.server_list[0])
-        if ret[self.vol_name]['tasks'] is not None:
+        if ret[self.vol_name]['task_status'] is not None:
             raise Exception("Rebalance has started!")
 
         redant.start_glusterd(self.random_server)


### PR DESCRIPTION
The key value is `task_status` and not `task`.

Fixes: #575

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
