### PR TITLE
Fixed condition in test_volume_status_with_absent_bricks

### DIFF
--- a/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
+++ b/tests/functional/glusterd/test_volume_status_with_absent_bricks.py
@@ -52,14 +52,14 @@ class TestCase(DParentTest):
         err_msg = 'Failed to find brick directory'
         ret = redant.volume_start(self.vol_name, self.server_list[0],
                                   excep=False)
-        if ret['error_code'] != 0 and err_msg not in ret['msg']['opErrstr']:
+        if ret['msg']['opRet'] != 0 and err_msg not in ret['msg']['opErrstr']:
             raise Exception("Unexpected:Volume started successfully"
                             " even though brick is deleted.")
 
         # Checking volume status
         ret = redant.get_volume_status(self.vol_name, self.server_list[0],
                                        excep=False)
-        if ret['error_code'] != 0 and ret['msg']['opErrstr'] !=\
+        if ret['msg']['opRet'] != 0 and ret['msg']['opErrstr'] !=\
            f'Volume {self.vol_name} is not started':
             raise Exception("Incorrect error message for gluster vol "
                             "status")


### PR DESCRIPTION
Fixed the condition. Replaced `error_code` with `['msg']['opRet']`.

Fixes: #608

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
