### PR TITLE
Migrated test_mountpoint_ownership_post_volume_restart

### DIFF
--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -239,7 +239,7 @@ class IoOps(AbstractOps):
         """Set permissions on a remote file.
 
         Args:
-            host (str): The hostname/ip of the remote system.
+            node (str): The node on which command has to execute
             fqpath (str): The fully-qualified path to the file.
             perms (str): A permissions string as passed to chmod.
 

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -235,6 +235,26 @@ class IoOps(AbstractOps):
         ret_val['file_perm'] = int(ret['msg'][0][:-1])
         return ret_val
 
+    def set_file_permissions(self, node: str, fqpath: str, perms: str):
+        """Set permissions on a remote file.
+
+        Args:
+            host (str): The hostname/ip of the remote system.
+            fqpath (str): The fully-qualified path to the file.
+            perms (str): A permissions string as passed to chmod.
+
+        Returns:
+            True on success. False on fail.
+        """
+        cmd = f"chmod {perms} {fqpath}"
+        ret = self.execute_abstract_op_node(cmd, node)
+
+        if ret['error_code'] == 0:
+            return True
+
+        self.logger.error(f"chmod failed: {ret['error_msg']}")
+        return False
+
     def check_core_file_exists(self, nodes: list, testrun_timestamp,
                                paths=['/', '/var/log/core',
                                       '/tmp', '/var/crash', '~/']):

--- a/common/ops/support_ops/io_ops.py
+++ b/common/ops/support_ops/io_ops.py
@@ -247,7 +247,7 @@ class IoOps(AbstractOps):
             True on success. False on fail.
         """
         cmd = f"chmod {perms} {fqpath}"
-        ret = self.execute_abstract_op_node(cmd, node)
+        ret = self.execute_abstract_op_node(cmd, node, False)
 
         if ret['error_code'] == 0:
             return True

--- a/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
+++ b/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
@@ -1,0 +1,109 @@
+#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" Description:
+      Test mount point ownership persistence post volume restart.
+"""
+
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.glusterfile import (
+    get_file_stat,
+    set_file_permissions)
+from glustolibs.gluster.volume_ops import (
+    volume_stop,
+    volume_start)
+from glustolibs.gluster.volume_libs import wait_for_volume_process_to_be_online
+
+
+@runs_on([['arbiter', 'distributed', 'replicated', 'distributed-replicated',
+           'dispersed', 'distributed-dispersed', 'distributed-arbiter'],
+          ['glusterfs']])
+class TestMountPointOwnershipPostVolumeRestart(GlusterBaseClass):
+    """ Test mount point ownership persistence post volume restart """
+
+    def setUp(self):
+        """Setup Volume"""
+        # Calling GlusterBaseClass setUp
+        self.get_super_method(self, 'setUp')()
+
+        # Setup and mount the volume
+        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to setup volume and mount it")
+        self.client = self.mounts[0].client_system
+        self.mountpoint = self.mounts[0].mountpoint
+
+    def validate_mount_permissions(self):
+        """
+        Verify the mount permissions
+        """
+        stat_mountpoint_dict = get_file_stat(self.client,
+                                             self.mounts[0].mountpoint)
+        self.assertEqual(stat_mountpoint_dict['access'], '777', "Expected 777 "
+                         " but found %s" % stat_mountpoint_dict['access'])
+        g.log.info("Mountpoint permissions is 777, as expected.")
+
+    def test_mountpoint_ownsership_post_volume_restart(self):
+        """
+        Test mountpoint ownership post volume restart
+        1. Create a volume and mount it on client.
+        2. set ownsership permissions and validate it.
+        3. Restart volume.
+        4. Ownership permissions should persist.
+        """
+        # Set full permissions on the mountpoint.
+        ret = set_file_permissions(self.clients[0], self.mountpoint,
+                                   "-R 777")
+        self.assertTrue(ret, "Failed to set permissions on the mountpoint")
+        g.log.info("Set full permissions on the mountpoint.")
+
+        # Validate the permissions set.
+        self.validate_mount_permissions()
+
+        # Stop the volume.
+        ret = volume_stop(self.mnode, self.volname)
+        self.assertTrue(ret, ("Failed to stop volume %s" % self.volname))
+        g.log.info("Successful in stopping volume.")
+
+        # Start the volume.
+        ret = volume_start(self.mnode, self.volname)
+        self.assertTrue(ret, ("Failed to start volume %s" % self.volname))
+        g.log.info("Successful in starting volume.")
+
+        # Wait for all volume processes to be up and running.
+        ret = wait_for_volume_process_to_be_online(self.mnode, self.volname)
+        self.assertTrue(ret, ("All volume processes are not up"))
+        g.log.info("All volume processes are up and running.")
+
+        # Adding sleep for the mount to be recognized by client.
+        sleep(3)
+
+        # validate the mountpoint permissions.
+        self.validate_mount_permissions()
+
+    def tearDown(self):
+        """tearDown callback"""
+        # Unmount volume and cleanup.
+        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
+        if not ret:
+            raise ExecutionError("Failed to unmount and cleanup volume")
+        g.log.info("Successful in unmount and cleanup of volume")
+
+        # Calling GlusterBaseClass tearDown
+        self.get_super_method(self, 'tearDown')()

--- a/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
+++ b/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
@@ -21,7 +21,6 @@ Description:
 
 # nonDisruptive;dist,rep,dist-rep,disp,dist-disp,dist-arb
 
-from time import sleep
 from tests.nd_parent_test import NdParentTest
 
 
@@ -68,8 +67,6 @@ class TestCase(NdParentTest):
                                                      self.server_list[0],
                                                      self.server_list)):
             raise Exception("All volume processes are not up")
-        # Adding sleep for the mount to be recognized by client.
-        sleep(3)
 
         # validate the mountpoint permissions.
         self._validate_mount_permissions()

--- a/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
+++ b/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
@@ -1,65 +1,45 @@
-#  Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2020 Red Hat, Inc. <http://www.redhat.com>
 
-""" Description:
-      Test mount point ownership persistence post volume restart.
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+    Test mount point ownership persistence post volume restart.
 """
 
+# nonDisruptive;dist,rep,dist-rep,disp,dist-disp,dist-arb
+
 from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.glusterfile import (
-    get_file_stat,
-    set_file_permissions)
-from glustolibs.gluster.volume_ops import (
-    volume_stop,
-    volume_start)
-from glustolibs.gluster.volume_libs import wait_for_volume_process_to_be_online
+from tests.nd_parent_test import NdParentTest
 
 
-@runs_on([['arbiter', 'distributed', 'replicated', 'distributed-replicated',
-           'dispersed', 'distributed-dispersed', 'distributed-arbiter'],
-          ['glusterfs']])
-class TestMountPointOwnershipPostVolumeRestart(GlusterBaseClass):
-    """ Test mount point ownership persistence post volume restart """
+class TestCase(NdParentTest):
 
-    def setUp(self):
-        """Setup Volume"""
-        # Calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-
-        # Setup and mount the volume
-        ret = self.setup_volume_and_mount_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to setup volume and mount it")
-        self.client = self.mounts[0].client_system
-        self.mountpoint = self.mounts[0].mountpoint
-
-    def validate_mount_permissions(self):
+    def _validate_mount_permissions(self):
         """
         Verify the mount permissions
         """
-        stat_mountpoint_dict = get_file_stat(self.client,
-                                             self.mounts[0].mountpoint)
-        self.assertEqual(stat_mountpoint_dict['access'], '777', "Expected 777 "
-                         " but found %s" % stat_mountpoint_dict['access'])
-        g.log.info("Mountpoint permissions is 777, as expected.")
+        stat_mountpoint_dict = (self.redant.
+                                get_file_permission(self.client_list[0],
+                                                    self.mountpoint))
 
-    def test_mountpoint_ownsership_post_volume_restart(self):
+        if stat_mountpoint_dict['file_perm'] != 777:
+            raise Exception(f"Expected 777 but found "
+                            f"{stat_mountpoint_dict['file_perm']}")
+
+    def run_test(self, redant):
         """
         Test mountpoint ownership post volume restart
         1. Create a volume and mount it on client.
