### PR TITLE
Removing test_probe_hostname from exclude list

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -52,6 +52,5 @@ volume_types:
         
 #excluded_tests - Tests which are excluded during the test run.
 excluded_tests:
-    - tests/functional/glusterd/test_peer_hostname.py
     - tests/functional/glusterd/test_quorum_syslog.py
     - tests/functional/glusterd/test_volume_set_when_glusterd_stopped_on_one_node.py


### PR DESCRIPTION
With recent fixes, we can run test_probe_hostname. Hence removing it from the exclude list.

Signed-off-by: srijan-sivakumar ssivakum@redhat.com

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
