### PR TITLE
[Common] Correcting function invocation name

### DIFF
--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -75,7 +75,7 @@ class MachineOps(AbstractOps):
                 return True
             time.sleep(1)
             iter_v += 1
-        status = self.check_power_node_status(node)
+        status = self.check_node_power_status(node)
         if status[node]:
             self.logger.info(f"{node} online.")
             return True
@@ -102,7 +102,7 @@ class MachineOps(AbstractOps):
                 return True
             time.sleep(1)
             iter_v += 1
-        status = self.check_power_node_status(node)
+        status = self.check_node_power_status(node)
         if not status[node]:
             self.logger.info(f"{node} offline.")
             return True


### PR DESCRIPTION
The method being invoked in machine ops functions is `check_power_node_status` while the actual name of the method is `check_node_power_status`
Fixes: #635 

Signed-off-by: srijan-sivakmuar ssivakum@redhat.com
<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
