### PR TITLE
[Core][Test] Removal of conv_dict

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -21,32 +21,32 @@ clients_info:
 #volume_types - Indivudual volume type information and minimum servers for
 #               each volume type
 volume_types:
-    distributed:
+    dist:
         dist_count: 4
         replica_count: 1
         transport: tcp
-    replicated:
+    rep:
         dist_count: 1
         replica_count: 3
         transport: tcp
-    distributed-replicated:
+    dist-rep:
         dist_count: 2
         replica_count: 3
         transport: tcp
-    dispersed:
+    disp:
         disperse_count: 3
         redundancy_count: 1
         transport: tcp
-    distributed-dispersed:
+    dist-disp:
         dist_count: 2
         disperse_count: 3
         redundancy_count: 1
         transport: tcp
-    arbiter:
+    arb:
         replica_count: 2
         arbiter_count: 1
         transport: tcp
-    distributed-arbiter:
+    dist-arb:
         dist_count: 2
         replica_count: 2
         arbiter_count: 1

--- a/core/parsing/params_handler.py
+++ b/core/parsing/params_handler.py
@@ -91,36 +91,36 @@ class ParamsHandler:
                                 }
                }
                volume_types: {
-                                "distributed": {
+                                "dist": {
                                     "dist_count": "4"
                                     "transport": "tcp"
                                 }
-                                "replicated": {
+                                "rep": {
                                     "replica_count": "3"
                                     "transport": "tcp"
                                 }
-                                "distributed-replicated": {
+                                "dist-rep": {
                                     "dist_count": "2"
                                     "replica_count": "3"
                                     "transport": "tcp"
                                 }
-                                "dispersed": {
+                                "disp": {
                                     "disperse_count": "6"
                                     "redundancy_count": "2"
                                     "transport": "tcp"
                                 }
-                                "distributed-dispersed": {
+                                "dist-disp": {
                                     "dist_count": "2"
                                     "disperse_count": "6"
                                     "redundancy_count": "2"
                                     "transport": "tcp"
                                 }
-                                "arbiter": {
+                                "arb": {
                                     "replica_count": "3"
                                     "arbiter_count": "1"
                                     "transport": "tcp"
                                 }
-                                "distributed-arbiter": {
+                                "dist-arb": {
                                     "dist_count": "2"
                                     "replica_count": "3"
                                     "arbiter_count": "1"
@@ -130,7 +130,6 @@ class ParamsHandler:
 
             }
         """
-
         return self.config_hashmap
 
     def get_brick_root_list(self, server_ip: str) -> list:
@@ -166,5 +165,4 @@ class ParamsHandler:
         Returns:
             list : list of exluded tests
         """
-
         return self.config_hashmap.get("excluded_tests", [])

--- a/docs/BP/Ops/volume_ops.md
+++ b/docs/BP/Ops/volume_ops.md
@@ -21,7 +21,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_mount(self.server_list[0], self.vol_name, self.mountpoint, self.client_list[0])
+		```
 
 2) **volume_unmount**<br>
     Unmounts the gluster volume from its client.
@@ -41,7 +43,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_unmount(self.vol_name, self.mountpoint, self.client_list[0])
+		```
 
 3) **volume_create**<br>
     Create the gluster volume with specified configuration
@@ -65,11 +69,13 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_type1 = 'dist'
             volume_name1 = f"{self.test_name}-{volume_type1}-1"
             volume_create(volume_name1, self.server_list[0],
-                          self.vol_type_inf[self.conv_dict[volume_type1]],
+                          self.vol_type_inf[volume_type1],
                           self.server_list, self.brick_roots, True)
+		```
 
 4) **volume_start**<br>
     Starts the gluster volume
@@ -91,7 +97,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_start(self.vol_name,self.server_list[0])
+		```
 
 5) **volume_stop**<br>
     Stops the gluster volume
@@ -112,7 +120,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_stop(self.vol_name, self.server_list[0], True)
+		```
 
 6) **volume_delete**<br>
     Deletes the gluster volume if given volume exists in gluster.
@@ -130,7 +140,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_delete(self.vol_name, self.server_list[0])
+		```
 
 7) **volume_delete_and_brick_cleanup**<br>
     Deletes the gluster volume if given volume exists in gluster.
@@ -148,7 +160,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_delete_and_brick_cleanup(self.vol_name, self.server_list[0])
+		```
 
 8) **get_volume_info**<br>
     Gives volume information.
@@ -159,8 +173,11 @@
         Returns:
             dict: a dictionary with volume information.
         Example:
+			```python
             get_volume_info(server)
-            >>>{'test-vol1': {
+			```
+			```json
+               {'test-vol1': {
                                'id': '6c0053a5-d11c-4ba0-ae5e-f5d5e43a4116',
                                'status': '0',
                                'statusStr': 'Created',
@@ -202,6 +219,7 @@
                                            }
                              }
                }
+			```
 
 9) **get_volume_list**<br>
     Fetches the volume names in the gluster.
@@ -212,8 +230,9 @@
         Returns:
             list: List of volume names
         Example:
+		```python
             get_volume_list(server)
-            >>>['testvol1', 'testvol2']
+		```
 
 10) **volume_reset**<br>
     Resets the gluster volume of all the reconfigured options.
@@ -234,7 +253,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+		```python
             volume_reset(self.vol_name,self.server_list[0])
+		```
 
 11) **get_volume_status**<br>
     Gets the status of all or the specified volume
@@ -256,8 +277,11 @@
             dict: volume status in dict of dictionary format
             None: In case no volumes are present
         Example:
+			```python
             get_volume_status("test-vol1",self.server_list[0])
-            >>>{ 'test-vol1': {
+			```
+			```json
+               { 'test-vol1': {
                                 'nodeCount': '2',
                                 'node': [{
                                            'hostname': 'server-vm1',
@@ -284,6 +308,7 @@
                                 'tasks': None
                               }
                }
+			```
 
 12) **get_volume_options**<br>
      Gets the option values for a given volume.
@@ -299,8 +324,11 @@
             dict: value for the given volume option in dict format, on success
             NoneType: on failure
         Example:
+			```python
             get_volume_options(self.server_list[0])
-            >>>{ 
+			```
+			```json
+               { 
                  'cluster.server-quorum-ratio': '51 (DEFAULT)',
                  'cluster.enable-shared-storage': 'disable (DEFAULT)',
                  'cluster.op-version': '100000',
@@ -312,6 +340,7 @@
                  'cluster.daemon-log-level': 'INFO (DEFAULT)',
                  'cluster.brick-graceful-cleanup': 'disable (DEFAULT)'
                }
+			```
 
 13) **set_volume_options**<br>
      Sets the option values for the given volume.
@@ -322,8 +351,10 @@
         Kwargs:
             node (str): Node on which cmd has to be executed. Default - None
         Example:
+			```python
             options = {"user.cifs":"enable","user.smb":"enable"}
             set_volume_options("test-vol1", options, self.server_list[0])
+			```
 
 14) **validate_volume_option**<br>
      Validate the volume options
@@ -336,8 +367,10 @@
         Returns:
             No value if success or else ValueError will be raised.
         Example:
+			```python
             options = {"user.cifs":"enable","user.smb":"enable"}
             validate_volume_option(sel.vol_name, options)
+			```
             
 
 15) **reset_volume_option**<br>
@@ -353,7 +386,9 @@
                 then reset volume will get executed without force option.
                 Default - False
         Example:
+			```python
             reset_volume_option("test-vol1", "option", server)
+			```
 
         Returns:
             ret: A dictionary consisting
@@ -386,7 +421,9 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
          Example:
+			```python
             volume_sync(hostname,self.server_list[0])
+			```
 
 17) **is_volume_started**<br>
 		Function to check whether a said volume is in started state.
@@ -397,7 +434,9 @@
 		Returns:
 			True if in Started state else False
 		Example:
+			```python
 			self.is_volume_started(self.vol_name, self.server_list[0])
+			```
 
 18) **wait_for_vol_to_go_offline**<br>
 		Function to wait till the said volume goes offline.
@@ -409,7 +448,9 @@
 		Returns:
 			True if it goes offline, else False
 		Example:
+			```python
 			self.wait_for_vol_to_go_offline(self.vol_name, self.server_list[0])
+			```
 
 18) **wait_for_vol_to_come_online**<br>
 		Function to wait till the said volume comes online.
@@ -421,7 +462,9 @@
 		Returns:
 			True if it comes online, else False
 		Example:
+			```python
 			self.wait_for_vol_to_come_online(self.vol_name, self.server_list[0])
+			```
 
 19) **setup_volume**<br>
         Function to setup the gluster volume with the specified configuration.
@@ -452,11 +495,13 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+			```python
             self.volume_type1 = 'dist'
             self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-            conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+            conf_dict = self.vol_type_inf[self.volume_type1]
             conf_dict['dist_count'] = 1
             redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,[self.server_list[0]], self.brick_roots, True)
+			```
 
 20) **volume_create_with_custom_bricks**<br>
         This function helps in creating a gluster volume with custom brick configuration.
@@ -485,9 +530,10 @@
                 - cmd : command that got executed
                 - node : node on which the command got executed
         Example:
+			```python
             self.volume_type1 = 'dist'
             self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-            conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+            conf_dict = self.vol_type_inf[self.volume_type1]
             brick_dict, brick_cmd = redant.form_brick_cmd(self.server_list,
                                                         self.brick_roots,
                                                         self.volume_name1, 4)
@@ -495,6 +541,7 @@
                                                     self.server_list[0],
                                                     conf_dict, brick_cmd,
                                                     brick_dict)
+			```
             
 21) **sanitize_volume**<br>
         This function helps in getting the volume ready for the next test case to be used. Generally, non-disruptive tests will require this function but even some strange scenario can be dealt with this in a test case.
@@ -508,10 +555,12 @@
             5. vol_param (dict) : Raw recipe for creating volume
 
         Example:
-                vol_param = self.vol_type_inf[self.conv_dict[self.volume_type]]
+			```python
+                vol_param = self.vol_type_inf[self.volume_type]
                 self.redant.sanitize_volume(self.vol_name, self.server_list,
                                             self.client_list, self.brick_roots,
                                             vol_param)
+			```
 
 22) **cleanup_volume**<br>
         This function comes handy in cleanup operations. Basically, it deletes the volume and its mountpoints.
@@ -521,7 +570,9 @@
             2. node (str) : Node on which the commands are run.
 
         Example:
+			```python
             self.redant.cleanup_volume(self.volume_name1, self.server_list[0])
+			```
 
  23) **is_distribute_volume**<br>
         This function checks if a volume is a plain distributed volume.
@@ -533,7 +584,9 @@
             NoneType: None if volume does not exist.
         
         Example:
+			```python
             self.is_distribute_volume(volname)
+			```
 
 24) **wait_for_volume_process_to_be_online**<br>
         This function waits for the volume's processes to be online until timeout
@@ -552,8 +605,10 @@
                   False otherwise
         
         Example:
+			```python
             self.redant.wait_for_volume_process_to_be_online(self.vol_name,
                self.server_list[0], self.server_list, timeout=600)
+			```
 
 25) **get_subvols**<br>
         This function helps in getting the subvolumes in the given volume.
@@ -568,4 +623,6 @@
                   to that subvol in node:brick_path format.
 
         Example:
+			```python
             ret = redant.get_subvols(self.vol_name, self.server_list[0])
+			```

--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -13,16 +13,6 @@ class DParentTest(metaclass=abc.ABCMeta):
 
     """
 
-    conv_dict = {
-        "dist": "distributed",
-        "rep": "replicated",
-        "dist-rep": "distributed-replicated",
-                    "disp": "dispersed",
-                    "dist-disp": "distributed-dispersed",
-                    "arb": "arbiter",
-                    "dist-arb": "distributed-arbiter"
-    }
-
     def __init__(self, mname: str, param_obj, volume_type: str,
                  env_obj, log_path: str, log_level: str = 'I'):
         """
@@ -76,7 +66,7 @@ class DParentTest(metaclass=abc.ABCMeta):
             if not self.setup_done and self.volume_type != "Generic":
                 self.redant.volume_create(
                     self.vol_name, self.server_list[0],
-                    self.vol_type_inf[self.conv_dict[self.volume_type]],
+                    self.vol_type_inf[self.volume_type],
                     self.server_list, self.brick_roots, True)
                 self.redant.volume_start(self.vol_name, self.server_list[0])
                 self.mountpoint = (f"/mnt/{self.vol_name}")

--- a/tests/example/sample_component/test_vol_ops.py
+++ b/tests/example/sample_component/test_vol_ops.py
@@ -21,7 +21,7 @@ class TestCase(NdParentTest):
         ret = redant.get_subvols(self.vol_name, self.server_list[0])
         redant.logger.info(f"{self.volume_type} : {ret}")
         volname = f"{self.test_name}"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_dict = self.vol_type_inf[self.volume_type]
         ret = redant.bulk_volume_creation(self.server_list[0], 5,
                                           volname, conf_dict,
                                           self.server_list,

--- a/tests/functional/glusterd/test_add_brick.py
+++ b/tests/functional/glusterd/test_add_brick.py
@@ -37,7 +37,7 @@ class TestCase(DParentTest):
            part of the cluster.
         """
         # form bricks list to test add brick functionality
-        rep_count = self.vol_type_inf[self.conv_dict['rep']]
+        rep_count = self.vol_type_inf['rep']
         rep_count = rep_count['replica_count']
         num_of_bricks = 4 * rep_count
 

--- a/tests/functional/glusterd/test_add_identical_brick_new_node.py
+++ b/tests/functional/glusterd/test_add_identical_brick_new_node.py
@@ -41,7 +41,7 @@ class TestCase(DParentTest):
         # Create a distributed volume on Node1
         self.volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         conf_dict['dist_count'] = 1
         redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,
                             [self.server_list[0]], self.brick_roots, True)

--- a/tests/functional/glusterd/test_brickmux_brick_process.py
+++ b/tests/functional/glusterd/test_brickmux_brick_process.py
@@ -39,7 +39,7 @@ class TestCase(DParentTest):
         redant.delete_cluster(self.server_list)
 
         redant.create_cluster(self.server_list[:3])
-        conf_dict = self.vol_type_inf[self.conv_dict["rep"]]
+        conf_dict = self.vol_type_inf["rep"]
         volname = f"{self.test_name}"
         # Volume Creation
         ret = redant.bulk_volume_creation(self.server_list[0], 3,

--- a/tests/functional/glusterd/test_bricks_online_after_node_reboot.py
+++ b/tests/functional/glusterd/test_bricks_online_after_node_reboot.py
@@ -67,7 +67,7 @@ class TestCase(DParentTest):
         for iteration, volume in enumerate(all_volumes):
             volname = f"{self.test_name}-{volume}-{iteration}"
             self.volume_names.append(volname)
-            conf_dict = self.vol_type_inf[self.conv_dict[volume]]
+            conf_dict = self.vol_type_inf[volume]
             redant.setup_volume(volname, self.server_list[0],
                                 conf_dict, self.server_list,
                                 self.brick_roots, True)

--- a/tests/functional/glusterd/test_change_reserve_limit.py
+++ b/tests/functional/glusterd/test_change_reserve_limit.py
@@ -113,7 +113,7 @@ class TestChangeReservcelimit(NdParentTest):
         # volume creation for setting reserve limit to higher value.
         self.volume_type1 = 'dist-rep'
         self.volume_name1 = f"{self.test_name}-1"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         redant.setup_volume(self.volume_name1, self.server_list[0],
                             conf_dict, self.server_list,
                             self.brick_roots, True)

--- a/tests/functional/glusterd/test_concurrent_set.py
+++ b/tests/functional/glusterd/test_concurrent_set.py
@@ -54,7 +54,7 @@ class TestCase(NdParentTest):
         volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{volume_type1}-1"
         redant.volume_create(self.volume_name1, self.server_list[0],
-                             self.vol_type_inf[self.conv_dict[volume_type1]],
+                             self.vol_type_inf[volume_type1],
                              self.server_list, self.brick_roots, True)
 
         cmd1 = ("for i in `seq 1 100`; do gluster volume set "

--- a/tests/functional/glusterd/test_create_vol_with_used_bricks.py
+++ b/tests/functional/glusterd/test_create_vol_with_used_bricks.py
@@ -61,7 +61,7 @@ class TestCase(NdParentTest):
             raise Exception("This test case requires at least 3 servers")
         self.volume_type1 = 'dist-rep'
         self.volume_name1 = "test_create_vol_with_fresh_bricks"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         redant.setup_volume(self.volume_name1, self.server_list[0],
                             conf_dict, self.server_list,
                             self.brick_roots)

--- a/tests/functional/glusterd/test_enable_brickmux_create_and_stop_three_volumes.py
+++ b/tests/functional/glusterd/test_enable_brickmux_create_and_stop_three_volumes.py
@@ -50,7 +50,7 @@ class TestCase(DParentTest):
         # Create and start 3 volume
         for number in range(1, 4):
             self.volname = f"test_volume_{number}"
-            conf_dict = self.vol_type_inf[self.conv_dict["rep"]]
+            conf_dict = self.vol_type_inf["rep"]
             redant.setup_volume(self.volname,
                                 self.server_list[0],
                                 conf_dict, self.server_list,

--- a/tests/functional/glusterd/test_get_state_on_brick_unmount.py
+++ b/tests/functional/glusterd/test_get_state_on_brick_unmount.py
@@ -32,7 +32,7 @@ class TestCase(DParentTest):
         Override the volume create, start and mount in parent_run_test
         """
         self.setup_done = True
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_dict = self.vol_type_inf[self.volume_type]
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_dict, self.server_list,
                                  self.brick_roots, False, True)
@@ -88,7 +88,7 @@ class TestCase(DParentTest):
         # Create another volume
         self.volume_name1 = 'second_volume'
         self.volume_type1 = 'dist'
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
 
         redant.setup_volume(self.volume_name1, self.server_list[0],
                             conf_dict, node_list,

--- a/tests/functional/glusterd/test_gluster_volume_status_xml_dump.py
+++ b/tests/functional/glusterd/test_gluster_volume_status_xml_dump.py
@@ -53,12 +53,12 @@ class TestCase(NdParentTest):
         volume_type = 'dist-arb'
         self.volume_name = f"{self.test_name}-{volume_type}-1"
         redant.setup_volume(self.volume_name, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict[volume_type]],
+                            self.vol_type_inf[volume_type],
                             self.server_list, self.brick_roots, True)
         volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{volume_type1}-1"
         redant.setup_volume(self.volume_name1, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict[volume_type1]],
+                            self.vol_type_inf[volume_type1],
                             self.server_list, self.brick_roots, True)
         redant.volume_stop(self.volume_name, self.server_list[0], force=True)
         sleep(2)

--- a/tests/functional/glusterd/test_glusterd_memory_consumption_increase.py
+++ b/tests/functional/glusterd/test_glusterd_memory_consumption_increase.py
@@ -29,7 +29,7 @@ class TestCase(DParentTest):
         """ Create, start, stop and delete 100 volumes in a loop """
         # Create and start 100 volumes in a loop
         volname = f"{self.test_name}{index}"
-        conf_dict = self.vol_type_inf[self.conv_dict['dist-rep']]
+        conf_dict = self.vol_type_inf['dist-rep']
         self.redant.bulk_volume_creation(self.server_list[0], 100,
                                          volname, conf_dict,
                                          self.server_list,

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -78,7 +78,7 @@ class TestCase(DParentTest):
                                          self.server_list[0])
 
         # Create a volume using the first 3 nodes
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_dict = self.vol_type_inf[self.volume_type]
         redant.setup_volume(self.vol_name, self.server_list[0],
                             conf_dict, self.server_list[:3],
                             self.brick_roots)
@@ -86,7 +86,7 @@ class TestCase(DParentTest):
         # Creating another volume and stopping it
         self.volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-1"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         redant.setup_volume(self.volume_name1, self.server_list[0],
                             conf_dict, self.server_list[:3],
                             self.brick_roots)

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -33,7 +33,7 @@ class TestCase(DParentTest):
         Override the volume create, start and mount in parent_run_test
         """
         self.setup_done = True
-        conf_hash = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_hash = self.vol_type_inf[self.volume_type]
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,
                                  self.brick_roots)

--- a/tests/functional/glusterd/test_peer_detach.py
+++ b/tests/functional/glusterd/test_peer_detach.py
@@ -101,7 +101,7 @@ class TestCase(DParentTest):
         volume_type = 'dist'
         self.volume_name = f"{self.test_name}-{volume_type}-1"
         redant.setup_volume(self.volume_name, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict[volume_type]],
+                            self.vol_type_inf[volume_type],
                             self.server_list, self.brick_roots)
 
         # Peer detach one node which contains the bricks of the volume created

--- a/tests/functional/glusterd/test_peer_probe.py
+++ b/tests/functional/glusterd/test_peer_probe.py
@@ -51,8 +51,8 @@ class TestCase(DParentTest):
         # Create a distributed volume on Node1
         volume_type1 = 'dist'
         volume_name1 = f"{self.test_name}-{volume_type1}-1"
-        self.vol_type_inf[self.conv_dict[volume_type1]]['dist-count'] = 1
-        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type1]]
+        self.vol_type_inf[volume_type1]['dist-count'] = 1
+        vol_params_dict = self.vol_type_inf[volume_type1]
         ret = redant.volume_create(volume_name1, self.server_list[0],
                                    vol_params_dict, self.server_list[0],
                                    self.brick_roots, True)
@@ -60,8 +60,8 @@ class TestCase(DParentTest):
         # Create a replicate volume on Node2 without force should fail
         volume_type2 = 'rep'
         volume_name2 = f"{self.test_name}-{volume_type2}-2"
-        self.vol_type_inf[self.conv_dict[volume_type2]]['replica_count'] = 2
-        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type2]]
+        self.vol_type_inf[volume_type2]['replica_count'] = 2
+        vol_params_dict = self.vol_type_inf[volume_type2]
         ret = redant.volume_create(volume_name2, self.server_list[1],
                                    vol_params_dict, self.server_list[1],
                                    self.brick_roots, excep=False)
@@ -73,8 +73,8 @@ class TestCase(DParentTest):
         # Create a replica volume on Node2 with force should succeed
         volume_type3 = 'rep'
         volume_name3 = f"{self.test_name}-{volume_type3}-3"
-        self.vol_type_inf[self.conv_dict[volume_type3]]['replica-count'] = 3
-        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type3]]
+        self.vol_type_inf[volume_type3]['replica-count'] = 3
+        vol_params_dict = self.vol_type_inf[volume_type3]
         ret = redant.volume_create(volume_name3, self.server_list[1],
                                    vol_params_dict, self.server_list[1],
                                    self.brick_roots, True)
@@ -119,8 +119,8 @@ class TestCase(DParentTest):
         # Create a replica volume on N1 and N2 with force
         volume_type4 = 'rep'
         volume_name4 = f"{self.test_name}-{volume_type4}-4"
-        self.vol_type_inf[self.conv_dict[volume_type4]]['replica-count'] = 2
-        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type4]]
+        self.vol_type_inf[volume_type4]['replica-count'] = 2
+        vol_params_dict = self.vol_type_inf[volume_type4]
         ret = redant.volume_create(volume_name4, self.server_list[0],
                                    vol_params_dict, self.server_list[0:2],
                                    self.brick_roots, True)
@@ -151,8 +151,8 @@ class TestCase(DParentTest):
         # Create a replica volume on N1, N2 and N3 with force
         volume_type5 = 'rep'
         volume_name5 = f"{self.test_name}-{volume_type5}-5"
-        self.vol_type_inf[self.conv_dict[volume_type5]]['replica-count'] = 3
-        vol_params_dict = self.vol_type_inf[self.conv_dict[volume_type5]]
+        self.vol_type_inf[volume_type5]['replica-count'] = 3
+        vol_params_dict = self.vol_type_inf[volume_type5]
         ret = redant.volume_create(volume_name5, self.server_list[0],
                                    vol_params_dict, self.server_list,
                                    self.brick_roots, True)

--- a/tests/functional/glusterd/test_peer_status.py
+++ b/tests/functional/glusterd/test_peer_status.py
@@ -73,9 +73,9 @@ class TestPeerStatus(DParentTest):
                             f"{self.server_list[1]}")
 
         # create a distributed volume with 2 bricks
-        self.vol_type_inf[self.conv_dict['dist']]['dist_count'] = 2
+        self.vol_type_inf['dist']['dist_count'] = 2
         redant.setup_volume(self.vol_name, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict['dist']],
+                            self.vol_type_inf['dist'],
                             self.server_list[0:2], self.brick_roots,
                             True)
 

--- a/tests/functional/glusterd/test_probe_hostname.py
+++ b/tests/functional/glusterd/test_probe_hostname.py
@@ -115,7 +115,7 @@ class TestCase(DParentTest):
 
         # Create a volume
         redant.volume_create("test-vol", self.server_list[0],
-                             self.vol_type_inf[self.conv_dict['dist']],
+                             self.vol_type_inf['dist'],
                              self.server_list, self.brick_roots, True)
 
         redant.logger.info("Volume: test-vol created successfully")

--- a/tests/functional/glusterd/test_profile_operations.py
+++ b/tests/functional/glusterd/test_profile_operations.py
@@ -125,7 +125,7 @@ class TestCase(DParentTest):
         volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{volume_type1}-1"
         redant.setup_volume(self.volume_name1, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict[volume_type1]],
+                            self.vol_type_inf[volume_type1],
                             self.server_list, self.brick_roots)
 
         # Stop volume

--- a/tests/functional/glusterd/test_profile_simultaneously_on_different_nodes.py
+++ b/tests/functional/glusterd/test_profile_simultaneously_on_different_nodes.py
@@ -92,7 +92,7 @@ class TestCase(DParentTest):
         volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{volume_type1}-1"
         redant.setup_volume(self.volume_name1, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict[volume_type1]],
+                            self.vol_type_inf[volume_type1],
                             self.server_list, self.brick_roots)
 
         # Start profile on volume.

--- a/tests/functional/glusterd/test_quorum_syslog.py
+++ b/tests/functional/glusterd/test_quorum_syslog.py
@@ -81,7 +81,7 @@ class TestCase(DParentTest):
         volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{volume_type1}-1"
         redant.setup_volume(self.volume_name1, self.server_list[0],
-                            self.vol_type_inf[self.conv_dict[volume_type1]],
+                            self.vol_type_inf[volume_type1],
                             self.server_list, self.brick_roots)
 
         # Enabling server quorum all volumes

--- a/tests/functional/glusterd/test_rebalance_hang.py
+++ b/tests/functional/glusterd/test_rebalance_hang.py
@@ -66,8 +66,8 @@ class TestCase(DParentTest):
         redant.create_cluster(self.server_list[:2])
         redant.wait_till_all_peers_connected(self.server_list[:2])
 
-        self.vol_type_inf[self.conv_dict['dist']]['dist-count'] = 2
-        vol_params_dict = self.vol_type_inf[self.conv_dict['dist']]
+        self.vol_type_inf['dist']['dist-count'] = 2
+        vol_params_dict = self.vol_type_inf['dist']
         redant.volume_create(self.vol_name, self.server_list[0],
                              vol_params_dict, self.server_list[:2],
                              self.brick_roots, True)

--- a/tests/functional/glusterd/test_rebalance_new_node.py
+++ b/tests/functional/glusterd/test_rebalance_new_node.py
@@ -53,7 +53,7 @@ class TestCase(DParentTest):
         """
         self.volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         redant.setup_volume(self.volume_name1, self.server_list[0], conf_dict,
                             self.server_list[0:2], self.brick_roots, True)
         self.mountpoint = (f"/mnt/{self.volume_name1}")

--- a/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
+++ b/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
@@ -51,7 +51,7 @@ class TestCase(DParentTest):
         # Create Volume
         self.volume_type = "dist-rep"
         self.vol_name = (f"{self.test_name}-{self.volume_type}")
-        conf_hash = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_hash = self.vol_type_inf[self.volume_type]
         redant.volume_create(self.vol_name, self.server_list[0], conf_hash,
                              self.server_list, self.brick_roots)
 

--- a/tests/functional/glusterd/test_reserved_port_range_for_gluster.py
+++ b/tests/functional/glusterd/test_reserved_port_range_for_gluster.py
@@ -78,7 +78,7 @@ class TestCase(DParentTest):
         for i in range(1, 51):
             volname = f"{self.vol_name}-volume-{i}"
             redant.volume_create(volname, self.server_list[0],
-                                 self.vol_type_inf[self.conv_dict['dist']],
+                                 self.vol_type_inf['dist'],
                                  self.server_list, self.brick_roots, True)
 
         # Try to start 50 volumes in loop

--- a/tests/functional/glusterd/test_setting_volume_option_when_one_node_is_down_in_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_option_when_one_node_is_down_in_cluster.py
@@ -40,7 +40,7 @@ class TestCase(DParentTest):
     def run_test(self, redant):
 
         # create a 2x3 volume
-        conf_hash = self.vol_type_inf[self.conv_dict['dist-rep']]
+        conf_hash = self.vol_type_inf['dist-rep']
         redant.setup_volume(self.vol_name, self.server_list[0],
                             conf_hash, self.server_list[:-1],
                             self.brick_roots, False, True)

--- a/tests/functional/glusterd/test_volume_create.py
+++ b/tests/functional/glusterd/test_volume_create.py
@@ -43,7 +43,7 @@ class TestCase(DParentTest):
 
         self.volume_type1 = 'dist'
         self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         brick_dict, brick_cmd = redant.form_brick_cmd(self.server_list,
                                                       self.brick_roots,
                                                       self.volume_name1, 4)
@@ -75,7 +75,7 @@ class TestCase(DParentTest):
         # create volume with previously used bricks and different volume name
         self.volume_type2 = 'dist'
         self.volume_name2 = f"{self.test_name}-{self.volume_type2}-2"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type2]]
+        conf_dict = self.vol_type_inf[self.volume_type2]
         ret = redant.volume_create_with_custom_bricks(self.volume_name2,
                                                       self.server_list[0],
                                                       conf_dict, brick_cmd,
@@ -95,7 +95,7 @@ class TestCase(DParentTest):
         # creating a volume with non existing brick path should fail
         self.volume_type3 = 'dist'
         self.volume_name3 = f"{self.test_name}-{self.volume_type3}-3"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type2]]
+        conf_dict = self.vol_type_inf[self.volume_type2]
         brick_dict, brick_cmd = redant.form_brick_cmd(self.server_list,
                                                       self.brick_roots,
                                                       self.volume_name3, 2)
@@ -155,7 +155,7 @@ class TestCase(DParentTest):
 
         self.volume_type4 = 'dist'
         self.volume_name4 = f"{self.test_name}-{self.volume_type4}-4"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type4]]
+        conf_dict = self.vol_type_inf[self.volume_type4]
         ret = redant.setup_volume(self.volume_name4, self.server_list[0],
                                   conf_dict, self.server_list,
                                   self.brick_roots, excep=False)

--- a/tests/functional/glusterd/test_volume_create_with_glusterd_restarts.py
+++ b/tests/functional/glusterd/test_volume_create_with_glusterd_restarts.py
@@ -94,7 +94,7 @@ class TestCase(DParentTest):
         # Creating volumes using 3 servers
         self.volume_type = "dist"
         self.vol_name = (f"{self.test_name}-{self.volume_type}")
-        conf_hash = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_hash = self.vol_type_inf[self.volume_type]
         redant.volume_create(self.vol_name, self.server_list[0], conf_hash,
                              list_of_three_servers, self.brick_roots)
         # check if process ended

--- a/tests/functional/glusterd/test_volume_operations.py
+++ b/tests/functional/glusterd/test_volume_operations.py
@@ -36,7 +36,7 @@ class TestVolumeCreate(DParentTest):
         Override the volume create, start and mount in parent_run_test
         """
         self.setup_done = True
-        conf_hash = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        conf_hash = self.vol_type_inf[self.volume_type]
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,
                                  self.brick_roots, False, True)

--- a/tests/functional/glusterd/test_volume_status_xml.py
+++ b/tests/functional/glusterd/test_volume_status_xml.py
@@ -44,9 +44,9 @@ class TestCase(DParentTest):
 
         # create a distributed volume with single node
         volume_type = 'dist'
-        self.vol_type_inf[self.conv_dict[volume_type]]['dist_count'] = 1
+        self.vol_type_inf[volume_type]['dist_count'] = 1
         redant.volume_create(self.vol_name, self.server_list[0],
-                             self.vol_type_inf[self.conv_dict[volume_type]],
+                             self.vol_type_inf[volume_type],
                              self.server_list, self.brick_roots, True)
 
         # Get volume status

--- a/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
+++ b/tests/functional/glusterd/test_xml_dump_of_gluster_volume_status_during_rebalance.py
@@ -58,7 +58,7 @@ class TestCase(DParentTest):
 
         self.volume_type1 = 'rep'
         self.volume_name1 = f"{self.test_name}-{self.volume_type1}-1"
-        conf_dict = self.vol_type_inf[self.conv_dict[self.volume_type1]]
+        conf_dict = self.vol_type_inf[self.volume_type1]
         redant.setup_volume(self.volume_name1, self.server_list[0],
                             conf_dict, self.server_list,
                             self.brick_roots, True)

--- a/tests/lazy_parent_test.py
+++ b/tests/lazy_parent_test.py
@@ -13,16 +13,6 @@ class LazyParentTest(metaclass=abc.ABCMeta):
     TEST_RES: states the result of the test case
     """
 
-    conv_dict = {
-        "dist": "distributed",
-        "rep": "replicated",
-        "dist-rep": "distributed-replicated",
-                    "disp": "dispersed",
-                    "dist-disp": "distributed-dispersed",
-                    "arb": "arbiter",
-                    "dist-arb": "distributed-arbiter"
-    }
-
     def __init__(self, mname: str, param_obj, volume_type: str,
                  env_obj, log_path: str, log_level: str = 'I'):
         """

--- a/tests/nd_parent_test.py
+++ b/tests/nd_parent_test.py
@@ -13,16 +13,6 @@ class NdParentTest(metaclass=abc.ABCMeta):
 
     """
 
-    conv_dict = {
-        "dist": "distributed",
-        "rep": "replicated",
-        "dist-rep": "distributed-replicated",
-                    "disp": "dispersed",
-                    "dist-disp": "distributed-dispersed",
-                    "arb": "arbiter",
-                    "dist-arb": "distributed-arbiter"
-    }
-
     def __init__(self, mname: str, param_obj, volume_type: str,
                  env_obj, log_path: str, log_level: str = 'I'):
         """
@@ -99,7 +89,7 @@ class NdParentTest(metaclass=abc.ABCMeta):
         if self.volume_type != "Generic":
             try:
                 # Volume started state.
-                vol_param = self.vol_type_inf[self.conv_dict[self.volume_type]]
+                vol_param = self.vol_type_inf[self.volume_type]
                 self.redant.sanitize_volume(self.vol_name, self.server_list,
                                             self.client_list, self.brick_roots,
                                             vol_param)

--- a/tests/vol_create_test.py
+++ b/tests/vol_create_test.py
@@ -29,7 +29,7 @@ class VolCreate(LazyParentTest):
         This child is responsible for the creation of a volume
         of said type so that tests can use it.
         """
-        vol_param = self.vol_type_inf[self.conv_dict[self.volume_type]]
+        vol_param = self.vol_type_inf[self.volume_type]
         redant.volume_create(self.vol_name, self.server_list[0], vol_param,
                              self.server_list, self.brick_roots, True)
         redant.volume_start(self.vol_name, self.server_list[0])


### PR DESCRIPTION
The patch removes the conv_dict conversion by changing
the config parts. This reduces the confusion with the volume
creation as well extra step of conversion.

Fixes: #699

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
