### PR TITLE
Migrated test_brickmux_brick_process

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -828,6 +828,15 @@ class VolumeOps(AbstractOps):
             multi_option (bool): Set multiple options together for a
                                  volume/cluster
             excep (bool): To bypass or not to bypass the exception handling.
+        Returns:
+            ret: A dictionary consisting
+                - Flag : Flag to check if connection failed
+                - msg : message
+                - error_msg: error message
+                - error_code: error code returned
+                - cmd : command that got executed
+                - node : node on which the command got executed
+
         Example:
             options = {"user.cifs":"enable","user.smb":"enable"}
             set_volume_options("test-vol1", options, server)

--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -55,6 +55,22 @@ class MachineOps(AbstractOps):
         self.logger.info(f"{nodes} power state : {ret}")
         return ret
 
+    def are_nodes_online(self, nodes: str):
+        """
+        Checks if all the nodes are online.
+
+        Args:
+            nodes (str|list): List of nodes
+        Return:
+        True if all the nodes are online else False
+        """
+        ret = self.check_node_power_status(nodes)
+        print(ret)
+        for key in ret:
+            if not ret[key]:
+                return False
+        return True
+
     def wait_node_power_up(self, node: str, timeout: int = 100):
         """
         Wait for a node to come up online.

--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -65,10 +65,8 @@ class MachineOps(AbstractOps):
         True if all the nodes are online else False
         """
         ret = self.check_node_power_status(nodes)
-        for key in ret:
-            if not ret[key]:
-                return False
-        return True
+
+        return all(list(ret.values()))
 
     def wait_node_power_up(self, node: str, timeout: int = 100):
         """

--- a/common/ops/support_ops/machine_ops.py
+++ b/common/ops/support_ops/machine_ops.py
@@ -65,7 +65,6 @@ class MachineOps(AbstractOps):
         True if all the nodes are online else False
         """
         ret = self.check_node_power_status(nodes)
-        print(ret)
         for key in ret:
             if not ret[key]:
                 return False

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -21,7 +21,6 @@
 """
 # disruptive;
 
-from time import sleep
 from tests.d_parent_test import DParentTest
 
 
@@ -57,21 +56,17 @@ class TestCase(DParentTest):
         for volname in vol_list:
             if vol_list.index(volname) == 2:
                 redant.execute_abstract_op_node("reboot",
-                                                self.server_list[2])
+                                                self.server_list[2],
+                                                False)
             ret = redant.volume_start(volname,
                                       self.server_list[0],
                                       excep=False)
-            print(ret, "\n\n")
 
-        for _ in range(10):
-            sleep(1)
-            ret = redant.are_nodes_online(self.server_list[2])
-            if ret:
-                break
+        if not redant.wait_node_power_up(self.server_list[2]):
+            raise Exception(f"Node {self.server_list[2]} not yet up")
 
-        if not ret:
-            raise Exception("Node is not online")
-
+        if not redant.wait_till_all_peers_connected(self.server_list):
+            raise Exception("Some peers not yet connected")
         for server in self.server_list:
             ret = redant.execute_abstract_op_node("pgrep glusterfsd",
                                                   server)

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -55,12 +55,10 @@ class TestCase(DParentTest):
         vol_list = redant.get_volume_list(self.server_list[0])
         for volname in vol_list:
             if vol_list.index(volname) == 2:
-                redant.execute_abstract_op_node("reboot",
-                                                self.server_list[2],
-                                                False)
-            ret = redant.volume_start(volname,
-                                      self.server_list[0],
-                                      excep=False)
+                redant.reboot_nodes(self.server_list[2])
+
+            redant.volume_start(volname,
+                                self.server_list[0])
 
         if not redant.wait_node_power_up(self.server_list[2]):
             raise Exception(f"Node {self.server_list[2]} not yet up")

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -66,8 +66,6 @@ class TestCase(DParentTest):
         if not redant.wait_till_all_peers_connected(self.server_list):
             raise Exception("Some peers not yet connected")
         for server in self.server_list:
-            ret = redant.execute_abstract_op_node("pgrep glusterfsd",
-                                                  server)
-            out = ret['msg']
-            if len(out) != 1:
+            out = redant.get_brick_processes_count(server)
+            if out is not None and out != 1:
                 raise Exception("More then 1 brick process seen in glusterfsd")

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -61,7 +61,7 @@ class TestCase(DParentTest):
             ret = redant.volume_start(volname,
                                       self.server_list[0],
                                       excep=False)
-            print(ret,"\n\n")
+            print(ret, "\n\n")
 
         for _ in range(10):
             sleep(1)

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -55,13 +55,11 @@ class TestCase(DParentTest):
                                   self.server_list[0])
         vol_list = redant.get_volume_list(self.server_list[0])
         for volname in vol_list:
-            print(volname)
-            print(vol_list.index(volname))
             # if vol_list.index(volname) == 2:
             #     redant.execute_abstract_op_node("reboot",
             #                                     self.server_list[2])
-            # redant.volume_start(volname,
-            #                     self.server_list[0])
+            redant.volume_start(volname,
+                                self.server_list[0])
 
         for _ in range(10):
             sleep(1)
@@ -75,8 +73,6 @@ class TestCase(DParentTest):
         for server in self.server_list:
             ret = redant.execute_abstract_op_node("pgrep glusterfsd",
                                                   server)
-            print("\n\n", ret['msg'])
-            # out = ret['msg'].split()
-            # self.assertFalse(ret, "Failed to get 'glusterfsd' pid")
-            # self.assertEqual(
-            #     len(out), 1, "More then 1 brick process  seen in glusterfsd")
+            out = ret['msg']
+            if len(out) != 1:
+                raise Exception("More then 1 brick process seen in glusterfsd")

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -1,91 +1,82 @@
-#  Copyright (C) 2021 Red Hat, Inc. <http://www.redhat.com>
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+ Copyright (C) 2021 Red Hat, Inc. <http://www.redhat.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ Description:
+ [Brick-mux] Observing multiple brick processes on node reboot with
+ volume start
+"""
+# disruptive;
 
 from time import sleep
