### PR TITLE
Fixed form_brick_cmd and replace_brick_from_volume

### DIFF
--- a/tests/example/sample_component/test_brick_ops.py
+++ b/tests/example/sample_component/test_brick_ops.py
@@ -4,7 +4,7 @@ get_all_bricks_online
 get_all_bricks_offline
 """
 
-# disruptive;dist-rep,dist,rep
+# disruptive;dist-rep,rep
 
 from tests.d_parent_test import DParentTest
 
@@ -87,6 +87,21 @@ class TestCase(DParentTest):
         if not redant.wait_for_vol_to_come_online(self.vol_name,
                                                   self.server_list[0]):
             raise Exception(f"Volume {self.vol_name} couldn't be started.")
+
+        existing_bricks = redant.get_all_bricks(self.vol_name,
+                                                self.server_list[0])
+        if existing_bricks is None:
+            raise Exception("Failed to get the bricks list")
+
+        for brick_to_replace in existing_bricks:
+            ret = (redant.
+                   replace_brick_from_volume(self.vol_name,
+                                             self.server_list[0],
+                                             self.server_list,
+                                             src_brick=brick_to_replace,
+                                             brick_roots=self.brick_roots))
+            if not ret:
+                raise Exception(f"Replace of {brick_to_replace} failed")
 
         # Brick additions
         if self.volume_type != 'dist':


### PR DESCRIPTION
The form brick cmd is not suitable for replace brick. Let's suppose if a test case demands multiple bricks to replace, then in that  case the following code:
```python
     if add_flag:
            brick_list = self.get_all_bricks(volname, server_list[0])
            last_brick_num = int(brick_list[-1].split('-')[-1])
            iter_add = len(brick_list)
            if last_brick_num >= iter_add:
                iter_add += 1
```
This will create the same brick always as the replace brick doesn't change the length of the brick_list. In that case, even if we had 0,1, 2 as the brick numbers. For the first replace it will work fine and we will have 3,1,2 but for the second replace it will again try to replace brick with 3 as the length is the same and the last brick is still 2.

Hence added a loop to get the max number of brick in the bricks list and
then increment that number by 1 and store in iter_add to take care of
multiple replacements.

In replace_brick_from_volume, added brick_roots as a param and renamed
self.vol_name with volname.

Added the replace brick operation in the test_brick_ops tc to check
proper execution of the rest of the functions related to the modified
ops.

Fixes: #758
Signed-off-by: Ayush Ujjwal <aujjwal@redhat.com>
