### PR TITLE
Migrated test_mount_after_removing_client_logs_dir

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -110,6 +110,36 @@ class IoOps(AbstractOps):
 
         return True
 
+    def get_dir_contents(self, path: str, node: str,
+                         recursive: bool = False,) -> list:
+        """
+        Get the files and directories present in a given directory.
+
+        Args:
+            path (str): The path to the directory.
+            node (str): IP of the remote system.
+
+        Optional:
+            recursive (bool): lists all entries recursively
+
+        Returns:
+            file_dir_list (list): List of files and directories on path.
+            None: In case of error or failure.
+        """
+        if recursive:
+            cmd = f"find {path}"
+        else:
+            cmd = f"ls {path}"
+
+        ret = self.execute_abstract_op_node(cmd, node, False)
+        if ret['error_code']:
+            self.logger.error(f"Unable to list directory contents for {path}:"
+                              f" {ret['error_msg']}")
+            return None
+
+        out = "".join(ret['msg'])
+        return list(filter(None, out.split("\n")))
+
     def get_file_stat(self, node: str, path: str) -> str:
         """
         Function to get file stat.

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -111,7 +111,7 @@ class IoOps(AbstractOps):
         return True
 
     def get_dir_contents(self, path: str, node: str,
-                         recursive: bool = False,) -> list:
+                         recursive: bool = False) -> list:
         """
         Get the files and directories present in a given directory.
 

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -30,7 +30,7 @@ from glustolibs.gluster.mount_ops import mount_volume, umount_volume
 class TestRemoveCientLogDirAndMount(GlusterBaseClass):
 
     def setUp(self):
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
         # Creating Volume and mounting volume.
         ret = self.setup_volume(self.mounts)
