### PR TITLE
Migration of test_volume_create.py

### DIFF
--- a/tests/functional/glusterd/test_gluster_detect_drop_of_outbound_traffic.py
+++ b/tests/functional/glusterd/test_gluster_detect_drop_of_outbound_traffic.py
@@ -1,0 +1,103 @@
+"""
+  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+    Gluster should detect drop of outbound traffic as network failure
+"""
+
+import traceback
+from tests.d_parent_test import DParentTest
+
+# disruptive;rep,dist,disp,arb,dist-arb,dist-rep
+
+
+class TestGlusterDetectDropOfOutboundTrafficAsNetworkFailure(DParentTest):
+
+    def terminate(self):
+        """
+        Update the iptables to remove the DROP rule
+        """
+        try:
+            if self.iptablerule_set:
+                cmd = "iptables -D OUTPUT -p tcp -m tcp --dport 24007 -j DROP"
+                self.redant.execute_abstract_op_node(cmd, self.server1)
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
+
+    def run_test(self, redant):
+        """
+        Test Case:
+        1) Create a volume and start it.
+        2) Add an iptable rule to drop outbound glusterd traffic
+        3) Check if the rule is added in iptables list
+        4) Execute few Gluster CLI commands like volume status, peer status
+        5) Gluster CLI commands should fail with suitable error message
+        """
+        self.server1 = self.server_list[1]
+
+        # Set iptablerule_set as false initially
+        self.iptablerule_set = False
+
+        # Set iptable rule on one node to drop outbound glusterd traffic
+        cmd = "iptables -I OUTPUT -p tcp --dport 24007 -j DROP"
+        redant.execute_abstract_op_node(cmd, self.server1)
+
+        # Update iptablerule_set to true
+        self.iptablerule_set = True
+
+        # Confirm if the iptable rule was added successfully
+        iptable_rule = "'OUTPUT -p tcp -m tcp --dport 24007 -j DROP'"
+        cmd = f"iptables -S OUTPUT | grep {iptable_rule} | wc -l"
+        ret = redant.execute_abstract_op_node(cmd, self.server1, False)
+        if ret['error_code'] != 0:
+            raise Exception("Failed to get the iptables rule output")
+
+        if int(ret['msg'][0].rstrip('\n')) != 1:
+            raise Exception("Failed to find the rule in the iptables"
+                            "rule list")
+
+        # Fetch number of nodes in the pool, except localhost
+        pool_list = redant.nodes_from_pool_list(self.server1)
+        peers_count = len(pool_list) - 1
+
+        # Gluster CLI commands should fail
+        # Check volume status command
+        vol_status = redant.get_volume_status(self.vol_name, self.server1,
+                                              excep=False)
+        if vol_status is None:
+            raise Exception("Failed to get the vol status")
+
+        err_str = vol_status['msg']['opErrstr']
+        err_count_staging = err_str.count("Staging failed on")
+        err_count_locking = err_str.count("Locking failed on")
+        if peers_count not in (err_count_staging, err_count_locking):
+            raise Exception("Unexpected: Number of nodes on which command"
+                            " failed is not equal to the peers count")
+
+        # Check peer status command and all peers are in 'Disconnected' state
+        peer_list = redant.get_peer_status(self.server1)
+
+        for peer in peer_list:
+            if peer["connected"] != '0':
+                raise Exception("Unexpected: All the peers are not in "
+                                "'Disconnected' state")
+            if peer["stateStr"] != 'Peer in Cluster':
+                raise Exception("Unexpected:All the peers not in"
+                                " 'Peer in Cluster' state")

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -41,7 +41,7 @@ class TestVolumeCreate(GlusterBaseClass):
     def setUpClass(cls):
 
         # Calling GlusterBaseClass setUpClass
-        GlusterBaseClass.setUpClass.im_func(cls)
+        cls.get_super_method(cls, 'setUpClass')()
 
         ret = cls.validate_peers_are_connected()
         if not ret:
