### PR TITLE
[Result] Fixing skip count and time output

### DIFF
--- a/core/result_handler.py
+++ b/core/result_handler.py
@@ -54,15 +54,15 @@ class ResultHandler:
         if time_in_sec >= 60:
             seconds = time_in_sec % 60
             time_in_sec -= seconds
-            time_in_min = time_in_sec / 60
+            time_in_min = int(time_in_sec / 60)
             if time_in_min >= 60:
                 minutes = time_in_min % 60
                 time_in_min -= minutes
-                time_in_hour = time_in_min / 60
+                time_in_hour = int(time_in_min / 60)
                 if time_in_hour >= 24:
                     hours = time_in_hour % 24
                     time_in_hour -= hours
-                    days = time_in_hour / 24
+                    days = int(time_in_hour / 24)
                 else:
                     hours = int(time_in_hour)
             else:
@@ -126,6 +126,8 @@ class ResultHandler:
             elif test_results[item][0]['tcNature'] == 'nonDisruptive' and\
                     test_results[item][0]['testResult'] is not None:
                 ndtest += 1
+            else:
+                skipCount += 1
 
             for each_vol_test in test_results[item]:
 
@@ -140,7 +142,6 @@ class ResultHandler:
                         if each_vol_test['testResult'] == 'PASS':
                             ndpass += 1
                 elif each_vol_test['testResult'] is None:
-                    skipCount += 1
                     skip_reason = each_vol_test['skipReason']
 
                 time_taken = cls._time_rollover_conversion(
@@ -233,12 +234,12 @@ class ResultHandler:
             elif test_results[item][0]['tcNature'] == 'nonDisruptive' and\
                     test_results[item][0]['testResult'] is not None:
                 ndtest += 1
+            else:
+                skipCount += 1
 
             for each_vol_test in test_results[item]:
 
-                if each_vol_test['testResult'] is None:
-                    skipCount += 1
-                else:
+                if each_vol_test['testResult'] is not None:
                     if each_vol_test['tcNature'] == 'disruptive':
                         dcount += 1
                         if each_vol_test['testResult'] == 'PASS':


### PR DESCRIPTION
The skip count took into account the total
subtest skips and hence the data outputted
was more than what was expected. This fix
changes how the count is aggregated.

Secondly, the time output was messing up whenever
the minute or hour wasn't an integer. Hence setting
them to int.

Updates: #719

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
