### PR TITLE
Migrated test_peer_detach_check_warning_message

### DIFF
--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -378,6 +378,19 @@ class PeerOps(AbstractOps):
                                   f"not in connected state")
                 is_connected = False
 
+        # check which server in servers is not part of the pool itself
+        peer_ips = [socket.gethostbyname(peer_stat['hostname']) for
+                    peer_stat in peer_status_list]
+
+        if not set(servers).issubset(peer_ips):
+            servers_not_in_pool = list(set(servers).difference(peer_ips))
+            for index, server in enumerate(servers_not_in_pool):
+                if server not in servers:
+                    servers_not_in_pool[index] = (socket.
+                                                  gethostbyaddr(server)[0])
+            self.logger.error(f"Servers: {servers_not_in_pool} not "
+                              "yet added to the pool.")
+            return False
         return is_connected
 
     def wait_for_peers_to_connect(self, servers: list, node: str,

--- a/common/ops/gluster_ops/peer_ops.py
+++ b/common/ops/gluster_ops/peer_ops.py
@@ -378,6 +378,9 @@ class PeerOps(AbstractOps):
                                   f"not in connected state")
                 is_connected = False
 
+        if not is_connected:
+            return False
+
         # check which server in servers is not part of the pool itself
         peer_ips = [socket.gethostbyname(peer_stat['hostname']) for
                     peer_stat in peer_status_list]

--- a/common/rexe.py
+++ b/common/rexe.py
@@ -167,9 +167,9 @@ class Rexe:
         if not self.connect_flag:
             return async_obj
         try:
-            _, stdout, stderr = self.node_dict[node].exec_command(cmd)
+            stdin, stdout, stderr = self.node_dict[node].exec_command(cmd)
             async_obj = {"cmd": cmd, "node": node, "stdout": stdout,
-                         "stderr": stderr}
+                         "stderr": stderr, "stdin": stdin}
         except Exception as e:
             # Reconnection to be done.
             node_ssh_client = paramiko.SSHClient()
@@ -185,10 +185,10 @@ class Rexe:
             except Exception as e:
                 self.logger.error(f"Connection failure. Exceptions {e}.")
             # On rebooting the node
-            _, stdout, stderr = self.node_dict[node].exec_command(cmd)
+            stdin, stdout, stderr = self.node_dict[node].exec_command(cmd)
 
             async_obj = {"cmd": cmd, "node": node, "stdout": stdout,
-                         "stderr": stderr}
+                         "stderr": stderr, "stdin": stdin}
         return async_obj
 
     def check_async_command_status(self, async_obj: dict) -> bool:

--- a/tests/functional/glusterd/test_peer_detach_check_warning_message.py
+++ b/tests/functional/glusterd/test_peer_detach_check_warning_message.py
@@ -1,44 +1,36 @@
-#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along`
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
 
