### PR TITLE
Migrating test_add_identical_brick_new_node.py

### DIFF
--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -115,8 +115,14 @@ class TestAddIdenticalBrick(GlusterBaseClass):
 
         # Replace just host IP to create identical brick
         add_bricks = []
-        add_bricks.append(string.replace(bricks_list[0],
-                                         self.servers[0], self.servers[1]))
+        try:
+            add_bricks.append(string.replace(bricks_list[0],
+                                             self.servers[0],
+                                             self.servers[1]))
+        except AttributeError:
+            add_bricks.append(str.replace(bricks_list[0],
+                                          self.servers[0],
+                                          self.servers[1]))
         ret, _, _ = add_brick(self.mnode, self.volname, add_bricks)
         self.assertEqual(ret, 0, "Failed to add the bricks to the volume")
         g.log.info("Successfully added bricks to volume %s", add_bricks[0])

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -19,12 +19,11 @@
     Add a new brick with identical name as the previous added
     brick on a new node and checking volume status.
 """
-import time
+
 from tests.d_parent_test import DParentTest
 
+
 # disruptive;
-
-
 class TestCase(DParentTest):
 
     def run_test(self, redant):
@@ -49,7 +48,8 @@ class TestCase(DParentTest):
 
         # Getting the bricks list to bring down a brick
         redant.logger.info("Get all the bricks of the volume")
-        bricks_list = redant.es.get_all_bricks_list(self.volume_name1)
+        bricks_list = redant.get_all_bricks(self.volume_name1,
+                                            self.server_list[0])
         if len(bricks_list) == 0:
             raise Exception(f"Failed to fetch bricks for {self.volume_name1}")
 
@@ -58,18 +58,16 @@ class TestCase(DParentTest):
         if not ret:
             raise Exception("Failed to bring down the bricks")
 
-        ret = redant.peer_probe(self.server_list[1], self.server_list[0])
-
-        # wait for some time before add-brick
-        time.sleep(2)
+        redant.peer_probe_servers(self.server_list[1], self.server_list[0],
+                                  True)
 
         _, brick_str = redant.form_brick_cmd([self.server_list[1]],
                                              self.brick_roots,
                                              self.volume_name1, 1)
 
         # adding identical brick on different node
-        ret = redant.add_brick(self.volume_name1, brick_str,
-                               self.server_list[0], True)
+        redant.add_brick(self.volume_name1, brick_str,
+                         self.server_list[0], True)
 
         redant.volume_start(self.volume_name1, self.server_list[0],
                             force=True)

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -1,0 +1,126 @@
+#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import string
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import (volume_create, volume_start,
+                                           get_volume_list, get_volume_status)
+from glustolibs.gluster.brick_libs import (get_all_bricks,
+                                           bring_bricks_offline)
+from glustolibs.gluster.volume_libs import (cleanup_volume)
+from glustolibs.gluster.peer_ops import (peer_probe, peer_detach,
+                                         peer_probe_servers,
+                                         nodes_from_pool_list)
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.brick_ops import add_brick
+from glustolibs.gluster.exceptions import ExecutionError
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class TestAddIdenticalBrick(GlusterBaseClass):
+
+    def setUp(self):
+
+        # Performing peer detach
+        for server in self.servers[1:]:
+            ret, _, _ = peer_detach(self.mnode, server)
+            if ret != 0:
+                raise ExecutionError("Peer detach failed")
+            g.log.info("Peer detach SUCCESSFUL.")
+        GlusterBaseClass.setUp.im_func(self)
+
+    def tearDown(self):
+        """
+        clean up all volumes and peer probe to form cluster
+        """
+        vol_list = get_volume_list(self.mnode)
+        if vol_list is not None:
+            for volume in vol_list:
+                ret = cleanup_volume(self.mnode, volume)
+                if not ret:
+                    raise ExecutionError("Failed to cleanup volume")
+                g.log.info("Volume deleted successfully : %s", volume)
+
+        # Peer probe detached servers
+        pool = nodes_from_pool_list(self.mnode)
+        for node in pool:
+            peer_detach(self.mnode, node)
+        ret = peer_probe_servers(self.mnode, self.servers)
+        if not ret:
+            raise ExecutionError("Failed to probe detached "
+                                 "servers %s" % self.servers)
+        g.log.info("Peer probe success for detached "
+                   "servers %s", self.servers)
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_add_identical_brick(self):
+        """
+        In this test case:
+        1. Create Dist Volume on Node 1
+        2. Down brick on Node 1
+        3. Peer Probe N2 from N1
+        4. Add identical brick on newly added node
+        5. Check volume status
+        """
+
+        # pylint: disable=too-many-statements
+        # Create a distributed volume on Node1
+        number_of_brick = 1
+        servers_info_from_single_node = {
+            self.servers[0]: self.all_servers_info[self.servers[0]]
+        }
+        self.volname = "testvol"
+        bricks_list = form_bricks_list(self.servers[0], self.volname,
+                                       number_of_brick, self.servers[0],
+                                       servers_info_from_single_node)
+        ret, _, _ = volume_create(self.servers[0], self.volname,
+                                  bricks_list, force=False)
+        self.assertEqual(ret, 0, "Volume create failed")
+        g.log.info("Volume %s created successfully", self.volname)
+
+        ret, _, _ = volume_start(self.servers[0], self.volname, True)
+        self.assertEqual(ret, 0, ("Failed to start the "
+                                  "volume %s", self.volname))
+        g.log.info("Get all the bricks of the volume")
+        bricks_list = get_all_bricks(self.mnode, self.volname)
+        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
+        g.log.info("Successfully got the list of bricks of volume")
+
+        ret = bring_bricks_offline(self.volname, bricks_list[0])
+        self.assertTrue(ret, "Failed to bring down the bricks")
+        g.log.info("Successfully brought the bricks down")
+
+        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
+        self.assertEqual(ret, 0, ("peer probe from %s to %s is failed",
+                                  self.servers[0], self.servers[1]))
+        g.log.info("peer probe is success from %s to "
+                   "%s", self.servers[0], self.servers[1])
+
+        # Replace just host IP to create identical brick
+        add_bricks = []
+        add_bricks.append(string.replace(bricks_list[0],
+                                         self.servers[0], self.servers[1]))
+        ret, _, _ = add_brick(self.mnode, self.volname, add_bricks)
+        self.assertEqual(ret, 0, "Failed to add the bricks to the volume")
+        g.log.info("Successfully added bricks to volume %s", add_bricks[0])
+
+        ret, _, _ = volume_start(self.mnode, self.volname, force=True)
+        self.assertEqual(ret, 0, "Volume start with force failed")
+
+        vol_status = get_volume_status(self.mnode, self.volname)
+        self.assertIsNotNone(vol_status, "Failed to get volume "
+                             "status for %s" % self.volname)

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -13,7 +13,7 @@
 #  You should have received a copy of the GNU General Public License along
 #  with this program; if not, write to the Free Software Foundation, Inc.,
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
+import time
 import string
 from glusto.core import Glusto as g
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
@@ -109,6 +109,9 @@ class TestAddIdenticalBrick(GlusterBaseClass):
                                   self.servers[0], self.servers[1]))
         g.log.info("peer probe is success from %s to "
                    "%s", self.servers[0], self.servers[1])
+
+        # wait for some time before add-brick
+        time.sleep(2)
 
         # Replace just host IP to create identical brick
         add_bricks = []

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -41,7 +41,7 @@ class TestAddIdenticalBrick(GlusterBaseClass):
             if ret != 0:
                 raise ExecutionError("Peer detach failed")
             g.log.info("Peer detach SUCCESSFUL.")
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
 
     def tearDown(self):
         """
