### PR TITLE
Added shared storage ops and migrate a TC

### DIFF
--- a/common/mixin.py
+++ b/common/mixin.py
@@ -15,11 +15,12 @@ from .ops.gluster_ops.profile_ops import ProfileOps
 from .ops.gluster_ops.rebalance_ops import RebalanceOps
 from .ops.gluster_ops.mount_ops import MountOps
 from .ops.gluster_ops.heal_ops import HealOps
+from .ops.gluster_ops.shared_storage_ops import SharedStorageOps
 
 
 class RedantMixin(GlusterOps, VolumeOps, BrickOps, PeerOps,
                   IoOps, MachineOps, MountOps, ProfileOps, RebalanceOps,
-                  HealOps, Rexe, Logger):
+                  HealOps, SharedStorageOps, Rexe, Logger):
     """
     A mixin class for redant project to encompass all ops, support
     modules and encapsulates the object responsible for the framework

--- a/common/ops/gluster_ops/shared_storage_ops.py
+++ b/common/ops/gluster_ops/shared_storage_ops.py
@@ -56,18 +56,19 @@ class SharedStorageOps(AbstractOps):
 
         return True
 
-    def is_shared_volume_mounted(self, node: str) -> bool:
+    def is_shared_volume_mounted(self, node: str, timeout: int = 20) -> bool:
         """
         Checks if shared storage volume is mounted
 
         Args:
             node (str) : Node on which command is to be executed
+        Optional:
+            timeout(int) : Maximum time allowed to check for shared volume
 
         Returns:
             bool : True if successfully disabled shared storage.
                    False otherwise.
         """
-        timeout = 20
         counter = 0
         path = "/run/gluster/shared_storage"
         while counter < timeout:
@@ -83,20 +84,22 @@ class SharedStorageOps(AbstractOps):
         return False
 
     def check_gluster_shared_volume(self, node: str,
-                                    present: bool = True) -> bool:
+                                    present: bool = True,
+                                    timeout: int = 20) -> bool:
         """
         Check gluster shared volume present or absent.
 
         Args:
             node (str) : Node on which command is to be executed
+        Optional:
             present (bool) : True if you want to check presence
                              False if you want to check absence.
+            timeout(int) : Maximum time allowed to check for shared volume
 
         Returns:
             bool : True if successfully disabled shared storage.
                    False otherwise.
         """
-        timeout = 20
         counter = 0
         self.logger.info("Waiting for shared storage to be"
                          " created/deleted")

--- a/common/ops/gluster_ops/shared_storage_ops.py
+++ b/common/ops/gluster_ops/shared_storage_ops.py
@@ -1,0 +1,124 @@
+"""
+Shared storage ops module deals with the functions related to shared storage
+operations.
+"""
+
+from time import sleep
+from common.ops.abstract_ops import AbstractOps
+
+
+class SharedStorageOps(AbstractOps):
+    """
+    Class which is responsible for methods for shared storage related
+    operations.
+    """
+    def enable_shared_storage(self, node: str) -> bool:
+        """
+        Enables the shared storage
+
+        Args:
+            node (str) : Node on which command is to be executed
+
+        Returns:
+            bool : True if successfully enabled shared storage.
+                   False otherwise.
+        """
+        option = {"cluster.enable-shared-storage": "enable"}
+
+        try:
+            self.redant.set_volume_options("all", option, node)
+
+        except Exception as error:
+            self.logger.error(f"Failed to enable shared storage: {error}")
+            return False
+
+        return True
+
+    def enable_shared_storage(self, node: str) -> bool:
+        """
+        Disable the shared storage
+
+        Args:
+            node (str) : Node on which command is to be executed
+
+        Returns:
+            bool : True if successfully disabled shared storage.
+                   False otherwise.
+        """
+        option = {"cluster.enable-shared-storage": "disable"}
+
+        try:
+            self.redant.set_volume_options("all", option, node)
+
+        except Exception as error:
+            self.logger.error(f"Failed to disable shared storage: {error}")
+            return False
+
+        return True
+
+    def is_shared_volume_mounted(self, node: str) -> bool:
+        """
+        Checks if shared storage volume is mounted
+
+        Args:
+            node (str) : Node on which command is to be executed
+
+        Returns:
+            bool : True if successfully disabled shared storage.
+                   False otherwise.
+        """
+        timeout = 20
+        counter = 0
+        path = "/run/gluster/shared_storage"
+        while counter < timeout:
+            ret = self.execute_abstract_op_node(path, node, False)
+            if ret['error_code'] == 0:
+                if path in ret['msg'][0].rstrip('\n'):
+                    self.logger.info("Shared storage is mounted")
+                    return True
+            else:
+                sleep(2)
+                counter += 2
+
+        self.logger.info("Shared storage not mounted")
+        return False
+
+    def check_gluster_shared_volume(self, node: str,
+                                    present: bool = True) -> bool:
+        """
+        Check gluster shared volume present or absent.
+
+        Args:
+            node (str) : Node on which command is to be executed
+            present (bool) : True if you want to check presence
+                             False if you want to check absence.
+
+        Returns:
+            bool : True if successfully disabled shared storage.
+                   False otherwise.
+        """
+        timeout = 20
+        counter = 0
+        self.logger.info("Waiting for shared storage to be"
+                         "created/deleted")
+
+        while counter < timeout:
+            vol_list = self.get_volume_list(node)
+            if vol_list is None:
+                self.logger.error("Failed to get vol list")
+                return False
+            if present and "gluster_shared_storage" in vol_list:
+                return True
+            elif (not present
+                  and "gluster_shared_storage" not in vol_list):
+                return True
+            else:
+                sleep(2)
+                counter += 2
+
+        if present:
+            self.logger.info("Shared storage volume is not created")
+        else:
+            self.logger.info("Shared storage volume is not deleted")
+
+        return False

--- a/common/ops/gluster_ops/shared_storage_ops.py
+++ b/common/ops/gluster_ops/shared_storage_ops.py
@@ -26,7 +26,7 @@ class SharedStorageOps(AbstractOps):
         option = {"cluster.enable-shared-storage": "enable"}
 
         try:
-            self.redant.set_volume_options("all", option, node)
+            self.set_volume_options("all", option, node)
 
         except Exception as error:
             self.logger.error(f"Failed to enable shared storage: {error}")
@@ -34,7 +34,7 @@ class SharedStorageOps(AbstractOps):
 
         return True
 
-    def enable_shared_storage(self, node: str) -> bool:
+    def disable_shared_storage(self, node: str) -> bool:
         """
         Disable the shared storage
 
