### PR TITLE
Fixed mountpoint connection failure in test

### DIFF
--- a/common/ops/gluster_ops/mount_ops.py
+++ b/common/ops/gluster_ops/mount_ops.py
@@ -144,11 +144,13 @@ class MountOps(AbstractOps):
 
         """
         cmd = f"stat -c '%a' {mountpoint}"
-        for _ in range(timeout):
+        count = 0
+        while count <= timeout:
             ret = self.execute_abstract_op_node(cmd,
                                                 client_node,
                                                 False)
             if ret['error_code'] == 0:
                 return True
             sleep(1)
+            count += 1
         return False

--- a/common/ops/gluster_ops/mount_ops.py
+++ b/common/ops/gluster_ops/mount_ops.py
@@ -3,6 +3,7 @@ This file contains one class - MountOps which
 holds mount related APIs which will be called
 from the test case.
 """
+from time import sleep
 from common.ops.abstract_ops import AbstractOps
 
 
@@ -122,3 +123,32 @@ class MountOps(AbstractOps):
             return count_of_proc
         else:
             return None
+
+    def wait_for_mountpoint_to_connect(self, mountpoint: str,
+                                       client_node: str,
+                                       timeout: int = 20):
+        """
+        This function waits for mountpoint to get connected.
+        A failed mountpoint connection results in exception
+        'Transport endpoint not connected'.
+
+        Args:
+            mountpoint (str) : the mountpoint to check
+            client_node (str): client node to execute the command
+            timeout (int) : Timeout by default 20s.
+                            Moreover, no one likes to wait forever :)
+
+        Returns:
+        True if mountpoint gets connected within the timeout
+        else False.
+
+        """
+        cmd = f"stat -c '%a' {mountpoint}"
+        for _ in range(timeout):
+            ret = self.execute_abstract_op_node(cmd,
+                                                client_node,
+                                                False)
+            if ret['error_code'] == 0:
+                return True
+            sleep(1)
+        return False

--- a/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
+++ b/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
@@ -68,5 +68,10 @@ class TestCase(NdParentTest):
                                                      self.server_list)):
             raise Exception("All volume processes are not up")
 
+        # # adding sleep for the mountpoint to be recognized by client
+        # sleep(3)
+        if not redant.wait_for_mountpoint_to_connect(self.mountpoint,
+                                                     self.client_list[0]):
+            raise Exception("Transport endpoint connection failed")
         # validate the mountpoint permissions.
         self._validate_mount_permissions()

--- a/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
+++ b/tests/functional/glusterd/test_mountpoint_ownership_post_volume_restart.py
@@ -68,8 +68,7 @@ class TestCase(NdParentTest):
                                                      self.server_list)):
             raise Exception("All volume processes are not up")
 
-        # # adding sleep for the mountpoint to be recognized by client
-        # sleep(3)
+        # validating if mountpoint connected
         if not redant.wait_for_mountpoint_to_connect(self.mountpoint,
                                                      self.client_list[0]):
             raise Exception("Transport endpoint connection failed")


### PR DESCRIPTION
In test_mountpoint_ownership_post_volume_restart the mountpoint on
client was failing to connect. Now there weretwo fixes:
1. Add a sleep(3) and it was perfectly working
2. create a function that can handle the same in every condition

So added a function to take care of the same and for all kinds of VMs.

Fixes: #616

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