@@ -65,7 +65,7 @@ class TestAddIdenticalBrick(GlusterBaseClass):
                                  "servers %s" % self.servers)
         g.log.info("Peer probe success for detached "
                    "servers %s", self.servers)
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_add_identical_brick(self):
         """

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -1,73 +1,33 @@
-#  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+  Copyright (C) 2018  Red Hat, Inc. <http://www.redhat.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+  Description:
+    Add a new brick with identical name as the previous added
+    brick on a new node and checking volume status.
+"""
 import time
-import string
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import (volume_create, volume_start,
-                                           get_volume_list, get_volume_status)
-from glustolibs.gluster.brick_libs import (get_all_bricks,
-                                           bring_bricks_offline)
-from glustolibs.gluster.volume_libs import (cleanup_volume)
-from glustolibs.gluster.peer_ops import (peer_probe, peer_detach,
-                                         peer_probe_servers,
-                                         nodes_from_pool_list)
-from glustolibs.gluster.lib_utils import form_bricks_list
-from glustolibs.gluster.brick_ops import add_brick
-from glustolibs.gluster.exceptions import ExecutionError
+from tests.d_parent_test import DParentTest
+
+# disruptive;
 
 
-@runs_on([['distributed'], ['glusterfs']])
-class TestAddIdenticalBrick(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    def setUp(self):
-
-        # Performing peer detach
-        for server in self.servers[1:]:
-            ret, _, _ = peer_detach(self.mnode, server)
-            if ret != 0:
-                raise ExecutionError("Peer detach failed")
-            g.log.info("Peer detach SUCCESSFUL.")
-        self.get_super_method(self, 'setUp')()
-
-    def tearDown(self):
-        """
-        clean up all volumes and peer probe to form cluster
-        """
-        vol_list = get_volume_list(self.mnode)
-        if vol_list is not None:
-            for volume in vol_list:
-                ret = cleanup_volume(self.mnode, volume)
-                if not ret:
-                    raise ExecutionError("Failed to cleanup volume")
-                g.log.info("Volume deleted successfully : %s", volume)
-
-        # Peer probe detached servers
-        pool = nodes_from_pool_list(self.mnode)
-        for node in pool:
-            peer_detach(self.mnode, node)
-        ret = peer_probe_servers(self.mnode, self.servers)
-        if not ret:
-            raise ExecutionError("Failed to probe detached "
-                                 "servers %s" % self.servers)
-        g.log.info("Peer probe success for detached "
-                   "servers %s", self.servers)
-        self.get_super_method(self, 'tearDown')()
-
-    def test_add_identical_brick(self):
+    def run_test(self, redant):
         """
         In this test case:
         1. Create Dist Volume on Node 1
@@ -77,59 +37,45 @@ class TestAddIdenticalBrick(GlusterBaseClass):
         5. Check volume status
         """
 
-        # pylint: disable=too-many-statements
+        redant.delete_cluster(self.server_list)
+
         # Create a distributed volume on Node1
-        number_of_brick = 1
-        servers_info_from_single_node = {
-            self.servers[0]: self.all_servers_info[self.servers[0]]
-        }
-        self.volname = "testvol"
-        bricks_list = form_bricks_list(self.servers[0], self.volname,
-                                       number_of_brick, self.servers[0],
-                                       servers_info_from_single_node)
-        ret, _, _ = volume_create(self.servers[0], self.volname,
-                                  bricks_list, force=False)
-        self.assertEqual(ret, 0, "Volume create failed")
-        g.log.info("Volume %s created successfully", self.volname)
+        self.volume_type1 = 'dist'
+        self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
+        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict['dist_count'] = 1
+        redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,
+                            [self.server_list[0]], self.brick_roots, True)
 
