### PR TITLE
Removed sp flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 /_/ |_/_____/_____/_/  |_/_/ |_/ /_/     
                                          
 
-usage: redant_main.py [-h] -c CONFIG_FILE -t TEST_DIR [-sp] [-l LOG_DIR]
+usage: redant_main.py [-h] -c CONFIG_FILE -t TEST_DIR [-l LOG_DIR]
                       [-ll LOG_LEVEL] [-cc CONCUR_COUNT] [-rf RESULT_PATH]
                       [-xls EXCEL_SHEET]
 
@@ -20,8 +20,6 @@ optional arguments:
                         Config file(s) to read.
   -t TEST_DIR, --test-dir TEST_DIR
                         The test directory where TC(s) exist
-  -sp, --specific-test-path
-                        Path of the specific test to be run from tests/
   -l LOG_DIR, --log-dir LOG_DIR
                         The directory wherein log will be stored.
   -ll LOG_LEVEL, --log-level LOG_LEVEL
@@ -106,8 +104,7 @@ which will inturn contain the log files specific to volume type.
 
 In addition to running TCs from within a suite, either performance or
 functional or even under a more granular level of component, one can select to
-run a specific TC also. To do this, one simply has to use the `-sp` flag while
-invoking redant and instead of the directory path provide the path of the TC.
+run a specific TC also.
 For example,
 `python3 core/redant_main.py -c core/parsing/config.yml -t tests/example/sample_component`
 

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -34,9 +34,6 @@ def pars_args():
     parser.add_argument("-t", "--test-dir",
                         help="The test directory where TC(s) exist",
                         dest="test_dir", default=None, type=str, required=True)
-    parser.add_argument("-sp", "--specific-test-path",
-                        help="Path of the specific test to be run from tests/",
-                        dest="spec_test", action='store_true', required=False)
     parser.add_argument("-l", "--log-dir",
                         help="The directory wherein log will be stored.",
                         dest="log_dir", default="/tmp/redant", type=str)
@@ -80,8 +77,10 @@ def main():
     spinner.start("Building test list")
     # Building the test list and obtaining the TC details.
     excluded_tests = param_obj.get_excluded_tests()
+    spec_test = (args.test_dir.endswith(".py")
+                 and args.test_dir.split("/")[-1].startswith("test"))
     TestListBuilder.create_test_dict(args.test_dir, excluded_tests,
-                                     args.spec_test)
+                                     spec_test)
     spinner.succeed("Test List built")
 
     spinner.start("Creating log dirs")
@@ -101,7 +100,7 @@ def main():
 
     # invoke the test_runner.
     TestRunner.init(TestListBuilder, param_obj, env_set, args.log_dir,
-                    args.log_level, args.concur_count, args.spec_test)
+                    args.log_level, args.concur_count, spec_test)
     result_queue = TestRunner.run_tests(env_obj)
 
     # Environment cleanup. TBD.

--- a/core/redant_main.py
+++ b/core/redant_main.py
@@ -79,8 +79,13 @@ def main():
     excluded_tests = param_obj.get_excluded_tests()
     spec_test = (args.test_dir.endswith(".py")
                  and args.test_dir.split("/")[-1].startswith("test"))
-    TestListBuilder.create_test_dict(args.test_dir, excluded_tests,
-                                     spec_test)
+    try:
+        TestListBuilder.create_test_dict(args.test_dir, excluded_tests,
+                                         spec_test)
+    except FileNotFoundError:
+        print("Error: Can't find the file\n")
+        spinner.fail("FileNotFoundError in test list builder")
+        return
     spinner.succeed("Test List built")
 
     spinner.start("Creating log dirs")


### PR DESCRIPTION
`sp` flag is removed from the Argument Parser. The same is handled using
a condition.

Fixes: #665

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