@@ -68,42 +48,28 @@ class TestMountPointOwnershipPostVolumeRestart(GlusterBaseClass):
         4. Ownership permissions should persist.
         """
         # Set full permissions on the mountpoint.
-        ret = set_file_permissions(self.clients[0], self.mountpoint,
-                                   "-R 777")
-        self.assertTrue(ret, "Failed to set permissions on the mountpoint")
-        g.log.info("Set full permissions on the mountpoint.")
+        ret = redant.set_file_permissions(self.client_list[0], self.mountpoint,
+                                          "-R 777")
+        if not ret:
+            raise Exception("Failed to set permissions on the mountpoint")
 
-        # Validate the permissions set.
-        self.validate_mount_permissions()
+        # # Validate the permissions set.
+        self._validate_mount_permissions()
 
         # Stop the volume.
-        ret = volume_stop(self.mnode, self.volname)
-        self.assertTrue(ret, ("Failed to stop volume %s" % self.volname))
-        g.log.info("Successful in stopping volume.")
+        redant.volume_stop(self.vol_name, self.server_list[0])
 
         # Start the volume.
-        ret = volume_start(self.mnode, self.volname)
-        self.assertTrue(ret, ("Failed to start volume %s" % self.volname))
-        g.log.info("Successful in starting volume.")
+        redant.volume_start(self.vol_name, self.server_list[0])
 
         # Wait for all volume processes to be up and running.
-        ret = wait_for_volume_process_to_be_online(self.mnode, self.volname)
-        self.assertTrue(ret, ("All volume processes are not up"))
-        g.log.info("All volume processes are up and running.")
-
+        if not (redant.
+                wait_for_volume_process_to_be_online(self.vol_name,
+                                                     self.server_list[0],
+                                                     self.server_list)):
+            raise Exception("All volume processes are not up")
         # Adding sleep for the mount to be recognized by client.
         sleep(3)
 
         # validate the mountpoint permissions.
-        self.validate_mount_permissions()
-
-    def tearDown(self):
-        """tearDown callback"""
-        # Unmount volume and cleanup.
-        ret = self.unmount_volume_and_cleanup_volume(mounts=self.mounts)
-        if not ret:
-            raise ExecutionError("Failed to unmount and cleanup volume")
-        g.log.info("Successful in unmount and cleanup of volume")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+        self._validate_mount_permissions()


### PR DESCRIPTION

Migrated the [test
case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py)

Updates: #292

Fixes: #581

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>