### PR TITLE
[Common] Fix bulk volume create

### DIFF
--- a/common/ops/gluster_ops/volume_ops.py
+++ b/common/ops/gluster_ops/volume_ops.py
@@ -62,8 +62,8 @@ class VolumeOps(AbstractOps):
         if create_only:
             return ret
 
-        # Allow sleep before volume start
-        sleep(2)
+        if not excep and ret['error_code'] != 0:
+            return ret
 
         # Start volume
         ret = self.volume_start(volname, node, excep)
@@ -1072,7 +1072,8 @@ class VolumeOps(AbstractOps):
                              server_list: list, brick_roots: dict,
                              vol_prefix="mult_vol_",
                              force: bool = False,
-                             create_only: bool = False):
+                             create_only: bool = False,
+                             excep: bool = True):
         """
         Creates the number of volumes user has specified.
 
@@ -1091,6 +1092,8 @@ class VolumeOps(AbstractOps):
                             False, will do volume create, start, set operation
                             if any provided in the volume_config.
                             By default, value is set to False.
+        excep (bool): True. Flag to indicate whether the exception handling
+                      will kick in the abstract ops or will it be disabled.
 
         Returns: (bool)
         True if all the volumes were created, false otherwise.
@@ -1104,8 +1107,8 @@ class VolumeOps(AbstractOps):
             ret = self.setup_volume(bulkvolname, node,
                                     conf_hash, server_list,
                                     brick_roots, force,
-                                    create_only, False)
-            if ret['error_code'] != 0:
+                                    create_only, excep)
+            if not excep and ret['error_code'] != 0:
                 self.logger.error("Volume creation failed for the"
                                   f" volume {volname}")
                 return False

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -46,7 +46,7 @@ class TestCase(DParentTest):
                                           volname, conf_dict,
                                           self.server_list[:3],
                                           self.brick_roots,
-                                          create_only=True)
+                                          create_only=True, excep=False)
         if not ret:
             raise Exception("Failed to create volumes")
         redant.set_volume_options('all',

--- a/tests/functional/glusterd/test_glusterd_memory_consumption_increase.py
+++ b/tests/functional/glusterd/test_glusterd_memory_consumption_increase.py
@@ -30,10 +30,10 @@ class TestCase(DParentTest):
         # Create and start 100 volumes in a loop
         volname = f"{self.test_name}{index}"
         conf_dict = self.vol_type_inf[self.conv_dict['dist-rep']]
-        ret = self.redant.bulk_volume_creation(self.server_list[0], 100,
-                                               volname, conf_dict,
-                                               self.server_list,
-                                               self.brick_roots)
+        self.redant.bulk_volume_creation(self.server_list[0], 100,
+                                         volname, conf_dict,
+                                         self.server_list,
+                                         self.brick_roots)
 
         # Stop 100 volumes in loop
         for i in range(100):

--- a/tests/functional/glusterd/test_glusterd_memory_consumption_increase.py
+++ b/tests/functional/glusterd/test_glusterd_memory_consumption_increase.py
@@ -35,9 +35,6 @@ class TestCase(DParentTest):
                                                self.server_list,
                                                self.brick_roots)
 
-        if not ret:
-            raise Exception("Failed to create volumes")
-
         # Stop 100 volumes in loop
         for i in range(100):
             volname = f"mult_vol_{self.test_name}{index}{i}"


### PR DESCRIPTION
The excep flag should not be hardcoded. It should be
left to the user to pass the excep flag to the
bulk_vol_create function so as to be used further
in setup_volume.

Fixes: #711
Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