@@ -73,7 +73,7 @@ class TestVolumeCreate(GlusterBaseClass):
                 raise ExecutionError("Unable to delete volume % s" % volume)
             g.log.info("Volume deleted successfully : %s", volume)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_volume_create(self):
         '''

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -23,7 +23,7 @@ import random
 from tests.d_parent_test import DParentTest
 
 
-# disruptive;dist
+# disruptive;
 class TestCase(DParentTest):
 
     def run_test(self, redant):
@@ -62,8 +62,8 @@ class TestCase(DParentTest):
         if not ret:
             raise Exception("Failed to bring down the bricks")
 
-        ret = redant.volume_start(self.volume_name1, self.server_list[0],
-                                  force=True)
+        redant.volume_start(self.volume_name1, self.server_list[0],
+                            force=True)
 
         ret = redant.wait_for_bricks_to_come_online(self.volume_name1,
                                                     self.server_list,
@@ -75,27 +75,34 @@ class TestCase(DParentTest):
         self.volume_type2 = 'dist'
         self.volume_name2 = f"{self.test_name}-{self.volume_type2}-2"
         conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type2]]
+        excep = True
         try:
             redant.volume_create_with_custom_bricks(self.volume_name2,
                                                     self.server_list[0],
                                                     conf_dict, brick_cmd,
                                                     brick_dict)
-            raise Exception("Unexpected: Successfully created the volume "
-                            "with previously used bricks")
+            excep = False
         except Exception:
             redant.logger.info("Expected: Failed to create a volume "
                                "with previously used bricks.")
+
+        if not excep:
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with previously used bricks")
 
         # create a volume with already existing volume name
         try:
             redant.setup_volume(self.volume_name1, self.server_list[0],
                                 conf_dict, self.server_list,
-                                self.brick_roots, True)
-            raise Exception("Unexpected: Successfully created the volume with "
-                            "already existing volname")
+                                self.brick_roots)
+            excep = False
         except Exception:
             redant.logger.info("Expected: Failed to create the volume with "
                                "already existing volname")
+
+        if not excep:
+            raise Exception("Unexpected: Successfully created the volume with "
+                            "already existing volname")
 
         # creating a volume with non existing brick path should fail
         self.volume_type3 = 'dist'
@@ -113,11 +120,14 @@ class TestCase(DParentTest):
                                                     self.server_list[0],
                                                     conf_dict, brick_cmd,
                                                     brick_dict)
-            raise Exception("Unexpected: Successfully created the volume "
-                            "with non existing brick path")
+            excep = False
         except Exception:
             redant.logger.info("Expected: Failed to create the volume with "
                                "non existing brick path")
+
+        if not excep:
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with non existing brick path")
 
         # cleanup the volume and peer detach all servers. form two clusters,try
         # to create a volume with bricks whose nodes are in different clusters
@@ -144,25 +154,28 @@ class TestCase(DParentTest):
         try:
             redant.setup_volume(self.volume_name3, self.server_list[0],
                                 conf_dict, self.server_list,
-                                self.brick_roots, True)
-            raise Exception("Unexpected: Successfully created the volume "
-                            "with bricks which are part of another cluster")
+                                self.brick_roots)
+            excep = False
         except Exception:
             redant.logger.info("Expected: Failed to create the volume with "
                                "bricks which are part of another cluster")
 
+        if not excep:
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with bricks which are part of another cluster")
+
         # form a cluster, bring a node down. try to create a volume when one of
         # the brick node is down
-        ret = redant.peer_detach(self.server_list[3], self.server_list[2])
+        redant.peer_detach(self.server_list[3], self.server_list[2])
 
-        ret = redant.peer_probe_servers(self.server_list, self.server_list[0])
+        redant.peer_probe_servers(self.server_list, self.server_list[0])
 
         # Taking random node from the first four nodes as the
         # volume getting created is using first four nodes
         # Excluding server_list[0]
         first_four_servers = self.server_list[:4]
         random_server = random.choice(first_four_servers[1:])
-        ret = redant.stop_glusterd(random_server)
+        redant.stop_glusterd(random_server)
 
         self.volume_type4 = 'dist'
         self.volume_name4 = f"{self.test_name}-{self.volume_type4}-4"
@@ -171,8 +184,11 @@ class TestCase(DParentTest):
             redant.setup_volume(self.volume_name4, self.server_list[0],
                                 conf_dict, self.server_list,
                                 self.brick_roots, True)
-            raise Exception("Unexpected: Successfully created the volume "
-                            "with brick whose node is down")
+            excep = False
         except Exception:
             redant.logger.info("Expected: Failed to create the volume with "
                                "brick whose node is down")
+
+        if not excep:
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with brick whose node is down")

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -1,214 +1,178 @@
-#  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+  Test glusterd behavior with the gluster volume create command
+"""
 
 import random
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.volume_ops import (volume_create, volume_start,
-                                           get_volume_list)
-from glustolibs.gluster.brick_libs import (get_all_bricks,
-                                           bring_bricks_offline,
-                                           wait_for_bricks_to_be_online)
-from glustolibs.gluster.volume_libs import setup_volume, cleanup_volume
-from glustolibs.gluster.peer_ops import (peer_detach_servers, peer_probe,
-                                         peer_probe_servers, is_peer_connected,
-                                         peer_detach)
-from glustolibs.gluster.lib_utils import form_bricks_list
-from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
+from tests.d_parent_test import DParentTest
 
 
-@runs_on([['distributed'], ['glusterfs']])
-class TestVolumeCreate(GlusterBaseClass):
-    '''
-    Test glusterd behavior with the gluster volume create command
-    '''
+# disruptive;dist
+class TestCase(DParentTest):
 
-    @classmethod
-    def setUpClass(cls):
-
-        # Calling GlusterBaseClass setUpClass
-        cls.get_super_method(cls, 'setUpClass')()
-
-        ret = cls.validate_peers_are_connected()
-        if not ret:
-            raise ExecutionError("Peers are not in connected state")
-
-    def tearDown(self):
-
-        # start glusterd on all servers
-        ret = start_glusterd(self.servers)
-        if not ret:
-            raise ExecutionError("Failed to start glusterd on all servers")
-
-        for server in self.servers:
-            ret = is_peer_connected(server, self.servers)
-            if not ret:
-                ret = peer_probe_servers(server, self.servers)
-                if not ret:
-                    raise ExecutionError("Failed to peer probe all "
-                                         "the servers")
-
-        # clean up all volumes
-        vol_list = get_volume_list(self.mnode)
-        if vol_list is None:
-            raise ExecutionError("Failed to get the volume list")
-
-        for volume in vol_list:
-            ret = cleanup_volume(self.mnode, volume)
-            if not ret:
-                raise ExecutionError("Unable to delete volume % s" % volume)
-            g.log.info("Volume deleted successfully : %s", volume)
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_volume_create(self):
-        '''
+    def run_test(self, redant):
+        """
         In this test case, volume create operations such as creating volume
         with non existing brick path, already used brick, already existing
         volume name, bring the bricks to online with volume start force,
         creating a volume with bricks in another cluster, creating a volume
         when one of the brick node is down are validated.
-        '''
-        # pylint: disable=too-many-statements
+        """
+        # Check for 4 servers
+        if len(self.server_list) < 4:
+            raise Exception("The test case requires 4 servers to run the test")
+
         # create and start a volume