-from glusto.core import Glusto as g
-from glustolibs.gluster.exceptions import ExecutionError
-from glustolibs.gluster.gluster_base_class import GlusterBaseClass
-from glustolibs.gluster.volume_libs import bulk_volume_creation, cleanup_volume
-from glustolibs.gluster.volume_ops import (set_volume_options, get_volume_list,
-                                           volume_start)
-from glustolibs.misc.misc_libs import are_nodes_online
+from tests.d_parent_test import DParentTest
 
 
-class TestBrickMuxProcessWhileNodeReboot(GlusterBaseClass):
-    """ Description:
-        [Brick-mux] Observing multiple brick processes on node reboot with
-        volume start
-    """
-    def test_brickmux_brick_process(self):
+class TestCase(DParentTest):
+
+    def run_test(self, redant):
         """
         1. Create a 3 node cluster.
         2. Set cluster.brick-multiplex to enable.
         3. Create 15 volumes of type replica 1x3.
         4. Start all the volumes one by one.
         5. While the volumes are starting reboot one node.
-        6. check for pifof glusterfsd single process should be visible
+        6. check for pidof glusterfsd single process should be visible
         """
-        volume_config = {
-            'name': 'test',
-            'servers': self.all_servers[:3],
-            'voltype': {'type': 'replicated',
-                        'replica_count': 3,
-                        'transport': 'tcp'}}
 
-        servers = self.all_servers[:3]
+        redant.delete_cluster(self.server_list)
+
+        redant.create_cluster(self.server_list[:3])
+        conf_dict = self.vol_type_inf[self.conv_dict["rep"]]
+        volname = f"{self.test_name}"
         # Volume Creation
-        ret = bulk_volume_creation(
-            self.mnode, 14, self.all_servers_info, volume_config,
-            is_create_only=True)
-        self.assertTrue(ret, "Volume creation Failed")
-        ret = set_volume_options(self.mnode, 'all',
-                                 {'cluster.brick-multiplex': 'enable'})
-        self.assertTrue(ret)
-        vol_list = get_volume_list(self.mnode)
+        ret = redant.bulk_volume_creation(self.server_list[0], 3,
+                                          volname, conf_dict,
+                                          self.server_list[:3],
+                                          self.brick_roots,
+                                          create_only=True)
+        if not ret:
+            raise Exception("Failed to create volumes")
+        redant.set_volume_options('all',
+                                  {'cluster.brick-multiplex': 'enable'},
+                                  self.server_list[0])
+        vol_list = redant.get_volume_list(self.server_list[0])
         for volname in vol_list:
-            if vol_list.index(volname) == 2:
-                g.run(servers[2], "reboot")
-            ret, out, _ = volume_start(self.mnode, volname)
-            self.assertFalse(
-                ret, "Failed to start volume '{}'".format(volname))
+            print(volname)
+            print(vol_list.index(volname))
+            # if vol_list.index(volname) == 2:
+            #     redant.execute_abstract_op_node("reboot",
+            #                                     self.server_list[2])
+            # redant.volume_start(volname,
+            #                     self.server_list[0])
 
         for _ in range(10):
             sleep(1)
-            _, node_result = are_nodes_online(servers[2])
-            self.assertTrue(node_result, "Node is not Online")
+            ret = redant.are_nodes_online(self.server_list[2])
+            if ret:
+                break
 
-        for server in servers:
-            ret, out, _ = g.run(server, "pgrep glusterfsd")
-            out = out.split()
-            self.assertFalse(ret, "Failed to get 'glusterfsd' pid")
-            self.assertEqual(
-                len(out), 1, "More then 1 brick process  seen in glusterfsd")
+        if not ret:
+            raise Exception("Node is not online")
 