@@ -48,7 +48,7 @@ class SharedStorageOps(AbstractOps):
         option = {"cluster.enable-shared-storage": "disable"}
 
         try:
-            self.redant.set_volume_options("all", option, node)
+            self.set_volume_options("all", option, node)
 
         except Exception as error:
             self.logger.error(f"Failed to disable shared storage: {error}")
@@ -71,14 +71,13 @@ class SharedStorageOps(AbstractOps):
         counter = 0
         path = "/run/gluster/shared_storage"
         while counter < timeout:
-            ret = self.execute_abstract_op_node(path, node, False)
-            if ret['error_code'] == 0:
-                if path in ret['msg'][0].rstrip('\n'):
-                    self.logger.info("Shared storage is mounted")
-                    return True
-            else:
-                sleep(2)
-                counter += 2
+            ret = self.execute_abstract_op_node("df -h", node, False)
+            if path in " ".join(ret['msg']):
+                self.logger.info("Shared storage is mounted")
+                return True
+
+            sleep(2)
+            counter += 2
 
         self.logger.info("Shared storage not mounted")
         return False
@@ -100,7 +99,7 @@ class SharedStorageOps(AbstractOps):
         timeout = 20
         counter = 0
         self.logger.info("Waiting for shared storage to be"
-                         "created/deleted")
+                         " created/deleted")
 
         while counter < timeout:
             vol_list = self.get_volume_list(node)