-        self.volume['name'] = "first_volume"
-        self.volname = "first_volume"
-        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
-        self.assertTrue(ret, "Failed to create and start volume")
+
+        self.volume_type1 = 'dist'
+        self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        brick_dict, brick_cmd = redant.form_brick_cmd(self.server_list,
+                                                      self.brick_roots,
+                                                      self.volume_name1, 4)
+        redant.volume_create_with_custom_bricks(self.volume_name1,
+                                                self.server_list[0],
+                                                conf_dict, brick_cmd,
+                                                brick_dict)
+        redant.volume_start(self.volume_name1, self.server_list[0])
 
         # bring a brick down and volume start force should bring it to online
+        redant.logger.info("Get all the bricks of the volume")
+        bricks_list = redant.es.get_all_bricks_list(self.volume_name1)
+        if len(bricks_list) == 0:
+            raise Exception("Failed to get the brick list")
 
-        g.log.info("Get all the bricks of the volume")
-        bricks_list = get_all_bricks(self.mnode, self.volname)
-        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
-        g.log.info("Successfully got the list of bricks of volume")
+        ret = redant.bring_bricks_offline(self.volume_name1, bricks_list[0:2])
+        if not ret:
+            raise Exception("Failed to bring down the bricks")
 
-        ret = bring_bricks_offline(self.volname, bricks_list[0:2])
-        self.assertTrue(ret, "Failed to bring down the bricks")
-        g.log.info("Successfully brought the bricks down")
+        ret = redant.volume_start(self.volume_name1, self.server_list[0],
+                                  force=True)
 
-        ret, _, _ = volume_start(self.mnode, self.volname, force=True)
-        self.assertEqual(ret, 0, "Failed to start the volume")
-        g.log.info("Volume start with force is success")
-
-        ret = wait_for_bricks_to_be_online(self.mnode, self.volname)
-        self.assertTrue(ret, "Failed to bring the bricks online")
-        g.log.info("Volume start with force successfully brought all the "
-                   "bricks online")
+        ret = redant.wait_for_bricks_to_come_online(self.volume_name1,
+                                                    self.server_list,
+                                                    bricks_list)
+        if not ret:
+            raise Exception("Failed to bring the bricks online")
 
         # create volume with previously used bricks and different volume name
-        self.volname = "second_volume"
-        ret, _, _ = volume_create(self.mnode, self.volname, bricks_list)
-        self.assertNotEqual(ret, 0, "Expected: It should fail to create a "
-                            "volume with previously used bricks. Actual:"
-                            "Successfully created the volume with previously"
-                            " used bricks")
-        g.log.info("Failed to create the volume with previously used bricks")
+        self.volume_type2 = 'dist'
+        self.volume_name2 = f"{self.test_name}-{self.volume_type2}-2"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type2]]
+        try:
+            redant.volume_create_with_custom_bricks(self.volume_name2,
+                                                    self.server_list[0],
+                                                    conf_dict, brick_cmd,
+                                                    brick_dict)
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with previously used bricks")
+        except Exception:
+            redant.logger.info("Expected: Failed to create a volume "
+                               "with previously used bricks.")
 
         # create a volume with already existing volume name
