### PR TITLE
Migrating test_reserve_limt_change_while_rebalance.py  

### DIFF
--- a/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
+++ b/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
@@ -1,69 +1,32 @@
-#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
 
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.glusterdir import mkdir
-from glustolibs.gluster.rebalance_ops import (
-    rebalance_start,
-    rebalance_stop,
-    wait_for_rebalance_to_complete
-)
-from glustolibs.gluster.volume_libs import expand_volume
-from glustolibs.gluster.volume_ops import set_volume_options
-from glustolibs.io.utils import run_linux_untar
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+    Performs reserve limit change, adds brick and checks
+    for reserve limit changes during rebalancing.
+"""
+
+from tests.nd_parent_test import NdParentTest
 
 
-@runs_on([['distributed-replicated'], ['glusterfs']])
-class TestReserveLimitChangeWhileRebalance(GlusterBaseClass):
+# nonDisruptive;dist-rep
+class TestCase(NdParentTest):
 
-    def _set_vol_option(self, option):
-        """Method for setting volume option"""
-        ret = set_volume_options(
-            self.mnode, self.volname, option)
-        self.assertTrue(ret)
-
-    @classmethod
-    def setUpClass(cls):
-        # Calling GlusterBaseClass setUpClass
-        cls.get_super_method(cls, 'setUpClass')()
-
-        # Set I/O flag to false
-        cls.is_io_running = False
-
-        # Setup Volume and Mount Volume
-        ret = cls.setup_volume_and_mount_volume(mounts=cls.mounts)
-        if not ret:
-            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
-
-    def tearDown(self):
-        if not wait_for_rebalance_to_complete(
-                self.mnode, self.volname, timeout=300):
-            raise ExecutionError(
-                "Failed to complete rebalance on volume '{}'".format(
-                    self.volname))
-
-        # Unmounting and cleaning volume
-        ret = self.unmount_volume_and_cleanup_volume([self.mounts[0]])
-        if not ret:
-            raise ExecutionError("Unable to delete volume % s" % self.volname)
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_reserve_limt_change_while_rebalance(self):
+    def run_test(self, redant):
         """
         1) Create a distributed-replicated volume and start it.
         2) Enable storage.reserve option on the volume using below command,
