### PR TITLE
[TestFix] Fixing test_probe_hostname

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -25,6 +25,7 @@ volume_types:
         dist_count: 4
         transport: tcp
     replicated:
+        dist_count: 1
         replica_count: 3
         transport: tcp
     distributed-replicated:
@@ -52,6 +53,6 @@ volume_types:
         
 #excluded_tests - Tests which are excluded during the test run.
 excluded_tests:
-    - tests/functional/glusterd/test_peer_hostname.py
     - tests/functional/glusterd/test_quorum_syslog.py
     - tests/functional/glusterd/test_volume_set_when_glusterd_stopped_on_one_node.py
+    - tests/functional/glusterd/test_gluster_volume_status_xml_dump.py

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -29,6 +29,15 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    def terminate(self):
+        """
+        Performing hard terminate to solve the peer issues.
+        As the test plays around with IP and hostname, that might
+        cause issues later in subsequent cases.
+        """
+        self.redant.hard_terminate(self.server_list, self.client_list,
+                                   self.brick_roots)
+
     def _vol_operations(self, redant, volname: str):
         """
         This function performs a


### PR DESCRIPTION
Added the terminate function to perform
a hard termiate so as to prevent the probe
issues coming up later because of the hostname
and IP issue.

Fixes: #601

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