-        self.volume['name'] = "first_volume"
-        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
-        self.assertTrue(ret, "Expected: It should fail to create a volume"
-                        " with already existing volume name. Actual: "
-                        "Successfully created the volume with "
-                        "already existing volname")
-        g.log.info("Failed to create the volume with already existing volname")
+        try:
+            redant.setup_volume(self.volume_name1, self.server_list[0],
+                                conf_dict, self.server_list,
+                                self.brick_roots, True)
+            raise Exception("Unexpected: Successfully created the volume with "
+                            "already existing volname")
+        except Exception:
+            redant.logger.info("Expected: Failed to create the volume with "
+                               "already existing volname")
 
         # creating a volume with non existing brick path should fail
+        self.volume_type3 = 'dist'
+        self.volume_name3 = f"{self.test_name}-{self.volume_type3}-3"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type2]]
+        brick_dict, brick_cmd = redant.form_brick_cmd(self.server_list,
+                                                      self.brick_roots,
+                                                      self.volume_name3, 2)
+        non_exist_path = ":/brick/non_existing_path"
+        non_existing_brick = " " + str(self.server_list[0]) + non_exist_path
+        brick_cmd += non_existing_brick
 
-        self.volname = "second_volume"
-        bricks_list = form_bricks_list(self.mnode, self.volname,
-                                       len(self.servers), self.servers,
-                                       self.all_servers_info)
-        nonexisting_brick_index = random.randint(0, len(bricks_list) - 1)
-        non_existing_brick = bricks_list[nonexisting_brick_index].split(":")[0]
-        non_existing_path = ":/brick/non_existing_path"
-        non_existing_brick = non_existing_brick + non_existing_path
-        bricks_list[nonexisting_brick_index] = non_existing_brick
-
-        ret, _, _ = volume_create(self.mnode, self.volname, bricks_list)
-        self.assertNotEqual(ret, 0, "Expected: Creating a volume with non "
-                            "existing brick path should fail. Actual: "
-                            "Successfully created the volume with "
-                            "non existing brick path")
-        g.log.info("Failed to create the volume with non existing brick path")
+        try:
+            redant.volume_create_with_custom_bricks(self.volume_name3,
+                                                    self.server_list[0],
+                                                    conf_dict, brick_cmd,
+                                                    brick_dict)
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with non existing brick path")
+        except Exception:
+            redant.logger.info("Expected: Failed to create the volume with "
+                               "non existing brick path")
 
         # cleanup the volume and peer detach all servers. form two clusters,try
         # to create a volume with bricks whose nodes are in different clusters
 
         # cleanup volumes
-        vol_list = get_volume_list(self.mnode)
-        self.assertIsNotNone(vol_list, "Failed to get the volume list")
+        vol_list = redant.es.get_volnames()
+        if vol_list is None:
+            raise Exception("Failed to get the volume list")
 
         for volume in vol_list:
-            ret = cleanup_volume(self.mnode, volume)
-            self.assertTrue(ret, "Unable to delete volume % s" % volume)
+            redant.cleanup_volume(volume, self.server_list[0])
 
         # peer detach all servers
-        ret = peer_detach_servers(self.mnode, self.servers)
-        self.assertTrue(ret, "Peer detach to all servers is failed")
-        g.log.info("Peer detach to all the servers is success")
+        redant.delete_cluster(self.server_list)
 
         # form cluster 1
-        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
-        self.assertEqual(ret, 0, "Peer probe from %s to %s is failed"
-                         % (self.servers[0], self.servers[1]))
-        g.log.info("Peer probe is success from %s to %s",
-                   self.servers[0], self.servers[1])
+        redant.peer_probe(self.server_list[1], self.server_list[0])
 
         # form cluster 2
-        ret, _, _ = peer_probe(self.servers[2], self.servers[3])
-        self.assertEqual(ret, 0, "Peer probe from %s to %s is failed"
-                         % (self.servers[2], self.servers[3]))
-        g.log.info("Peer probe is success from %s to %s",
-                   self.servers[2], self.servers[3])
+        redant.peer_probe(self.server_list[3], self.server_list[2])
 
         # Creating a volume with bricks which are part of another
         # cluster should fail
