### PR TITLE
Modifying mount command

### DIFF
--- a/common/ops/gluster_ops/mount_ops.py
+++ b/common/ops/gluster_ops/mount_ops.py
@@ -39,7 +39,7 @@ class MountOps(AbstractOps):
 
         """
 
-        cmd = f"mount -t glusterfs {server}:/{volname} {path}"
+        cmd = f"mount.glusterfs {server}:/{volname} {path}"
 
         ret = self.execute_abstract_op_node(cmd, node, excep)
         self.es.add_new_mountpath(volname, node, path)


### PR DESCRIPTION
The mount command is modified
from `mount -t glusterfs` to
`mount.glusterfs` as the mount script
is sometimes not added to path.

### All Submissions:

Desciption:

(If it closes the issue)
Fixes: #676



<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