-        ret, _, _ = volume_start(self.servers[0], self.volname, True)
-        self.assertEqual(ret, 0, ("Failed to start the "
-                                  "volume %s", self.volname))
-        g.log.info("Get all the bricks of the volume")
-        bricks_list = get_all_bricks(self.mnode, self.volname)
-        self.assertIsNotNone(bricks_list, "Failed to get the brick list")
-        g.log.info("Successfully got the list of bricks of volume")
+        # Getting the bricks list to bring down a brick
+        redant.logger.info("Get all the bricks of the volume")
+        bricks_list = redant.es.get_all_bricks_list(self.volume_name1)
+        if len(bricks_list) == 0:
+            raise Exception(f"Failed to fetch bricks for {self.volume_name1}")
 
-        ret = bring_bricks_offline(self.volname, bricks_list[0])
-        self.assertTrue(ret, "Failed to bring down the bricks")
-        g.log.info("Successfully brought the bricks down")
+        # Bring the brick offline
+        ret = redant.bring_bricks_offline(self.volume_name1, bricks_list[0])
+        if not ret:
+            raise Exception("Failed to bring down the bricks")
 
-        ret, _, _ = peer_probe(self.servers[0], self.servers[1])
-        self.assertEqual(ret, 0, ("peer probe from %s to %s is failed",
-                                  self.servers[0], self.servers[1]))
-        g.log.info("peer probe is success from %s to "
-                   "%s", self.servers[0], self.servers[1])
+        ret = redant.peer_probe(self.server_list[1], self.server_list[0])
 
         # wait for some time before add-brick
         time.sleep(2)
 