-from glusto.core import Glusto as g
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.peer_ops import (peer_detach, peer_probe,
-                                         is_peer_connected)
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along`
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Description:
+This test checks the warning message return
+on detaching a peer from the cluster.
+"""
+# disruptive;
+
+from tests.d_parent_test import DParentTest
 
 
-class TestPeerDetachWarningMessage(GlusterBaseClass):
+class TestCase(DParentTest):
 
-    def tearDown(self):
-
-        # Peer probe node which was detached
-        ret, _, _ = peer_probe(self.mnode, self.servers[1])
-        if ret:
-            raise ExecutionError("Failed to detach %s" % self.servers[1])
-        g.log.info("Peer detach successful %s", self.servers[1])
-
-        self.get_super_method(self, 'tearDown')()
-
-    def test_peer_detach_check_warning_message(self):
-        # pylint: disable=too-many-statements
+    def run_test(self, redant):
         """
         Test Case:
         1) Create a cluster.
-        2) Peer detach a node but don't press y.
+        2) Peer detach a node and send an 'n'.
         3) Check the warning message.
         4) Check peer status.
            (Node shouldn't be detached!)
@@ -48,36 +40,38 @@ class TestPeerDetachWarningMessage(GlusterBaseClass):
         """
 
         # Peer detach one node
-        ret, msg, _ = g.run(self.mnode, "gluster peer detach %s"
-                            % self.servers[1])
-        self.assertEqual(ret, 0, "ERROR: Peer detach successful %s"
-                         % self.servers[1])
-        g.log.info("EXPECTED: Failed to detach %s", self.servers[1])
+        cmd = f"gluster peer detach {self.server_list[1]}"
+        ret = redant.execute_command_async(cmd, self.server_list[0])
+        ret['stdin'].write("n\n")
+        ret = redant.collect_async_result(ret)
+        msg = ret['msg'][0]
 
         # Checking warning message
-        expected_msg = ' '.join([
-            'All clients mounted through the peer which is getting',
-            'detached need to be remounted using one of the other',
-            'active peers in the trusted storage pool to ensure',
-            'client gets notification on any changes done on the',
-            'gluster configuration and if the same has been done',
-            'do you want to proceed'
-            ])
-        self.assertIn(expected_msg, msg.split('?')[0],
-                      "Incorrect warning message for peer detach.")
-        g.log.info("Correct warning message for peer detach.")
+        expected_msg = ''.join(['All clients mounted through ',
+                                'the peer which is getting detached ',
+                                'need to be remounted using one of ',
+                                'the other active peers in the ',
+                                'trusted storage pool to ensure '
+                                'client gets notification ',
+                                'on any changes done on the ',
+                                'gluster configuration and ',
+                                'if the same has been done ',
+                                'do you want to proceed'])
+        if expected_msg not in msg:
+            raise Exception("Incorrect warning message for peer detach.")
 
         # Checking if peer is connected
-        ret = is_peer_connected(self.mnode, self.servers[1])
-        self.assertTrue(ret, "Peer is not in connected state.")
-        g.log.info("Peers is in connected state.")
+        ret = redant.is_peer_connected(self.server_list[1],
+                                       self.server_list[0])
+        if not ret:
+            raise Exception("Peer is not in connected state.")
 
         # Peer detach one node
-        ret, _, _ = peer_detach(self.mnode, self.servers[1])
-        self.assertEqual(ret, 0, "Failed to detach %s" % self.servers[1])
-        g.log.info("Peer detach successful %s", self.servers[1])
+        redant.peer_detach(self.server_list[1],
+                           self.server_list[0])
 
         # Checking if peer is connected
-        ret = is_peer_connected(self.mnode, self.servers[1])
-        self.assertFalse(ret, "Peer is in connected state.")
-        g.log.info("Peer is not in connected state.")
+        ret = redant.is_peer_connected(self.server_list[1],
+                                       self.server_list[0])
+        if ret:
+            raise Exception("Peer is in connected state.")

--- a/tests/functional/glusterd/test_peer_detach_check_warning_message.py
+++ b/tests/functional/glusterd/test_peer_detach_check_warning_message.py
@@ -31,7 +31,7 @@ class TestPeerDetachWarningMessage(GlusterBaseClass):
             raise ExecutionError("Failed to detach %s" % self.servers[1])
         g.log.info("Peer detach successful %s", self.servers[1])
 
-        GlusterBaseClass.tearDown.im_func(self)
+        self.get_super_method(self, 'tearDown')()
 
     def test_peer_detach_check_warning_message(self):
         # pylint: disable=too-many-statements

--- a/tests/functional/glusterd/test_peer_detach_check_warning_message.py
+++ b/tests/functional/glusterd/test_peer_detach_check_warning_message.py
@@ -1,0 +1,83 @@
+#  Copyright (C) 2019  Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along`
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from glusto.core import Glusto as g
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.peer_ops import (peer_detach, peer_probe,
+                                         is_peer_connected)
+
+
+class TestPeerDetachWarningMessage(GlusterBaseClass):
+
+    def tearDown(self):
+
+        # Peer probe node which was detached
+        ret, _, _ = peer_probe(self.mnode, self.servers[1])
+        if ret:
+            raise ExecutionError("Failed to detach %s" % self.servers[1])
+        g.log.info("Peer detach successful %s", self.servers[1])
+
+        GlusterBaseClass.tearDown.im_func(self)
+
+    def test_peer_detach_check_warning_message(self):
+        # pylint: disable=too-many-statements
+        """
+        Test Case:
+        1) Create a cluster.
+        2) Peer detach a node but don't press y.
+        3) Check the warning message.
+        4) Check peer status.
+           (Node shouldn't be detached!)
+        5) Peer detach a node now press y.
+        6) Check peer status.
+           (Node should be detached!)
+        """
+
+        # Peer detach one node
+        ret, msg, _ = g.run(self.mnode, "gluster peer detach %s"
+                            % self.servers[1])
+        self.assertEqual(ret, 0, "ERROR: Peer detach successful %s"
+                         % self.servers[1])
+        g.log.info("EXPECTED: Failed to detach %s", self.servers[1])
+
+        # Checking warning message
+        expected_msg = ' '.join([
+            'All clients mounted through the peer which is getting',
+            'detached need to be remounted using one of the other',
+            'active peers in the trusted storage pool to ensure',
+            'client gets notification on any changes done on the',
+            'gluster configuration and if the same has been done',
+            'do you want to proceed'
+            ])
+        self.assertIn(expected_msg, msg.split('?')[0],
+                      "Incorrect warning message for peer detach.")
+        g.log.info("Correct warning message for peer detach.")
+
+        # Checking if peer is connected
+        ret = is_peer_connected(self.mnode, self.servers[1])
+        self.assertTrue(ret, "Peer is not in connected state.")
+        g.log.info("Peers is in connected state.")
+
+        # Peer detach one node
+        ret, _, _ = peer_detach(self.mnode, self.servers[1])
+        self.assertEqual(ret, 0, "Failed to detach %s" % self.servers[1])
+        g.log.info("Peer detach successful %s", self.servers[1])
+
+        # Checking if peer is connected
+        ret = is_peer_connected(self.mnode, self.servers[1])
+        self.assertFalse(ret, "Peer is in connected state.")
+        g.log.info("Peer is not in connected state.")


### PR DESCRIPTION
Migrated the [test
case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_peer_detach_check_warning_message.py)

Updates: #292

Fixes: #356

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>