### PR TITLE
[Test] Custom setup invoked with decorator.

### DIFF
--- a/tests/d_parent_test.py
+++ b/tests/d_parent_test.py
@@ -46,6 +46,13 @@ class DParentTest(metaclass=abc.ABCMeta):
     def setup_test(self):
         pass
 
+    @classmethod
+    def setup_custom_enable(cls, fun):
+        def inner(self, *args, **kwargs):
+            self.setup_done = True
+            return fun(self, *args, **kwargs)
+        return inner
+
     @abc.abstractmethod
     def run_test(self, redant):
         pass

--- a/tests/functional/glusterd/test_get_state_on_brick_unmount.py
+++ b/tests/functional/glusterd/test_get_state_on_brick_unmount.py
@@ -27,11 +27,11 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
         conf_dict = self.vol_type_inf[self.volume_type]
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_dict, self.server_list,

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -27,11 +27,12 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
+        pass
 
     def terminate(self):
         """

--- a/tests/functional/glusterd/test_glusterd_quorum.py
+++ b/tests/functional/glusterd/test_glusterd_quorum.py
@@ -32,7 +32,6 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        pass
 
     def terminate(self):
         """

--- a/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
+++ b/tests/functional/glusterd/test_mount_after_removing_client_logs_dir.py
@@ -28,11 +28,11 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
         conf_hash = self.vol_type_inf[self.volume_type]
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,

--- a/tests/functional/glusterd/test_peer_probe_firewall_ports_not_opened.py
+++ b/tests/functional/glusterd/test_peer_probe_firewall_ports_not_opened.py
@@ -28,11 +28,11 @@ from tests.d_parent_test import DParentTest
 
 class TestPeerProbeWithFirewallNotOpened(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
         self.redant.delete_cluster(self.server_list)
 
     def terminate(self):

--- a/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
+++ b/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
@@ -27,11 +27,12 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
+        pass
 
     def run_test(self, redant):
         '''

--- a/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
+++ b/tests/functional/glusterd/test_replace_brick_quorum_not_met.py
@@ -32,7 +32,6 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        pass
 
     def run_test(self, redant):
         '''

--- a/tests/functional/glusterd/test_setting_volume_option_when_one_node_is_down_in_cluster.py
+++ b/tests/functional/glusterd/test_setting_volume_option_when_one_node_is_down_in_cluster.py
@@ -29,11 +29,11 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
         last_node = self.server_list[len(self.server_list)-1]
         self.redant.peer_detach(last_node, self.server_list[0])
 

--- a/tests/functional/glusterd/test_volume_create_with_glusterd_restarts.py
+++ b/tests/functional/glusterd/test_volume_create_with_glusterd_restarts.py
@@ -33,7 +33,6 @@ class TestCase(DParentTest):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        pass
 
     def terminate(self):
         """

--- a/tests/functional/glusterd/test_volume_create_with_glusterd_restarts.py
+++ b/tests/functional/glusterd/test_volume_create_with_glusterd_restarts.py
@@ -28,11 +28,12 @@ from tests.d_parent_test import DParentTest
 
 class TestCase(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
+        pass
 
     def terminate(self):
         """

--- a/tests/functional/glusterd/test_volume_operations.py
+++ b/tests/functional/glusterd/test_volume_operations.py
@@ -31,11 +31,11 @@ from tests.d_parent_test import DParentTest
 
 class TestVolumeCreate(DParentTest):
 
+    @DParentTest.setup_custom_enable
     def setup_test(self):
         """
         Override the volume create, start and mount in parent_run_test
         """
-        self.setup_done = True
         conf_hash = self.vol_type_inf[self.volume_type]
         self.redant.setup_volume(self.vol_name, self.server_list[0],
                                  conf_hash, self.server_list,


### PR DESCRIPTION
The current custom setup requires that the
setup custom variable is set. But this puts
the onus on to the user to properly know the variable
and use it. But this can be replaced with a decorator.

Now this decorator could be further used to define
what the parent itself is supposed to do.
There are many a cases wherein cluster is not required
from the parent and even a volume is not needed
in the started state. This can be controlled
with the help of arguments passed to the decorator
and eventually used in the parent while the setup
is going on.

Fixes: #742

Signed-off-by: srijan-sivakumar <ssivakum@redhat.com>

<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