--- a/tests/functional/glusterd/test_glusterd_split_brain.py
+++ b/tests/functional/glusterd/test_glusterd_split_brain.py
@@ -43,11 +43,9 @@ class TestCase(DParentTest):
 
         # Create a dist-rep volume using first 4 nodes
         conf_hash = {
-            "distributed-replicated": {
-                "dist_count": 2,
-                "replica_count": 3,
-                "transport": "tcp"
-            }
+            "dist_count": 2,
+            "replica_count": 3,
+            "transport": "tcp"
         }
         self.volname = f"{self.test_name}-{self.volume_type}"
         redant.setup_volume(self.volname, self.server_list[0],

--- a/tests/functional/glusterd/test_shared_storage.py
+++ b/tests/functional/glusterd/test_shared_storage.py
@@ -1,0 +1,192 @@
+#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+    Description:
+    Test cases in this module related glusterd enabling and
+    disabling shared storage
+"""
+
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
+from glustolibs.gluster.volume_ops import (volume_create,
+                                           volume_delete, get_volume_list)
+from glustolibs.gluster.volume_libs import cleanup_volume
+from glustolibs.gluster.lib_utils import form_bricks_list
+from glustolibs.gluster.shared_storage_ops import (enable_shared_storage,
+                                                   is_shared_volume_mounted,
+                                                   disable_shared_storage,
+                                                   check_gluster_shared_volume)
+from glustolibs.gluster.exceptions import ExecutionError
+
+
+@runs_on([['distributed'], ['glusterfs']])
+class SharedStorage(GlusterBaseClass):
+
+    def setUp(self):
+        # calling GlusterBaseClass setUp
+        GlusterBaseClass.setUp.im_func(self)
+        # Creating Volume
+        g.log.info("Started creating volume")
+        ret = self.setup_volume()
+        if not ret:
+            raise ExecutionError("Volume creation failed")
+        g.log.info("Volume created successfully : %s", self.volname)
+
+    def tearDown(self):
+        # Stopping and cleaning up the volume
+        vol_list = get_volume_list(self.mnode)
+        if vol_list is None:
+            raise ExecutionError("Failed to get volume list")
+
+        for volume in vol_list:
+            ret = cleanup_volume(self.mnode, volume)
+            if not ret:
+                raise ExecutionError("Failed Cleanup the Volume")
+            g.log.info("Volume deleted successfully : %s", volume)
+
+        # Calling GlusterBaseClass tearDown
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_shared_storage(self):
+        """This test case includes:
+        -> Enable a shared storage
+        -> Disable a shared storage
+        -> Create volume of any type with
+           name gluster_shared_storage
+        -> Disable the shared storage
+        -> Check, volume created in step-3 is
+           not deleted
+        -> Delete the volume
+        -> Enable the shared storage
+        -> Check volume with name gluster_shared_storage
+           is created
+        -> Disable the shared storage
+        """
+        # pylint: disable=too-many-statements, too-many-branches
+        # Enable a shared storage without specifying the domain
+        ret = enable_shared_storage(self.mnode)
+        self.assertTrue(ret, ("Failed to enable a shared storage"))
+        g.log.info("Successfully enabled: enable-shared-storage option")
+
+        # Check volume list to confirm gluster_shared_storage is created
+        ret = check_gluster_shared_volume(self.mnode)
+        self.assertTrue(ret, ("gluster_shared_storage volume not"
+                              " created even after enabling it"))
+        g.log.info("gluster_shared_storage volume created"
+                   " successfully")
+
+        # Check the shared volume got mounted
+        ret = is_shared_volume_mounted(self.mnode)
+        self.assertTrue(ret, ("Shared volume not mounted even"
+                              " after enabling it"))
+        g.log.info("Shared volume mounted successfully")
+
+        # Disable a shared storage without specifying the domain
+        ret = disable_shared_storage(self.mnode)
+        self.assertTrue(ret, ("Failed to disable a shared storage"))
+        g.log.info("Successfully disabled: disable-shared-storage")
+
+        # Check volume list to confirm gluster_shared_storage is deleted
+        ret = check_gluster_shared_volume(self.mnode, present=False)
+        self.assertTrue(ret, ("gluster_shared_storage volume not"
+                              " deleted even after disabling it"))
+        g.log.info("gluster_shared_storage volume deleted"
+                   " successfully")
+
+        # Check the shared volume unmounted
+        ret = is_shared_volume_mounted(self.mnode)
+        self.assertFalse(ret, ("Shared volume not unmounted even"
+                               " after disabling it"))
+        g.log.info("Shared volume unmounted successfully")
+
+        # Create a volume with name gluster_shared_storage
+        g.log.info("creation of volume should succeed")
+        volume = "gluster_shared_storage"
+        bricks_list = form_bricks_list(self.mnode, volume,
+                                       2, self.servers,
+                                       self.all_servers_info)
+        count = 0
+        while count < 20:
+            ret, _, _ = volume_create(self.mnode, volume, bricks_list, True)
+            if not ret:
+                break
+            sleep(2)
+            count += 1
+        self.assertEqual(ret, 0, "Failed to create volume")
+        g.log.info("Volume create is success")
+
+        # Disable the shared storage should fail
+        ret = disable_shared_storage(self.mnode)
+        self.assertFalse(ret, ("Unexpected: Successfully disabled"
+                               " shared-storage"))
+        g.log.info("Volume set: failed as expected")
+
+        # Check volume list to confirm gluster_shared_storage
+        # is not deleted which was created before
+        vol_list = get_volume_list(self.mnode)
+        _rc = False
+        for vol in vol_list:
+            if vol == "gluster_shared_storage":
+                _rc = True
+                break
+        self.assertTrue(_rc, ("gluster_shared_storage volume got"
+                              " deleted after disabling it"))
+        g.log.info("gluster_shared_storage volume not deleted as "
+                   " expected after disabling enable-shared-storage")
+
+        # Delete the volume created
+        ret = volume_delete(self.mnode, volume)
+        self.assertTrue(ret, ("Failed to cleanup the Volume "
+                              "%s", volume))
+        g.log.info("Volume deleted successfully : %s", volume)
+
+        # Enable the shared storage
+        ret = enable_shared_storage(self.mnode)
+        self.assertTrue(ret, ("Failed to enable a shared storage"))
+        g.log.info("Successfully enabled: enable-shared-storage option")
+
+        # Check volume list to confirm gluster_shared_storage is created
+        ret = check_gluster_shared_volume(self.mnode)
+        self.assertTrue(ret, ("gluster_shared_storage volume not"
+                              " created even after enabling it"))
+        g.log.info("gluster_shared_storage volume created"
+                   " successfully")
+
+        # Check the shared volume got mounted
+        ret = is_shared_volume_mounted(self.mnode)
+        self.assertTrue(ret, ("Shared volume not mounted even"
+                              " after enabling it"))
+        g.log.info("Shared volume mounted successfully")
+
+        # Disable a shared storage
+        ret = disable_shared_storage(self.mnode)
+        self.assertTrue(ret, ("Failed to disable a shared storage"))
+        g.log.info("Successfully disabled: disable-shared-storage")
+
+        # Check volume list to confirm gluster_shared_storage is deleted
+        ret = check_gluster_shared_volume(self.mnode, present=False)
+        self.assertTrue(ret, ("gluster_shared_storage volume not"
+                              " deleted even after disabling it"))
+        g.log.info("gluster_shared_storage volume deleted"
+                   " successfully")
+
+        # Check the shared volume unmounted
+        ret = is_shared_volume_mounted(self.mnode)
+        self.assertFalse(ret, ("Shared volume not unmounted even"
+                               " after disabling it"))
+        g.log.info("Shared volume unmounted successfully")

--- a/tests/functional/glusterd/test_shared_storage.py
+++ b/tests/functional/glusterd/test_shared_storage.py
@@ -39,7 +39,7 @@ class SharedStorage(GlusterBaseClass):
 
     def setUp(self):
         # calling GlusterBaseClass setUp
-        GlusterBaseClass.setUp.im_func(self)
+        self.get_super_method(self, 'setUp')()
         # Creating Volume
         g.log.info("Started creating volume")
         ret = self.setup_volume()
@@ -60,7 +60,7 @@ class SharedStorage(GlusterBaseClass):
             g.log.info("Volume deleted successfully : %s", volume)
 
         # Calling GlusterBaseClass tearDown
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_shared_storage(self):
         """This test case includes:

--- a/tests/functional/glusterd/test_shared_storage.py
+++ b/tests/functional/glusterd/test_shared_storage.py
@@ -1,4 +1,4 @@
-#  Copyright (C) 2017-2018  Red Hat, Inc. <http://www.redhat.com>
+#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -20,32 +20,32 @@
     disabling shared storage
 """
 
+from random import choice
 from time import sleep
 from glusto.core import Glusto as g
+from glustolibs.gluster.brick_libs import get_all_bricks
+from glustolibs.gluster.exceptions import ExecutionError
 from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.volume_ops import (volume_create,
-                                           volume_delete, get_volume_list)
-from glustolibs.gluster.volume_libs import cleanup_volume
 from glustolibs.gluster.lib_utils import form_bricks_list
 from glustolibs.gluster.shared_storage_ops import (enable_shared_storage,
                                                    is_shared_volume_mounted,
                                                    disable_shared_storage,
                                                    check_gluster_shared_volume)
-from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.volume_ops import (volume_create,
+                                           volume_delete, get_volume_list)
+from glustolibs.gluster.volume_libs import cleanup_volume
+from glustolibs.misc.misc_libs import reboot_nodes_and_wait_to_come_online
 
 
-@runs_on([['distributed'], ['glusterfs']])
+@runs_on([['distributed'], ['glusterfs', 'nfs']])
 class SharedStorage(GlusterBaseClass):
 
     def setUp(self):
         # calling GlusterBaseClass setUp
         self.get_super_method(self, 'setUp')()
         # Creating Volume
-        g.log.info("Started creating volume")
-        ret = self.setup_volume()
-        if not ret:
+        if not self.setup_volume():
             raise ExecutionError("Volume creation failed")
-        g.log.info("Volume created successfully : %s", self.volname)
 
     def tearDown(self):
         # Stopping and cleaning up the volume
@@ -54,31 +54,15 @@ class SharedStorage(GlusterBaseClass):
             raise ExecutionError("Failed to get volume list")
 
         for volume in vol_list:
-            ret = cleanup_volume(self.mnode, volume)
-            if not ret:
+            if not cleanup_volume(self.mnode, volume):
                 raise ExecutionError("Failed Cleanup the Volume")
-            g.log.info("Volume deleted successfully : %s", volume)
 
         # Calling GlusterBaseClass tearDown
         self.get_super_method(self, 'tearDown')()
 
-    def test_shared_storage(self):
-        """This test case includes:
-        -> Enable a shared storage
-        -> Disable a shared storage
-        -> Create volume of any type with
-           name gluster_shared_storage
-        -> Disable the shared storage
-        -> Check, volume created in step-3 is
-           not deleted
-        -> Delete the volume
-        -> Enable the shared storage
-        -> Check volume with name gluster_shared_storage
-           is created
-        -> Disable the shared storage
-        """
-        # pylint: disable=too-many-statements, too-many-branches
-        # Enable a shared storage without specifying the domain
+    def _enable_and_check_shared_storage(self):
+        """Enable and check shared storage is present"""
+
         ret = enable_shared_storage(self.mnode)
         self.assertTrue(ret, ("Failed to enable a shared storage"))
         g.log.info("Successfully enabled: enable-shared-storage option")
@@ -90,13 +74,9 @@ class SharedStorage(GlusterBaseClass):
         g.log.info("gluster_shared_storage volume created"
                    " successfully")
 
-        # Check the shared volume got mounted
-        ret = is_shared_volume_mounted(self.mnode)
-        self.assertTrue(ret, ("Shared volume not mounted even"
-                              " after enabling it"))
-        g.log.info("Shared volume mounted successfully")
+    def _disable_and_check_shared_storage(self):
+        """Disable a shared storage without specifying the domain and check"""
 
-        # Disable a shared storage without specifying the domain
         ret = disable_shared_storage(self.mnode)
         self.assertTrue(ret, ("Failed to disable a shared storage"))
         g.log.info("Successfully disabled: disable-shared-storage")
@@ -108,17 +88,52 @@ class SharedStorage(GlusterBaseClass):
         g.log.info("gluster_shared_storage volume deleted"
                    " successfully")
 
-        # Check the shared volume unmounted
-        ret = is_shared_volume_mounted(self.mnode)
-        self.assertFalse(ret, ("Shared volume not unmounted even"
-                               " after disabling it"))
-        g.log.info("Shared volume unmounted successfully")
+    def _is_shared_storage_mounted_on_the_nodes(self, brick_details, mounted):
+        """
+        Checks if the shared storage is mounted on the nodes where it is
+        created.
+        """
+        for node in brick_details:
+            ret = is_shared_volume_mounted(node.split(":")[0])
+            if mounted:
+                self.assertTrue(ret, ("Shared volume not mounted even after"
+                                      " enabling it"))
+                g.log.info("Shared volume mounted successfully")
+            else:
+                self.assertFalse(ret, ("Shared volume not unmounted even"
+                                       " after disabling it"))
+                g.log.info("Shared volume unmounted successfully")
+
+    def _get_all_bricks(self):
+        """Get all bricks where the shared storage is mounted"""
+
+        brick_list = get_all_bricks(self.mnode, "gluster_shared_storage")
+        self.assertIsNotNone(brick_list, "Unable to fetch brick list of shared"
+                                         " storage")
+        return brick_list
+
+    def _shared_storage_test_without_node_reboot(self):
+        """Shared storge testcase till the node reboot scenario"""
+
+        # Enable shared storage and check it is present on the cluster
+        self._enable_and_check_shared_storage()
+
+        # Get all the bricks where shared storage is mounted
+        brick_list = self._get_all_bricks()
+
+        # Check the shared volume is mounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=True)
+        # Disable shared storage and check it is not present on the cluster
+        self._disable_and_check_shared_storage()
+
+        # Check the shared volume is unmounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=False)
 
         # Create a volume with name gluster_shared_storage
-        g.log.info("creation of volume should succeed")
         volume = "gluster_shared_storage"
-        bricks_list = form_bricks_list(self.mnode, volume,
-                                       2, self.servers,
+        bricks_list = form_bricks_list(self.mnode, volume, 2, self.servers,
                                        self.all_servers_info)
         count = 0
         while count < 20:
@@ -155,38 +170,78 @@ class SharedStorage(GlusterBaseClass):
                               "%s", volume))
         g.log.info("Volume deleted successfully : %s", volume)
 
-        # Enable the shared storage
-        ret = enable_shared_storage(self.mnode)
-        self.assertTrue(ret, ("Failed to enable a shared storage"))
-        g.log.info("Successfully enabled: enable-shared-storage option")
+        # Enable shared storage and check it is present on the cluster
+        self._enable_and_check_shared_storage()
 
-        # Check volume list to confirm gluster_shared_storage is created
-        ret = check_gluster_shared_volume(self.mnode)
-        self.assertTrue(ret, ("gluster_shared_storage volume not"
-                              " created even after enabling it"))
-        g.log.info("gluster_shared_storage volume created"
-                   " successfully")
+        # Check the shared volume is mounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=True)
 
-        # Check the shared volume got mounted
-        ret = is_shared_volume_mounted(self.mnode)
-        self.assertTrue(ret, ("Shared volume not mounted even"
-                              " after enabling it"))
-        g.log.info("Shared volume mounted successfully")
+        # Disable shared storage and check it is not present on the cluster
+        self._disable_and_check_shared_storage()
 
-        # Disable a shared storage
-        ret = disable_shared_storage(self.mnode)
-        self.assertTrue(ret, ("Failed to disable a shared storage"))
-        g.log.info("Successfully disabled: disable-shared-storage")
+        # Check the shared volume is unmounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=False)
 
-        # Check volume list to confirm gluster_shared_storage is deleted
-        ret = check_gluster_shared_volume(self.mnode, present=False)
-        self.assertTrue(ret, ("gluster_shared_storage volume not"
-                              " deleted even after disabling it"))
-        g.log.info("gluster_shared_storage volume deleted"
-                   " successfully")
+    def test_shared_storage(self):
+        """
+        This test case includes:
+        -> Enable a shared storage
+        -> Disable a shared storage
+        -> Create volume of any type with
+           name gluster_shared_storage
+        -> Disable the shared storage
+        -> Check, volume created in step-3 is
+           not deleted
+        -> Delete the volume
+        -> Enable the shared storage
+        -> Check volume with name gluster_shared_storage
+           is created
+        -> Disable the shared storage
+        -> Enable shared storage and validate whether it is mounted
+        -> Perform node reboot
+        -> Post reboot validate the bricks are mounted back or not
+        """
+        # pylint: disable=too-many-statements, too-many-branches
+        self._shared_storage_test_without_node_reboot()
 
-        # Check the shared volume unmounted
-        ret = is_shared_volume_mounted(self.mnode)
-        self.assertFalse(ret, ("Shared volume not unmounted even"
-                               " after disabling it"))
-        g.log.info("Shared volume unmounted successfully")
+        # Enable shared storage and check it is present on the cluster
+        self._enable_and_check_shared_storage()
+
+        # Get all the bricks where shared storage is mounted
+        brick_list = self._get_all_bricks()
+
+        # Check the shared volume is mounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=True)
+
+        # Perform node reboot on any of the nodes where the shared storage is
+        # mounted
+        node_to_reboot = choice(brick_list)
+        node_to_reboot = node_to_reboot.split(":")[0]
+        ret = reboot_nodes_and_wait_to_come_online(node_to_reboot)
+        self.assertTrue(ret, "Reboot Failed on node: "
+                             "{}".format(node_to_reboot))
+        g.log.info("Node: %s rebooted successfully", node_to_reboot)
+
+        # Post reboot checking peers are connected
+        count = 0
+        while count < 10:
+            ret = self.validate_peers_are_connected()
+            if ret:
+                break
+            sleep(3)
+            count += 1
+        self.assertTrue(ret, "Peers are not in connected state.")
+
+        # Check the shared volume is mounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=True)
+
+        # Disable shared storage and check it is not present on the cluster
+        self._disable_and_check_shared_storage()
+
+        # Check the shared volume is unmounted on the nodes where it is created
+        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
+                                                     mounted=False)

--- a/tests/functional/glusterd/test_shared_storage.py
+++ b/tests/functional/glusterd/test_shared_storage.py
@@ -23,7 +23,7 @@
 from random import choice
 from tests.d_parent_test import DParentTest
 
-# disruptive;dist
+# disruptive;
 
 
 class TestSharedStorage(DParentTest):
@@ -100,11 +100,9 @@ class TestSharedStorage(DParentTest):
         # Create a volume with name gluster_shared_storage
         volume = "gluster_shared_storage"
         conf_hash = {
-            "replicated": {
-                "dist_count": 1,
-                "replica_count": 2,
-                "transport": "tcp"
-            }
+            "dist_count": 1,
+            "replica_count": 2,
+            "transport": "tcp"
         }
         self.redant.volume_create(volume, self.server_list[0],
                                   conf_hash, self.server_list,

--- a/tests/functional/glusterd/test_shared_storage.py
+++ b/tests/functional/glusterd/test_shared_storage.py
@@ -1,115 +1,82 @@
-#  Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 """
-    Description:
-    Test cases in this module related glusterd enabling and
-    disabling shared storage
+ Copyright (C) 2017-2020  Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+   Test cases in this module related glusterd enabling and
+   disabling shared storage
 """
 
 from random import choice
-from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.brick_libs import get_all_bricks
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass, runs_on
-from glustolibs.gluster.lib_utils import form_bricks_list
-from glustolibs.gluster.shared_storage_ops import (enable_shared_storage,
-                                                   is_shared_volume_mounted,
-                                                   disable_shared_storage,
-                                                   check_gluster_shared_volume)
-from glustolibs.gluster.volume_ops import (volume_create,
-                                           volume_delete, get_volume_list)
-from glustolibs.gluster.volume_libs import cleanup_volume
-from glustolibs.misc.misc_libs import reboot_nodes_and_wait_to_come_online
+from tests.d_parent_test import DParentTest
+
+# disruptive;dist
 
 
-@runs_on([['distributed'], ['glusterfs', 'nfs']])
-class SharedStorage(GlusterBaseClass):
-
-    def setUp(self):
-        # calling GlusterBaseClass setUp
-        self.get_super_method(self, 'setUp')()
-        # Creating Volume
-        if not self.setup_volume():
-            raise ExecutionError("Volume creation failed")
-
-    def tearDown(self):
-        # Stopping and cleaning up the volume
-        vol_list = get_volume_list(self.mnode)
-        if vol_list is None:
-            raise ExecutionError("Failed to get volume list")
-
-        for volume in vol_list:
-            if not cleanup_volume(self.mnode, volume):
-                raise ExecutionError("Failed Cleanup the Volume")
-
-        # Calling GlusterBaseClass tearDown
-        self.get_super_method(self, 'tearDown')()
+class TestSharedStorage(DParentTest):
 
     def _enable_and_check_shared_storage(self):
         """Enable and check shared storage is present"""
 
-        ret = enable_shared_storage(self.mnode)
-        self.assertTrue(ret, ("Failed to enable a shared storage"))
-        g.log.info("Successfully enabled: enable-shared-storage option")
+        ret = self.redant.enable_shared_storage(self.server_list[0])
+        if not ret:
+            raise Exception("Failed to enable shared storage volume")
 
         # Check volume list to confirm gluster_shared_storage is created
-        ret = check_gluster_shared_volume(self.mnode)
-        self.assertTrue(ret, ("gluster_shared_storage volume not"
-                              " created even after enabling it"))
-        g.log.info("gluster_shared_storage volume created"
-                   " successfully")
+        ret = self.redant.check_gluster_shared_volume(self.server_list[0])
+        if not ret:
+            raise Exception("gluster_shared_storage volume not created after"
+                            " enabling it")
 
     def _disable_and_check_shared_storage(self):
         """Disable a shared storage without specifying the domain and check"""
 
-        ret = disable_shared_storage(self.mnode)
-        self.assertTrue(ret, ("Failed to disable a shared storage"))
-        g.log.info("Successfully disabled: disable-shared-storage")
+        ret = self.redant.disable_shared_storage(self.server_list[0])
+        if not ret:
+            raise Exception("Failed to disable shared storage volume")
 
-        # Check volume list to confirm gluster_shared_storage is deleted
-        ret = check_gluster_shared_volume(self.mnode, present=False)
-        self.assertTrue(ret, ("gluster_shared_storage volume not"
-                              " deleted even after disabling it"))
-        g.log.info("gluster_shared_storage volume deleted"
-                   " successfully")
+        # Check volume list to confirm gluster_shared_storage is created
+        ret = self.redant.check_gluster_shared_volume(self.server_list[0],
+                                                      False)
+        if not ret:
+            raise Exception("gluster_shared_storage volume not deleted after"
+                            " disabling it")
 
     def _is_shared_storage_mounted_on_the_nodes(self, brick_details, mounted):
         """
         Checks if the shared storage is mounted on the nodes where it is
         created.
         """
-        for node in brick_details:
-            ret = is_shared_volume_mounted(node.split(":")[0])
-            if mounted:
-                self.assertTrue(ret, ("Shared volume not mounted even after"
-                                      " enabling it"))
-                g.log.info("Shared volume mounted successfully")
-            else:
-                self.assertFalse(ret, ("Shared volume not unmounted even"
-                                       " after disabling it"))
-                g.log.info("Shared volume unmounted successfully")
+        for brick in brick_details:
+            ret = self.redant.is_shared_volume_mounted(brick.split(":")[0])
+            if mounted and not ret:
+                raise Exception("Shared volume not mounted even after "
+                                "enabling it")
+            elif not mounted and ret:
+                raise Exception("Shared volume not unmounted even"
+                                " after disabling it")
 
     def _get_all_bricks(self):
         """Get all bricks where the shared storage is mounted"""
 
-        brick_list = get_all_bricks(self.mnode, "gluster_shared_storage")
-        self.assertIsNotNone(brick_list, "Unable to fetch brick list of shared"
-                                         " storage")
+        brick_list = self.redant.get_all_bricks("gluster_shared_storage",
+                                                self.server_list[0])
+        if brick_list is None:
+            raise Exception("Failed to get the brick list")
+
         return brick_list
 
     def _shared_storage_test_without_node_reboot(self):
@@ -122,69 +89,59 @@ class SharedStorage(GlusterBaseClass):
         brick_list = self._get_all_bricks()
 
         # Check the shared volume is mounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=True)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, True)
+
         # Disable shared storage and check it is not present on the cluster
         self._disable_and_check_shared_storage()
 
         # Check the shared volume is unmounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=False)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, False)
 
         # Create a volume with name gluster_shared_storage
         volume = "gluster_shared_storage"
-        bricks_list = form_bricks_list(self.mnode, volume, 2, self.servers,
-                                       self.all_servers_info)
-        count = 0
-        while count < 20:
-            ret, _, _ = volume_create(self.mnode, volume, bricks_list, True)
-            if not ret:
-                break
-            sleep(2)
-            count += 1
-        self.assertEqual(ret, 0, "Failed to create volume")
-        g.log.info("Volume create is success")
+        conf_hash = {
+            "replicated": {
+                "dist_count": 1,
+                "replica_count": 2,
+                "transport": "tcp"
+            }
+        }
+        self.redant.volume_create(volume, self.server_list[0],
+                                  conf_hash, self.server_list,
+                                  self.brick_roots, True)
 
         # Disable the shared storage should fail
-        ret = disable_shared_storage(self.mnode)
-        self.assertFalse(ret, ("Unexpected: Successfully disabled"
-                               " shared-storage"))
-        g.log.info("Volume set: failed as expected")
+        ret = self.redant.disable_shared_storage(self.server_list[0])
+        if ret:
+            raise Exception("Unexpected: Successfully disabled shared"
+                            " storage")
 
         # Check volume list to confirm gluster_shared_storage
         # is not deleted which was created before
-        vol_list = get_volume_list(self.mnode)
-        _rc = False
-        for vol in vol_list:
-            if vol == "gluster_shared_storage":
-                _rc = True
-                break
-        self.assertTrue(_rc, ("gluster_shared_storage volume got"
-                              " deleted after disabling it"))
-        g.log.info("gluster_shared_storage volume not deleted as "
-                   " expected after disabling enable-shared-storage")
+        vol_list = self.redant.get_volume_list(self.server_list[0])
+        if vol_list is None:
+            raise Exception("Failed to get volume list")
+
+        if "gluster_shared_storage" not in vol_list:
+            raise Exception("gluster_shared_storage volume got"
+                            " deleted after disabling it")
 
         # Delete the volume created
-        ret = volume_delete(self.mnode, volume)
-        self.assertTrue(ret, ("Failed to cleanup the Volume "
-                              "%s", volume))
-        g.log.info("Volume deleted successfully : %s", volume)
+        self.redant.volume_delete(volume, self.server_list[0])
 
         # Enable shared storage and check it is present on the cluster
         self._enable_and_check_shared_storage()
 
         # Check the shared volume is mounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=True)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, True)
 
         # Disable shared storage and check it is not present on the cluster
         self._disable_and_check_shared_storage()
 
         # Check the shared volume is unmounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=False)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, False)
 
-    def test_shared_storage(self):
+    def run_test(self, redant):
         """
         This test case includes:
         -> Enable a shared storage
@@ -203,7 +160,6 @@ class SharedStorage(GlusterBaseClass):
         -> Perform node reboot
         -> Post reboot validate the bricks are mounted back or not
         """
-        # pylint: disable=too-many-statements, too-many-branches
         self._shared_storage_test_without_node_reboot()
 
         # Enable shared storage and check it is present on the cluster
@@ -213,35 +169,25 @@ class SharedStorage(GlusterBaseClass):
         brick_list = self._get_all_bricks()
 
         # Check the shared volume is mounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=True)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, True)
 
         # Perform node reboot on any of the nodes where the shared storage is
         # mounted
         node_to_reboot = choice(brick_list)
         node_to_reboot = node_to_reboot.split(":")[0]
-        ret = reboot_nodes_and_wait_to_come_online(node_to_reboot)
-        self.assertTrue(ret, "Reboot Failed on node: "
-                             "{}".format(node_to_reboot))
-        g.log.info("Node: %s rebooted successfully", node_to_reboot)
+        redant.reboot_nodes(node_to_reboot)
+        if not redant.wait_node_power_up(node_to_reboot):
+            raise Exception("Node has not come up after reboot")
 
         # Post reboot checking peers are connected
-        count = 0
-        while count < 10:
-            ret = self.validate_peers_are_connected()
-            if ret:
-                break
-            sleep(3)
-            count += 1
-        self.assertTrue(ret, "Peers are not in connected state.")
+        if not redant.wait_till_all_peers_connected(self.server_list):
+            raise Exception("Peers are not connected after node reboot")
 
         # Check the shared volume is mounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=True)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, True)
 
         # Disable shared storage and check it is not present on the cluster
         self._disable_and_check_shared_storage()
 
         # Check the shared volume is unmounted on the nodes where it is created
-        self._is_shared_storage_mounted_on_the_nodes(brick_details=brick_list,
-                                                     mounted=False)
+        self._is_shared_storage_mounted_on_the_nodes(brick_list, False)


### PR DESCRIPTION
Migrated TC [test_shared_storage](https://github.com/gluster/glusto-tests/blob/master/tests/functional/glusterd/test_shared_storage.py)

Added `shared_storage_ops`

Fixes: #609 , and Fixes: #610 
Updates: #292 
Signed-off-by: nik-redhat <nladha@redhat.com>