@@ -75,7 +75,7 @@ class TestRemoveCientLogDirAndMount(GlusterBaseClass):
                                  % self.volname)
         g.log.info("Volume deleted successfully : %s", self.volname)
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_mount_after_removing_client_logs_dir(self):
 

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -1,0 +1,125 @@
+#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+    Description:
+    A testcase to remove /var/log/glusterfs/ on client, mounting a volume
+    and createing a file and a dir on it.
+"""
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.glusterdir import (mkdir, get_dir_contents)
+from glustolibs.gluster.mount_ops import mount_volume, umount_volume
+
+
+@runs_on([['distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed'], ['glusterfs']])
+class TestRemoveCientLogDirAndMount(GlusterBaseClass):
+
+    def setUp(self):
+        GlusterBaseClass.setUp.im_func(self)
+
+        # Creating Volume and mounting volume.
+        ret = self.setup_volume(self.mounts)
+        if not ret:
+            raise ExecutionError("Volume creation or mount failed: %s"
+                                 % self.volname)
+        g.log.info("Volme created and mounted successfully : %s",
+                   self.volname)
+
+    def tearDown(self):
+
+        # Resetting the /var/log/glusterfs on client
+        # and archiving the present one.
+        cmd = ('for file in `ls /var/log/glusterfs/`; do '
+               'mv /var/log/glusterfs/$file'
+               ' /var/log/glusterfs/`date +%s`-$file; done')
+        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
+        self.assertEqual(ret, 0, "Renaming all files failed")
+        g.log.info("Successfully renamed files in"
+                   " /var/log/glusterfs on client: %s",
+                   self.mounts[0].client_system)
+        cmd = ('mv /root/glusterfs/* /var/log/glusterfs/;'
+               'rm -rf /root/glusterfs')
+        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
+        self.assertEqual(ret, 0,
+                         "Failed to move old files back to /var/log/glusterfs")
+        g.log.info("Successfully moved files in"
+                   " /var/log/glusterfs on client: %s",
+                   self.mounts[0])
+
+        # Unmounting the volume.
+        ret, _, _ = umount_volume(mclient=self.mounts[0].client_system,
+                                  mpoint=self.mounts[0].mountpoint)
+        if ret:
+            raise ExecutionError("Volume %s is not unmounted" % self.volname)
+        g.log.info("Volume unmounted successfully : %s", self.volname)
+
+        # clean up all volumes
+        ret = self.cleanup_volume()
+        if not ret:
+            raise ExecutionError("Unable to delete volume % s"
+                                 % self.volname)
+        g.log.info("Volume deleted successfully : %s", self.volname)
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_mount_after_removing_client_logs_dir(self):
+
+        # pylint: disable=too-many-statements
+        """
+        Test Case:
+        1. Create all types of volumes.
+        2. Start all volumes.
+        3. Delete /var/log/glusterfs folder on the client.
+        4. Mount all the volumes one by one.
+        5. Run IO on all the mount points.
+        6. Check if logs are generated in /var/log/glusterfs/.
+        """
+
+        # Removing dir /var/log/glusterfs on client.
+        cmd = 'mv /var/log/glusterfs /root/'
+        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
+        self.assertEqual(ret, 0, "Unable to remove /var/log/glusterfs dir")
+        g.log.info("Successfully removed /var/log/glusterfs on client: %s",
+                   self.mounts[0].client_system)
+
+        # Mounting the volume.
+        ret, _, _ = mount_volume(self.volname, mtype=self.mount_type,
+                                 mpoint=self.mounts[0].mountpoint,
+                                 mserver=self.mnode,
+                                 mclient=self.mounts[0].client_system)
+        self.assertEqual(ret, 0, ("Volume %s is not mounted") % self.volname)
+        g.log.info("Volume mounted successfully : %s", self.volname)
+
+        # Running IO on the mount point.
+        # Creating a dir on the mount point.
+        ret = mkdir(self.mounts[0].client_system,
+                    self.mounts[0].mountpoint+"/dir2")
+        self.assertTrue(ret, "Failed to create dir2")
+        g.log.info("dir2 created successfully for %s", self.mounts[0])
+
+        # Creating a file on the mount point.
+        cmd = ('touch  %s/file' % self.mounts[0].mountpoint)
+        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
+        self.assertEqual(ret, 0, "Failed to create file")
+        g.log.info("file created successfully for %s", self.mounts[0])
+
+        # Checking if logs are regenerated or not.
+        ret = get_dir_contents(self.mounts[0].client_system,
+                               '/var/log/glusterfs/')
+        self.assertIsNotNone(ret, 'Log files were not regenerated.')
+        g.log.info("Log files were properly regenearted.")

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -21,7 +21,7 @@
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.glusterdir import (get_dir_contents, mkdir, rmdir)
+from glustolibs.gluster.glusterdir import (get_dir_contents, mkdir)
 from glustolibs.gluster.mount_ops import mount_volume, umount_volume
 
 
@@ -67,11 +67,6 @@ class TestRemoveCientLogDirAndMount(GlusterBaseClass):
         if ret:
             raise ExecutionError("Volume %s is not unmounted" % self.volname)
         g.log.info("Volume unmounted successfully : %s", self.volname)
-
-        ret = rmdir(self.mounts[0].client_system, self.mounts[0].mountpoint)
-        if not ret:
-            raise ExecutionError("Failed to remove directory mount directory.")
-        g.log.info("Mount directory is removed successfully")
 
         # clean up all volumes
         ret = self.cleanup_volume()

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -1,85 +1,64 @@
-#  Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
-    Description:
+ Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along`
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
     A testcase to remove /var/log/glusterfs/ on client, mounting a volume
     and createing a file and a dir on it.
 """
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.glusterdir import (get_dir_contents, mkdir)
-from glustolibs.gluster.mount_ops import mount_volume, umount_volume
+
+import traceback
+from tests.d_parent_test import DParentTest
+
+# disruptive;dist,dist-rep,rep,disp,dist-disp
 
 
-@runs_on([['distributed', 'replicated', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed'], ['glusterfs']])
-class TestRemoveCientLogDirAndMount(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    def setUp(self):
-        self.get_super_method(self, 'setUp')()
+    def setup_test(self):
+        """
+        Override the volume create, start and mount in parent_run_test
+        """
+        self.setup_done = True
+        conf_hash = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        self.redant.setup_volume(self.vol_name, self.server_list[0],
+                                 conf_hash, self.server_list,
+                                 self.brick_roots)
 
-        # Creating Volume and mounting volume.
-        ret = self.setup_volume(self.mounts)
-        if not ret:
-            raise ExecutionError("Volume creation or mount failed: %s"
-                                 % self.volname)
-        g.log.info("Volme created and mounted successfully : %s",
-                   self.volname)
-
-    def tearDown(self):
+    def terminate(self):
 
         # Resetting the /var/log/glusterfs on client
         # and archiving the present one.
-        cmd = ('for file in `ls /var/log/glusterfs/`; do '
-               'mv /var/log/glusterfs/$file'
-               ' /var/log/glusterfs/`date +%s`-$file; done')
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Renaming all files failed")
-        g.log.info("Successfully renamed files in"
-                   " /var/log/glusterfs on client: %s",
-                   self.mounts[0].client_system)
-        cmd = ('mv /root/glusterfs/* /var/log/glusterfs/;'
-               'rm -rf /root/glusterfs')
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0,
-                         "Failed to move old files back to /var/log/glusterfs")
-        g.log.info("Successfully moved files in"
-                   " /var/log/glusterfs on client: %s",
-                   self.mounts[0])
+        try:
+            cmd = ('for file in `ls /var/log/glusterfs/`; do '
+                   'mv /var/log/glusterfs/$file'
+                   ' /var/log/glusterfs/`date +%s`-$file; done')
+            self.redant.execute_abstract_op_node(cmd, self.client_list[0])
 
-        # Unmounting the volume.
-        ret, _, _ = umount_volume(mclient=self.mounts[0].client_system,
-                                  mpoint=self.mounts[0].mountpoint)
-        if ret:
-            raise ExecutionError("Volume %s is not unmounted" % self.volname)
-        g.log.info("Volume unmounted successfully : %s", self.volname)
+            cmd = ('mv /root/glusterfs/* /var/log/glusterfs/;'
+                   'rm -rf /root/glusterfs')
+            self.redant.execute_abstract_op_node(cmd, self.client_list[0])
 
-        # clean up all volumes
-        ret = self.cleanup_volume()
-        if not ret:
-            raise ExecutionError("Unable to delete volume % s"
-                                 % self.volname)
-        g.log.info("Volume deleted successfully : %s", self.volname)
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
-        self.get_super_method(self, 'tearDown')()
-
-    def test_mount_after_removing_client_logs_dir(self):
-
-        # pylint: disable=too-many-statements
+    def run_test(self, redant):
         """
         Test Case:
         1. Create all types of volumes.
@@ -92,94 +71,64 @@ class TestRemoveCientLogDirAndMount(GlusterBaseClass):
 
         # Removing dir /var/log/glusterfs on client.
         cmd = 'mv /var/log/glusterfs /root/'
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Unable to remove /var/log/glusterfs dir")
-        g.log.info("Successfully removed /var/log/glusterfs on client: %s",
-                   self.mounts[0].client_system)
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Mounting the volume.
-        ret, _, _ = mount_volume(self.volname, mtype=self.mount_type,
-                                 mpoint=self.mounts[0].mountpoint,
-                                 mserver=self.mnode,
-                                 mclient=self.mounts[0].client_system)
-        self.assertEqual(ret, 0, ("Volume %s is not mounted") % self.volname)
-        g.log.info("Volume mounted successfully : %s", self.volname)
+        self.mountpoint = (f"/mnt/{self.vol_name}")
+        redant.volume_mount(self.server_list[0], self.vol_name,
+                            self.mountpoint, self.client_list[0])
 
         # Running IO on the mount point.
         # Creating a dir on the mount point.
-        ret = mkdir(self.mounts[0].client_system,
-                    self.mounts[0].mountpoint+"/dir2")
-        self.assertTrue(ret, "Failed to create dir2")
-        g.log.info("dir2 created successfully for %s", self.mounts[0])
+        redant.create_dir(self.mountpoint, "dir2", self.client_list[0])
 
         # Creating a file on the mount point.
-        cmd = ('touch  %s/file' % self.mounts[0].mountpoint)
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Failed to create file")
-        g.log.info("file created successfully for %s", self.mounts[0])
+        cmd = f"touch  {self.mountpoint}/file"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Checking if logs are regenerated or not.
-        ret = get_dir_contents(self.mounts[0].client_system,
-                               '/var/log/glusterfs/')
-        self.assertIsNotNone(ret, 'Log files were not regenerated.')
-        g.log.info("Log files were properly regenearted.")
+        ret = redant.get_dir_contents('/var/log/glusterfs/',
+                                      self.client_list[0])
+        if ret is None:
+            raise Exception("Log files were not regenerated")
 
-    def test_mount_remove_client_logs_dir_remount(self):
+        # Moving the logs back in place, and archiving the old ones
+        cmd = ('for file in `ls /var/log/glusterfs/`; do '
+               'mv /var/log/glusterfs/$file'
+               ' /var/log/glusterfs/`date +%s`-$file; done')
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
-        # pylint: disable=too-many-statements
-        """
-        1. Create all types of volumes and start them.
-        2. Mount all volumes on clients.
-        3. Delete /var/log/glusterfs folder on client.
-        4. Run IO on all the mount points.
-        5. Unmount and remount all volumes.
-        6. Check if logs are regenerated or not.
-        """
+        cmd = ('mv /root/glusterfs/* /var/log/glusterfs/;'
+               'rm -rf /root/glusterfs')
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
-        # Mounting the volume.
-        ret, _, _ = mount_volume(self.volname, mtype=self.mount_type,
-                                 mpoint=self.mounts[0].mountpoint,
-                                 mserver=self.mnode,
-                                 mclient=self.mounts[0].client_system)
-        self.assertEqual(ret, 0, ("Volume %s is not mounted.") % self.volname)
-        g.log.info("Volume mounted successfully : %s", self.volname)
+        # Merged TC test_mount_remove_client_logs_dir_remount
+        # 1. Delete /var/log/glusterfs folder on client.
+        # 4. Run IO on all the mount points.
+        # 5. Unmount and remount all volumes.
+        # 6. Check if logs are regenerated or not.
 
         # Removing dir /var/log/glusterfs on client.
         cmd = 'mv /var/log/glusterfs /root/'
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Unable to remove /var/log/glusterfs dir.")
-        g.log.info("Successfully removed /var/log/glusterfs on client: %s",
-                   self.mounts[0])
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Running IO on the mount point.
         # Creating a dir on the mount point.
-        ret = mkdir(self.mounts[0].client_system,
-                    self.mounts[0].mountpoint+"/dir")
-        self.assertTrue(ret, "Failed to create dir.")
-        g.log.info("dir created successfully for %s", self.mounts[0])
+        redant.create_dir(self.mountpoint, "dir", self.client_list[0])
 
         # Creating a file on the mount point.
-        cmd = ('touch  %s/file' % self.mounts[0].mountpoint)
-        ret, _, _ = g.run(self.mounts[0].client_system, cmd)
-        self.assertEqual(ret, 0, "Failed to create file.")
-        g.log.info("file created successfully for %s", self.mounts[0])
+        cmd = f"touch  {self.mountpoint}/file1"
+        redant.execute_abstract_op_node(cmd, self.client_list[0])
 
         # Unmounting and remounting volume.
-        ret, _, _ = umount_volume(mclient=self.mounts[0].client_system,
-                                  mpoint=self.mounts[0].mountpoint)
-        self.assertEqual(ret, 0,
-                         ("Volume %s is not unmounted.") % self.volname)
-        g.log.info("Volume unmounted successfully : %s", self.volname)
+        redant.volume_unmount(self.vol_name, self.mountpoint,
+                              self.client_list[0])
 
-        ret, _, _ = mount_volume(self.volname, mtype=self.mount_type,
-                                 mpoint=self.mounts[0].mountpoint,
-                                 mserver=self.mnode,
-                                 mclient=self.mounts[0].client_system)
-        self.assertEqual(ret, 0, ("Volume %s is not mounted.") % self.volname)
-        g.log.info("Volume mounted successfully : %s", self.volname)
+        redant.volume_mount(self.server_list[0], self.vol_name,
+                            self.mountpoint, self.client_list[0])
 
         # Checking if logs are regenerated or not.
-        ret = get_dir_contents(self.mounts[0].client_system,
-                               '/var/log/glusterfs/')
-        self.assertIsNotNone(ret, 'Log files were not regenerated.')
-        g.log.info("Log files were properly regenearted.")
+        ret = redant.get_dir_contents('/var/log/glusterfs/',
+                                      self.client_list[0])
+        if ret is None:
+            raise Exception("Log files were not regenerated")

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -15,7 +15,7 @@
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-  Description:
+ Description:
     A testcase to remove /var/log/glusterfs/ on client, mounting a volume
     and createing a file and a dir on it.
 """

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -75,6 +75,8 @@ class TestCase(DParentTest):
 
         # Mounting the volume.
         self.mountpoint = (f"/mnt/{self.vol_name}")
+        self.redant.execute_abstract_op_node(f"mkdir -p {self.mountpoint}",
+                                             self.client_list[0])
         redant.volume_mount(self.server_list[0], self.vol_name,
                             self.mountpoint, self.client_list[0])
 

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2019-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
 from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.glusterdir import (mkdir, get_dir_contents)
+from glustolibs.gluster.glusterdir import (get_dir_contents, mkdir, rmdir)
 from glustolibs.gluster.mount_ops import mount_volume, umount_volume
 
 
@@ -67,6 +67,11 @@ class TestRemoveCientLogDirAndMount(GlusterBaseClass):
         if ret:
             raise ExecutionError("Volume %s is not unmounted" % self.volname)
         g.log.info("Volume unmounted successfully : %s", self.volname)
+
+        ret = rmdir(self.mounts[0].client_system, self.mounts[0].mountpoint)
+        if not ret:
+            raise ExecutionError("Failed to remove directory mount directory.")
+        g.log.info("Mount directory is removed successfully")
 
         # clean up all volumes
         ret = self.cleanup_volume()


### PR DESCRIPTION
Migrated TC [test_mount_after_removing_client_logs_dir](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py)

Fixes: #558 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>