-        # Replace just host IP to create identical brick
-        add_bricks = []
-        try:
-            add_bricks.append(string.replace(bricks_list[0],
-                                             self.servers[0],
-                                             self.servers[1]))
-        except AttributeError:
-            add_bricks.append(str.replace(bricks_list[0],
-                                          self.servers[0],
-                                          self.servers[1]))
-        ret, _, _ = add_brick(self.mnode, self.volname, add_bricks)
-        self.assertEqual(ret, 0, "Failed to add the bricks to the volume")
-        g.log.info("Successfully added bricks to volume %s", add_bricks[0])
+        _, brick_str = redant.form_brick_cmd([self.server_list[1]],
+                                             self.brick_roots,
+                                             self.volume_name1, 1)
 
-        ret, _, _ = volume_start(self.mnode, self.volname, force=True)
-        self.assertEqual(ret, 0, "Volume start with force failed")
+        # adding identical brick on different node
+        ret = redant.add_brick(self.volume_name1, brick_str,
+                               self.server_list[0], True)
 
-        vol_status = get_volume_status(self.mnode, self.volname)
-        self.assertIsNotNone(vol_status, "Failed to get volume "
-                             "status for %s" % self.volname)
+        redant.volume_start(self.volume_name1, self.server_list[0],
+                            force=True)
+
+        vol_status = redant.get_volume_status(self.volume_name1,
+                                              self.server_list[0])
+
+        if vol_status is None:
+            raise Exception("Volume status returned None")

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -47,10 +47,9 @@ class TestCase(DParentTest):
                             [self.server_list[0]], self.brick_roots, True)
 
         # Getting the bricks list to bring down a brick
-        redant.logger.info("Get all the bricks of the volume")
         bricks_list = redant.get_all_bricks(self.volume_name1,
                                             self.server_list[0])
-        if len(bricks_list) == 0:
+        if bricks_list is None:
             raise Exception(f"Failed to fetch bricks for {self.volume_name1}")
 
         # Bring the brick offline
@@ -58,8 +57,11 @@ class TestCase(DParentTest):
         if not ret:
             raise Exception("Failed to bring down the bricks")
 
-        redant.peer_probe_servers(self.server_list[1], self.server_list[0],
-                                  True)
+        ret = redant.peer_probe_servers(self.server_list[1],
+                                        self.server_list[0],
+                                        True)
+        if not ret:
+            raise Exception("Peer Probing servers failed")
 
         _, brick_str = redant.form_brick_cmd([self.server_list[1]],
                                              self.brick_roots,


### PR DESCRIPTION
Migrating [test_add_identical_brick_new_node.py](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_add_identical_brick_new_node.py) from glusto to redant
    
Updates: #292
Fixes: #598
Signed-off-by: Nishith Vihar Sakinala <nsakinal@redhat.com>