-        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
-        self.assertFalse(ret, "Expected: Creating a volume with bricks"
-                         " which are part of another cluster should fail."
-                         " Actual: Successfully created the volume with "
-                         "bricks which are part of another cluster")
-        g.log.info("Failed to create the volume with bricks which are "
-                   "part of another cluster")
+        try:
+            redant.setup_volume(self.volume_name3, self.server_list[0],
+                                conf_dict, self.server_list,
+                                self.brick_roots, True)
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with bricks which are part of another cluster")
+        except Exception:
+            redant.logger.info("Expected: Failed to create the volume with "
+                               "bricks which are part of another cluster")
 
         # form a cluster, bring a node down. try to create a volume when one of
         # the brick node is down
-        ret, _, _ = peer_detach(self.servers[2], self.servers[3])
-        self.assertEqual(ret, 0, "Peer detach is failed")
-        g.log.info("Peer detach is success")
+        ret = redant.peer_detach(self.server_list[3], self.server_list[2])
 
-        ret = peer_probe_servers(self.mnode, self.servers)
-        self.assertTrue(ret, "Peer probe is failed")
-        g.log.info("Peer probe to all the servers is success")
+        ret = redant.peer_probe_servers(self.server_list, self.server_list[0])
 
         # Taking random node from the first four nodes as the
         # volume getting created is using first four nodes
-        # Excluding servers[0] as it is mnode
-        first_four_servers = self.servers[:4]
+        # Excluding server_list[0]
+        first_four_servers = self.server_list[:4]
         random_server = random.choice(first_four_servers[1:])
-        ret = stop_glusterd(random_server)
-        self.assertTrue(ret, "Glusterd is stopped successfully")
+        ret = redant.stop_glusterd(random_server)
 
-        self.volume['name'] = "third_volume"
-        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
-        self.assertFalse(ret, "Expected: It should fail to create a volume "
-                         "when one of the node is down. Actual: Successfully "
-                         "created the volume with brick whose node is down")
-
-        g.log.info("Failed to create the volume with brick whose node is down")
+        self.volume_type4 = 'dist'
+        self.volume_name4 = f"{self.test_name}-{self.volume_type4}-4"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type4]]
+        try:
+            redant.setup_volume(self.volume_name4, self.server_list[0],
+                                conf_dict, self.server_list,
+                                self.brick_roots, True)
+            raise Exception("Unexpected: Successfully created the volume "
+                            "with brick whose node is down")
+        except Exception:
+            redant.logger.info("Expected: Failed to create the volume with "
+                               "brick whose node is down")

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -197,7 +197,11 @@ class TestVolumeCreate(GlusterBaseClass):
         self.assertTrue(ret, "Peer probe is failed")
         g.log.info("Peer probe to all the servers is success")
 
-        random_server = self.servers[random.randint(1, len(self.servers) - 1)]
+        # Taking random node from the first four nodes as the
+        # volume getting created is using first four nodes
+        # Excluding servers[0] as it is mnode
+        first_four_servers = self.servers[:4]
+        random_server = random.choice(first_four_servers[1:])
         ret = stop_glusterd(random_server)
         self.assertTrue(ret, "Glusterd is stopped successfully")
 
@@ -205,6 +209,6 @@ class TestVolumeCreate(GlusterBaseClass):
         ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
         self.assertFalse(ret, "Expected: It should fail to create a volume "
                          "when one of the node is down. Actual: Successfully "
-                         "created the volume with bbrick whose node is down")
+                         "created the volume with brick whose node is down")
 
         g.log.info("Failed to create the volume with brick whose node is down")

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -115,7 +115,7 @@ class TestCase(DParentTest):
 
         # cleanup volumes
         vol_list = redant.get_volume_list(self.server_list[0])
-        if len(vol_list) == 0 :
+        if len(vol_list) == 0:
             raise Exception("Failed to get the volume list")
 
         for volume in vol_list:

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -14,6 +14,7 @@
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import random
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
@@ -28,11 +29,13 @@ from glustolibs.gluster.peer_ops import (peer_detach_servers, peer_probe,
                                          peer_detach)
 from glustolibs.gluster.lib_utils import form_bricks_list
 from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
-import random
 
 
 @runs_on([['distributed'], ['glusterfs']])
 class TestVolumeCreate(GlusterBaseClass):
+    '''
+    Test glusterd behavior with the gluster volume create command
+    '''
 
     @classmethod
     def setUpClass(cls):
@@ -68,12 +71,19 @@ class TestVolumeCreate(GlusterBaseClass):
             ret = cleanup_volume(self.mnode, volume)
             if not ret:
                 raise ExecutionError("Unable to delete volume % s" % volume)
-            g.log.info("Volume deleted successfully : %s" % volume)
+            g.log.info("Volume deleted successfully : %s", volume)
 
         GlusterBaseClass.tearDown.im_func(self)
 
     def test_volume_create(self):