@@ -81,47 +44,44 @@ class TestReserveLimitChangeWhileRebalance(GlusterBaseClass):
         """
 
         # Setting storage.reserve 50
-        self._set_vol_option({"storage.reserve": "50"})
+        redant.set_volume_options(self.vol_name, {"storage.reserve": "50"},
+                                  self.server_list[0])
 
-        self.list_of_io_processes = []
         # Create a dir to start untar
-        self.linux_untar_dir = "{}/{}".format(self.mounts[0].mountpoint,
-                                              "linuxuntar")
-        ret = mkdir(self.clients[0], self.linux_untar_dir)
-        self.assertTrue(ret, "Failed to create dir linuxuntar for untar")
+        self.linux_untar_dir = f"{self.mountpoint}/linux_untar"
+        redant.execute_abstract_op_node("mkdir -p "
+                                        f"{self.linux_untar_dir}",
+                                        self.client_list[0])
 
-        # Start linux untar on dir linuxuntar
-        ret = run_linux_untar(self.clients[0], self.mounts[0].mountpoint,
-                              dirs=tuple(['linuxuntar']))
-        self.list_of_io_processes += ret
-        self.is_io_running = True
+        # Start linux untar on dir linux_untar
+        redant.run_linux_untar(self.clients[0], self.mountpoint,
+                               dirs=tuple(['linux_untar']))
 
         # Add bricks to the volume
-        ret = expand_volume(self.mnode, self.volname, self.servers,
-                            self.all_servers_info)
-        self.assertTrue(ret, "Failed to add brick with rsync on volume %s"
-                        % self.volname)
+        mul_factor = 1
+        _, br_cmd = redant.form_brick_cmd(self.server_list,
+                                          self.brick_roots,
+                                          self.vol_name, mul_factor, True)
+        redant.add_brick(self.vol_name, br_cmd,
+                         self.server_list[0])
 
         # Trigger rebalance on the volume
-        ret, _, _ = rebalance_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
-                         % self.volname)
+        redant.rebalance_start(self.vol_name, self.server_list[0])
 
         # Setting storage.reserve 30
-        self._set_vol_option({"storage.reserve": "30"})
+        redant.set_volume_options(self.vol_name, {"storage.reserve": "30"},
+                                  self.server_list[0])
 
         # Stopping Rebalance
-        ret, _, _ = rebalance_stop(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to stop rebalance on the volume %s"
-                         % self.volname)
+        redant.rebalance_stop(self.vol_name, self.server_list[0])
 
         # Setting storage.reserve 500
-        self._set_vol_option({"storage.reserve": "500"})
+        redant.set_volume_options(self.vol_name, {"storage.reserve": "500"},
+                                  self.server_list[0])
 
         # Trigger rebalance on the volume
-        ret, _, _ = rebalance_start(self.mnode, self.volname)
-        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
-                         % self.volname)
+        redant.rebalance_start(self.vol_name, self.server_list[0])
 
         # Setting storage.reserve 70
-        self._set_vol_option({"storage.reserve": "70"})
+        redant.set_volume_options(self.vol_name, {"storage.reserve": "70"},
+                                  self.server_list[0])

--- a/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
+++ b/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
@@ -1,0 +1,127 @@
+#  Copyright (C) 2020  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.glusterdir import mkdir
+from glustolibs.gluster.rebalance_ops import (
+    rebalance_start,
+    rebalance_stop,
+    wait_for_rebalance_to_complete
+)
+from glustolibs.gluster.volume_libs import expand_volume
+from glustolibs.gluster.volume_ops import set_volume_options
+from glustolibs.io.utils import run_linux_untar
+
+
+@runs_on([['distributed-replicated'], ['glusterfs']])
+class TestReserveLimitChangeWhileRebalance(GlusterBaseClass):
+
+    def _set_vol_option(self, option):
+        """Method for setting volume option"""
+        ret = set_volume_options(
+            self.mnode, self.volname, option)
+        self.assertTrue(ret)
+
+    @classmethod
+    def setUpClass(cls):
+        # Calling GlusterBaseClass setUpClass
+        cls.get_super_method(cls, 'setUpClass')()
+
+        # Set I/O flag to false
+        cls.is_io_running = False
+
+        # Setup Volume and Mount Volume
+        ret = cls.setup_volume_and_mount_volume(mounts=cls.mounts)
+        if not ret:
+            raise ExecutionError("Failed to Setup_Volume and Mount_Volume")
+
+    def tearDown(self):
+        if not wait_for_rebalance_to_complete(
+                self.mnode, self.volname, timeout=300):
+            raise ExecutionError(
+                "Failed to complete rebalance on volume '{}'".format(
+                    self.volname))
+
+        # Unmounting and cleaning volume
+        ret = self.unmount_volume_and_cleanup_volume([self.mounts[0]])
+        if not ret:
+            raise ExecutionError("Unable to delete volume % s" % self.volname)
+
+        self.get_super_method(self, 'tearDown')()
+
+    def test_reserve_limt_change_while_rebalance(self):
+        """
+        1) Create a distributed-replicated volume and start it.
+        2) Enable storage.reserve option on the volume using below command,
+           gluster volume set storage.reserve 50
+        3) Mount the volume on a client
+        4) Add some data on the mount point (should be within reserve limits)
+        5) Now, add-brick and trigger rebalance.
+           While rebalance is in-progress change the reserve limit to a lower
+           value say (30)
+        6. Stop the rebalance
+        7. Reset the storage reserve value to 50 as in step 2
+        8. trigger rebalance
+        9. while rebalance in-progress change the reserve limit to a higher
+         value say (70)
+        """
+
+        # Setting storage.reserve 50
+        self._set_vol_option({"storage.reserve": "50"})
+
+        self.list_of_io_processes = []
+        # Create a dir to start untar
+        self.linux_untar_dir = "{}/{}".format(self.mounts[0].mountpoint,
+                                              "linuxuntar")
+        ret = mkdir(self.clients[0], self.linux_untar_dir)
+        self.assertTrue(ret, "Failed to create dir linuxuntar for untar")
+
+        # Start linux untar on dir linuxuntar
+        ret = run_linux_untar(self.clients[0], self.mounts[0].mountpoint,
+                              dirs=tuple(['linuxuntar']))
+        self.list_of_io_processes += ret
+        self.is_io_running = True
+
+        # Add bricks to the volume
+        ret = expand_volume(self.mnode, self.volname, self.servers,
+                            self.all_servers_info)
+        self.assertTrue(ret, "Failed to add brick with rsync on volume %s"
+                        % self.volname)
+
+        # Trigger rebalance on the volume
+        ret, _, _ = rebalance_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
+                         % self.volname)
+
+        # Setting storage.reserve 30
+        self._set_vol_option({"storage.reserve": "30"})
+
+        # Stopping Rebalance
+        ret, _, _ = rebalance_stop(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to stop rebalance on the volume %s"
+                         % self.volname)
+
+        # Setting storage.reserve 500
+        self._set_vol_option({"storage.reserve": "500"})
+
+        # Trigger rebalance on the volume
+        ret, _, _ = rebalance_start(self.mnode, self.volname)
+        self.assertEqual(ret, 0, "Failed to start rebalance on the volume %s"
+                         % self.volname)
+
+        # Setting storage.reserve 70
+        self._set_vol_option({"storage.reserve": "70"})

--- a/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
+++ b/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
@@ -20,11 +20,24 @@
     for reserve limit changes during rebalancing.
 """
 
