### PR TITLE
[Core] XLS exception handling

### DIFF
--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -305,9 +305,10 @@ class ResultHandler:
                     each_vol_test['timeTaken'])
                 result_sheet.write(row, 2, time_taken)
                 if each_vol_test['testResult'] is None:
-                    result_sheet.write(row, 3, each_vol_test['skipReason'])
+                    skip_reason = str(each_vol_test['skipReason'])
                 else:
-                    result_sheet.write(row, 3, "NA")
+                    skip_reason = "NA"
+                result_sheet.write(row, 3, skip_reason)
                 row += 1
 
             row += 2


### PR DESCRIPTION
xlsx writter cannot accept a exception as an input
hence converting it into string before pushing the
skip reason.

Fixes: #727

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