-    def tearDown(self):
-        """
-        Cleanup and umount volume
-        """
-        # Cleanup and umount volume
-        for vol in get_volume_list(self.mnode):
-            ret = cleanup_volume(self.mnode, vol)
-            if not ret:
-                raise ExecutionError("Failed to  Cleanup Volume")
-            ret = set_volume_options(self.mnode, 'all',
-                                     {'cluster.brick-multiplex': 'disable'})
-            if not ret:
-                raise ExecutionError("Failed to set volume option")
-            # Calling GlusterBaseClass teardown
-            self.get_super_method(self, 'tearDown')()
+        for server in self.server_list:
+            ret = redant.execute_abstract_op_node("pgrep glusterfsd",
+                                                  server)
+            print("\n\n", ret['msg'])
+            # out = ret['msg'].split()
+            # self.assertFalse(ret, "Failed to get 'glusterfsd' pid")
+            # self.assertEqual(
+            #     len(out), 1, "More then 1 brick process  seen in glusterfsd")

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -55,11 +55,13 @@ class TestCase(DParentTest):
                                   self.server_list[0])
         vol_list = redant.get_volume_list(self.server_list[0])
         for volname in vol_list:
-            # if vol_list.index(volname) == 2:
-            #     redant.execute_abstract_op_node("reboot",
-            #                                     self.server_list[2])
-            redant.volume_start(volname,
-                                self.server_list[0])
+            if vol_list.index(volname) == 2:
+                redant.execute_abstract_op_node("reboot",
+                                                self.server_list[2])
+            ret = redant.volume_start(volname,
+                                      self.server_list[0],
+                                      excep=False)
+            print(ret,"\n\n")
 
         for _ in range(10):
             sleep(1)

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -1,0 +1,91 @@
+#  Copyright (C) 2021 Red Hat, Inc. <http://www.redhat.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from time import sleep
+from glusto.core import Glusto as g
+from glustolibs.gluster.exceptions import ExecutionError
+from glustolibs.gluster.gluster_base_class import GlusterBaseClass
+from glustolibs.gluster.volume_libs import bulk_volume_creation, cleanup_volume
+from glustolibs.gluster.volume_ops import (set_volume_options, get_volume_list,
+                                           volume_start)
+from glustolibs.misc.misc_libs import are_nodes_online
+
+
+class TestBrickMuxProcessWhileNodeReboot(GlusterBaseClass):
+    """ Description:
+        [Brick-mux] Observing multiple brick processes on node reboot with
+        volume start
+    """
+    def test_brickmux_brick_process(self):
+        """
+        1. Create a 3 node cluster.
+        2. Set cluster.brick-multiplex to enable.
+        3. Create 15 volumes of type replica 1x3.
+        4. Start all the volumes one by one.
+        5. While the volumes are starting reboot one node.
+        6. check for pifof glusterfsd single process should be visible
+        """
+        volume_config = {
+            'name': 'test',
+            'servers': self.all_servers[:3],
+            'voltype': {'type': 'replicated',
+                        'replica_count': 3,
+                        'transport': 'tcp'}}
+
+        servers = self.all_servers[:3]
+        # Volume Creation
+        ret = bulk_volume_creation(
+            self.mnode, 14, self.all_servers_info, volume_config,
+            is_create_only=True)
+        self.assertTrue(ret, "Volume creation Failed")
+        ret = set_volume_options(self.mnode, 'all',
+                                 {'cluster.brick-multiplex': 'enable'})
+        self.assertTrue(ret)
+        vol_list = get_volume_list(self.mnode)
+        for volname in vol_list:
+            if vol_list.index(volname) == 2:
+                g.run(servers[2], "reboot")
+            ret, out, _ = volume_start(self.mnode, volname)
+            self.assertFalse(
+                ret, "Failed to start volume '{}'".format(volname))
+
+        for _ in range(10):
+            sleep(1)
+            _, node_result = are_nodes_online(servers[2])
+            self.assertTrue(node_result, "Node is not Online")
+
+        for server in servers:
+            ret, out, _ = g.run(server, "pgrep glusterfsd")
+            out = out.split()
+            self.assertFalse(ret, "Failed to get 'glusterfsd' pid")
+            self.assertEqual(
+                len(out), 1, "More then 1 brick process  seen in glusterfsd")
+
+    def tearDown(self):
+        """
+        Cleanup and umount volume
+        """
+        # Cleanup and umount volume
+        for vol in get_volume_list(self.mnode):
+            ret = cleanup_volume(self.mnode, vol)
+            if not ret:
+                raise ExecutionError("Failed to  Cleanup Volume")
+            ret = set_volume_options(self.mnode, 'all',
+                                     {'cluster.brick-multiplex': 'disable'})
+            if not ret:
+                raise ExecutionError("Failed to set volume option")
+            # Calling GlusterBaseClass teardown
+            self.get_super_method(self, 'tearDown')()


### PR DESCRIPTION

Migrated the [test
case](https://github.com/gluster/glusto-tests/blob/HEAD/tests/functional/glusterd/test_brickmux_brick_process.py)

Added are_nodes_online.

Fixes: #685

Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>