+import traceback
 from tests.nd_parent_test import NdParentTest
 
 
 # nonDisruptive;dist-rep
 class TestCase(NdParentTest):
+
+    def terminate(self):
+        try:
+            ret = self.redant.wait_for_rebalance_to_complete(
+                                        self.vol_name, self.server_list[0])
+            if not ret:
+                raise Exception("Rebalance not completed. Wait timeout")
+        except Exception as error:
+            tb = traceback.format_exc()
+            self.redant.logger.error(error)
+            self.redant.logger.error(tb)
+        super().terminate()
 
     def run_test(self, redant):
         """

--- a/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
+++ b/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
@@ -29,8 +29,9 @@ class TestCase(NdParentTest):
 
     def terminate(self):
         try:
-            ret = self.redant.wait_for_rebalance_to_complete(
-                                        self.vol_name, self.server_list[0])
+            ret = (self.redant.
+                   wait_for_rebalance_to_complete(self.vol_name,
+                                                  self.server_list[0]))
             if not ret:
                 raise Exception("Rebalance not completed. Wait timeout")
         except Exception as error:
@@ -41,6 +42,7 @@ class TestCase(NdParentTest):
 
     def run_test(self, redant):
         """
+        Steps:
         1) Create a distributed-replicated volume and start it.
         2) Enable storage.reserve option on the volume using below command,
            gluster volume set storage.reserve 50
@@ -53,7 +55,7 @@ class TestCase(NdParentTest):
         7. Reset the storage reserve value to 50 as in step 2
         8. trigger rebalance
         9. while rebalance in-progress change the reserve limit to a higher
-         value say (70)
+           value say (70)
         """
 
         # Setting storage.reserve 50
@@ -67,7 +69,7 @@ class TestCase(NdParentTest):
                                         self.client_list[0])
 
         # Start linux untar on dir linux_untar
-        redant.run_linux_untar(self.clients[0], self.mountpoint,
+        redant.run_linux_untar(self.client_list[0], self.mountpoint,
                                dirs=tuple(['linux_untar']))
 
         # Add bricks to the volume

--- a/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
+++ b/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py
@@ -21,11 +21,11 @@
 """
 
 import traceback
-from tests.nd_parent_test import NdParentTest
+from tests.d_parent_test import DParentTest
 
 
-# nonDisruptive;dist-rep
-class TestCase(NdParentTest):
+# disruptive;dist-rep
+class TestCase(DParentTest):
 
     def terminate(self):
         try:
@@ -73,12 +73,12 @@ class TestCase(NdParentTest):
                                dirs=tuple(['linux_untar']))
 
         # Add bricks to the volume
-        mul_factor = 1
+        mul_factor = 3
         _, br_cmd = redant.form_brick_cmd(self.server_list,
                                           self.brick_roots,
                                           self.vol_name, mul_factor, True)
-        redant.add_brick(self.vol_name, br_cmd,
-                         self.server_list[0])
+        redant.add_brick(self.vol_name, br_cmd, self.server_list[0],
+                         replica_count=3)
 
         # Trigger rebalance on the volume
         redant.rebalance_start(self.vol_name, self.server_list[0])


### PR DESCRIPTION
Migrating [test_reserve_limt_change_while_rebalance.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_reserve_limt_change_while_rebalance.py) from glusto to redant.             
                                                                               
Updates: #292:                                                                  
Fixes: #585                                                                                                            
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com> 