-
+        '''
+        In this test case, volume create operations such as creating volume
+        with non existing brick path, already used brick, already existing
+        volume name, bring the bricks to online with volume start force,
+        creating a volume with bricks in another cluster, creating a volume
+        when one of the brick node is down are validated.
+        '''
+        # pylint: disable=too-many-statements
         # create and start a volume
         self.volume['name'] = "first_volume"
         self.volname = "first_volume"
@@ -157,15 +167,15 @@ class TestVolumeCreate(GlusterBaseClass):
         ret, _, _ = peer_probe(self.servers[0], self.servers[1])
         self.assertEqual(ret, 0, "Peer probe from %s to %s is failed"
                          % (self.servers[0], self.servers[1]))
-        g.log.info("Peer probe is success from %s to %s"
-                   % (self.servers[0], self.servers[1]))
+        g.log.info("Peer probe is success from %s to %s",
+                   self.servers[0], self.servers[1])
 
         # form cluster 2
         ret, _, _ = peer_probe(self.servers[2], self.servers[3])
         self.assertEqual(ret, 0, "Peer probe from %s to %s is failed"
                          % (self.servers[2], self.servers[3]))
-        g.log.info("Peer probe is success from %s to %s"
-                   % (self.servers[2], self.servers[3]))
+        g.log.info("Peer probe is success from %s to %s",
+                   self.servers[2], self.servers[3])
 
         # Creating a volume with bricks which are part of another
         # cluster should fail

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -53,9 +53,9 @@ class TestCase(DParentTest):
         redant.volume_start(self.volume_name1, self.server_list[0])
 
         # bring a brick down and volume start force should bring it to online
-        redant.logger.info("Get all the bricks of the volume")
-        bricks_list = redant.es.get_all_bricks_list(self.volume_name1)
-        if len(bricks_list) == 0:
+        bricks_list = redant.get_all_bricks(self.volume_name1,
+                                            self.server_list[0])
+        if bricks_list is None:
             raise Exception("Failed to get the brick list")
 
         ret = redant.bring_bricks_offline(self.volume_name1, bricks_list[0:2])
@@ -114,8 +114,8 @@ class TestCase(DParentTest):
         # to create a volume with bricks whose nodes are in different clusters
 
         # cleanup volumes
-        vol_list = redant.es.get_volnames()
-        if vol_list is None:
+        vol_list = redant.get_volume_list(self.server_list[0])
+        if len(vol_list) == 0 :
             raise Exception("Failed to get the volume list")
 
         for volume in vol_list:

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -16,7 +16,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
   Description:
-  Test glusterd behavior with the gluster volume create command
+    Test glusterd behavior with the gluster volume create command
 """
 
 import random
@@ -75,32 +75,19 @@ class TestCase(DParentTest):
         self.volume_type2 = 'dist'
         self.volume_name2 = f"{self.test_name}-{self.volume_type2}-2"
         conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type2]]
-        excep = True
-        try:
-            redant.volume_create_with_custom_bricks(self.volume_name2,
-                                                    self.server_list[0],
-                                                    conf_dict, brick_cmd,
-                                                    brick_dict)
-            excep = False
-        except Exception:
-            redant.logger.info("Expected: Failed to create a volume "
-                               "with previously used bricks.")
-
-        if not excep:
+        ret = redant.volume_create_with_custom_bricks(self.volume_name2,
+                                                      self.server_list[0],
+                                                      conf_dict, brick_cmd,
+                                                      brick_dict, excep=False)
+        if ret['error_code'] == 0:
             raise Exception("Unexpected: Successfully created the volume "
                             "with previously used bricks")
 
         # create a volume with already existing volume name
-        try:
-            redant.setup_volume(self.volume_name1, self.server_list[0],
-                                conf_dict, self.server_list,
-                                self.brick_roots)
-            excep = False
-        except Exception:
-            redant.logger.info("Expected: Failed to create the volume with "
-                               "already existing volname")
-
-        if not excep:
+        ret = redant.setup_volume(self.volume_name1, self.server_list[0],
+                                  conf_dict, self.server_list,
+                                  self.brick_roots, excep=False)
+        if ret['error_code'] == 0:
             raise Exception("Unexpected: Successfully created the volume with "
                             "already existing volname")
 
@@ -115,17 +102,11 @@ class TestCase(DParentTest):
         non_existing_brick = " " + str(self.server_list[0]) + non_exist_path
         brick_cmd += non_existing_brick
 
-        try:
-            redant.volume_create_with_custom_bricks(self.volume_name3,
-                                                    self.server_list[0],
-                                                    conf_dict, brick_cmd,
-                                                    brick_dict)
-            excep = False
-        except Exception:
-            redant.logger.info("Expected: Failed to create the volume with "
-                               "non existing brick path")
-
-        if not excep:
+        ret = redant.volume_create_with_custom_bricks(self.volume_name3,
+                                                      self.server_list[0],
+                                                      conf_dict, brick_cmd,
+                                                      brick_dict, excep=False)
+        if ret['error_code'] == 0:
             raise Exception("Unexpected: Successfully created the volume "
                             "with non existing brick path")
 
@@ -151,16 +132,10 @@ class TestCase(DParentTest):
 
         # Creating a volume with bricks which are part of another
         # cluster should fail
-        try:
-            redant.setup_volume(self.volume_name3, self.server_list[0],
-                                conf_dict, self.server_list,
-                                self.brick_roots)
-            excep = False
-        except Exception:
-            redant.logger.info("Expected: Failed to create the volume with "
-                               "bricks which are part of another cluster")
-
-        if not excep:
+        ret = redant.setup_volume(self.volume_name3, self.server_list[0],
+                                  conf_dict, self.server_list,
+                                  self.brick_roots, excep=False)
+        if ret['error_code'] == 0:
             raise Exception("Unexpected: Successfully created the volume "
                             "with bricks which are part of another cluster")
 
@@ -180,15 +155,9 @@ class TestCase(DParentTest):
         self.volume_type4 = 'dist'
         self.volume_name4 = f"{self.test_name}-{self.volume_type4}-4"
         conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type4]]
-        try:
-            redant.setup_volume(self.volume_name4, self.server_list[0],
-                                conf_dict, self.server_list,
-                                self.brick_roots, True)
-            excep = False
-        except Exception:
-            redant.logger.info("Expected: Failed to create the volume with "
-                               "brick whose node is down")
-
-        if not excep:
+        ret = redant.setup_volume(self.volume_name4, self.server_list[0],
+                                  conf_dict, self.server_list,
+                                  self.brick_roots, excep=False)
+        if ret['error_code'] == 0:
             raise Exception("Unexpected: Successfully created the volume "
                             "with brick whose node is down")

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -1,0 +1,200 @@
+#  Copyright (C) 2016-2017  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_ops import (volume_create, volume_start,
+                                           get_volume_list)
+from glustolibs.gluster.brick_libs import (get_all_bricks,
+                                           bring_bricks_offline,
+                                           wait_for_bricks_to_be_online)
+from glustolibs.gluster.volume_libs import setup_volume, cleanup_volume
+from glustolibs.gluster.peer_ops import (peer_detach_servers, peer_probe,
+                                         peer_probe_servers, is_peer_connected,
+                                         peer_detach)
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.gluster_init import start_glusterd, stop_glusterd
+import random
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestVolumeCreate(GlusterBaseClass):
+
+    @classmethod
+    def setUpClass(cls):
+
+        # Calling GlusterBaseClass setUpClass
+        GlusterBaseClass.setUpClass.im_func(cls)
+
+        ret = cls.validate_peers_are_connected()
+        if not ret:
+            raise ExecutionError("Peers are not in connected state")
+
+    def tearDown(self):
+
+        # start glusterd on all servers
+        ret = start_glusterd(self.servers)
+        if not ret:
+            raise ExecutionError("Failed to start glusterd on all servers")
+
+        for server in self.servers:
+            ret = is_peer_connected(server, self.servers)
+            if not ret:
+                ret = peer_probe_servers(server, self.servers)
+                if not ret:
+                    raise ExecutionError("Failed to peer probe all "
+                                         "the servers")
+
+        # clean up all volumes
+        vol_list = get_volume_list(self.mnode)
+        if vol_list is None:
+            raise ExecutionError("Failed to get the volume list")
+
+        for volume in vol_list:
+            ret = cleanup_volume(self.mnode, volume)
+            if not ret:
+                raise ExecutionError("Unable to delete volume % s" % volume)
+            g.log.info("Volume deleted successfully : %s" % volume)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_volume_create(self):
+
+        # create and start a volume
+        self.volume['name'] = "first_volume"
+        self.volname = "first_volume"
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertTrue(ret, "Failed to create and start volume")
+
+        # bring a brick down and volume start force should bring it to online
+
+        g.log.info("Get all the bricks of the volume")
+        bricks_list = get_all_bricks(self.mnode, self.volname)
+        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
+        g.log.info("Successfully got the list of bricks of volume")
+
+        ret = bring_bricks_offline(self.volname, bricks_list[0:2])
+        self.assertTrue(ret, "Failed to bring down the bricks")
+        g.log.info("Successfully brought the bricks down")
+
+        ret, _, _ = volume_start(self.mnode, self.volname, force=True)
+        self.assertEqual(ret, 0, "Failed to start the volume")
+        g.log.info("Volume start with force is success")
+
+        ret = wait_for_bricks_to_be_online(self.mnode, self.volname)
+        self.assertTrue(ret, "Failed to bring the bricks online")
+        g.log.info("Volume start with force successfully brought all the "
+                   "bricks online")
+
+        # create volume with previously used bricks and different volume name
+        self.volname = "second_volume"
+        ret, _, _ = volume_create(self.mnode, self.volname, bricks_list)
+        self.assertNotEqual(ret, 0, "Expected: It should fail to create a "
+                            "volume with previously used bricks. Actual:"
+                            "Successfully created the volume with previously"
+                            " used bricks")
+        g.log.info("Failed to create the volume with previously used bricks")
+
+        # create a volume with already existing volume name
+        self.volume['name'] = "first_volume"
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertTrue(ret, "Expected: It should fail to create a volume"
+                        " with already existing volume name. Actual: "
+                        "Successfully created the volume with "
+                        "already existing volname")
+        g.log.info("Failed to create the volume with already existing volname")
+
+        # creating a volume with non existing brick path should fail
+
+        self.volname = "second_volume"
+        bricks_list = form_bricks_list(self.mnode, self.volname,
+                                       len(self.servers), self.servers,
+                                       self.all_servers_info)
+        nonexisting_brick_index = random.randint(0, len(bricks_list) - 1)
+        non_existing_brick = bricks_list[nonexisting_brick_index].split(":")[0]
+        non_existing_path = ":/brick/non_existing_path"
+        non_existing_brick = non_existing_brick + non_existing_path
+        bricks_list[nonexisting_brick_index] = non_existing_brick
+
+        ret, _, _ = volume_create(self.mnode, self.volname, bricks_list)
+        self.assertNotEqual(ret, 0, "Expected: Creating a volume with non "
+                            "existing brick path should fail. Actual: "
+                            "Successfully created the volume with "
+                            "non existing brick path")
+        g.log.info("Failed to create the volume with non existing brick path")
+
+        # cleanup the volume and peer detach all servers. form two clusters,try
+        # to create a volume with bricks whose nodes are in different clusters
+
+        # cleanup volumes
+        vol_list = get_volume_list(self.mnode)
+        self.assertIsNotNone(vol_list, "Failed to get the volume list")
+
+        for volume in vol_list:
+            ret = cleanup_volume(self.mnode, volume)
+            self.assertTrue(ret, "Unable to delete volume % s" % volume)
+
+        # peer detach all servers
+        ret = peer_detach_servers(self.mnode, self.servers)
+        self.assertTrue(ret, "Peer detach to all servers is failed")
+        g.log.info("Peer detach to all the servers is success")
+
+        # form cluster 1
+        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
+        self.assertEqual(ret, 0, "Peer probe from %s to %s is failed"
+                         % (self.servers[0], self.servers[1]))
+        g.log.info("Peer probe is success from %s to %s"
+                   % (self.servers[0], self.servers[1]))
+
+        # form cluster 2
+        ret, _, _ = peer_probe(self.servers[2], self.servers[3])
+        self.assertEqual(ret, 0, "Peer probe from %s to %s is failed"
+                         % (self.servers[2], self.servers[3]))
+        g.log.info("Peer probe is success from %s to %s"
+                   % (self.servers[2], self.servers[3]))
+
+        # Creating a volume with bricks which are part of another
+        # cluster should fail
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertFalse(ret, "Expected: Creating a volume with bricks"
+                         " which are part of another cluster should fail."
+                         " Actual: Successfully created the volume with "
+                         "bricks which are part of another cluster")
+        g.log.info("Failed to create the volume with bricks which are "
+                   "part of another cluster")
+
+        # form a cluster, bring a node down. try to create a volume when one of
+        # the brick node is down
+        ret, _, _ = peer_detach(self.servers[2], self.servers[3])
+        self.assertEqual(ret, 0, "Peer detach is failed")
+        g.log.info("Peer detach is success")
+
+        ret = peer_probe_servers(self.mnode, self.servers)
+        self.assertTrue(ret, "Peer probe is failed")
+        g.log.info("Peer probe to all the servers is success")
+
+        random_server = self.servers[random.randint(1, len(self.servers) - 1)]
+        ret = stop_glusterd(random_server)
+        self.assertTrue(ret, "Glusterd is stopped successfully")
+
+        self.volume['name'] = "third_volume"
+        ret = setup_volume(self.mnode, self.all_servers_info, self.volume)
+        self.assertFalse(ret, "Expected: It should fail to create a volume "
+                         "when one of the node is down. Actual: Successfully "
+                         "created the volume with bbrick whose node is down")
+
+        g.log.info("Failed to create the volume with brick whose node is down")


### PR DESCRIPTION
Migration of [test_volume_create.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_volume_create.py) from glusto to redant

Updates: #292
Fixes: #562 
Signed-off-by: Nishith Vihar Sakinala nsakinal@redhat.com