### PR TITLE
[Core] Removed the usage of cleands structure in the framework

### DIFF
--- a/common/ops/gluster_ops/brick_ops.py
+++ b/common/ops/gluster_ops/brick_ops.py
@@ -238,9 +238,9 @@ class BrickOps(AbstractOps):
 
         # Delete old brick
         if delete_brick:
-            brick_node, brick_path = src_brick.split(':')
-            brick_dict_remove = {brick_node: [brick_path]}
-            self.es.add_data_to_cleands(brick_dict_remove)
+            ret = self.delete_bricks(src_brick)
+            if not ret:
+                return False
 
         return True
 
@@ -592,17 +592,6 @@ class BrickOps(AbstractOps):
                 bricks_list_to_remove.extend(random.choice(subvols_list))
 
         return list(set(bricks_list_to_remove))
-
-    def cleanup_brick_dirs(self):
-        """
-        This function requests for the cleands and clears the brick dirs which
-        have been populated in it.
-        """
-        cleands_val = list(self.es.get_cleands_data().items())
-        for (node, b_dir_l) in cleands_val:
-            for b_dir in b_dir_l:
-                self.execute_abstract_op_node(f"rm -rf {b_dir}", node)
-                self.es.remove_val_from_cleands(node, b_dir)
 
     def are_bricks_offline(self, volname: str,
                            bricks_list: list, node: str,
@@ -1045,6 +1034,9 @@ class BrickOps(AbstractOps):
             bool : True if all the bricks are deleted. False, otherwise.
 
         """
+        if not isinstance(bricks_list, list):
+            bricks_list = [bricks_list]
+
         _rc = True
         for brick in bricks_list:
             brick_node, brick_path = brick.split(":")

--- a/core/environ.py
+++ b/core/environ.py
@@ -131,7 +131,6 @@ class FrameworkEnv:
         current state of the environment used to run the framework.
         """
         self.volds = {}
-        self.cleands = {}
         self.clusteropt = {}
 
     def _validate_volname(self, volname: str):
@@ -387,14 +386,12 @@ class FrameworkEnv:
 
     def remove_bricks_from_brickdata(self, volname: str, brick_data: dict):
         """
-        Method to remove the brick brickdata and add it to the cleands
-        dictionary.
+        Method to remove the brick brickdata
         """
         self._validate_volname(volname)
         for node in brick_data:
             for brick in brick_data[node]:
                 self.volds[volname]["brickdata"][node].remove(brick)
-        self.add_data_to_cleands(brick_data)
 
     def get_brickdata(self, volname: str) -> dict:
         """
@@ -555,50 +552,6 @@ class FrameworkEnv:
         elif self.volds[volname]['options'] != {} and \
                 option in self.volds[volname]['options']:
             del self.volds[volname]['options'][option]
-
-    def add_data_to_cleands(self, brickdata: dict):
-        """
-        Method to store the bricks to be cleaned up per node. This
-        is to be accessed when the TC ends.
-        Arg:
-            brickdata (dict) : A dictionary containing keys of node IPs
-                               and the corresponding values being list of
-                               brick paths.
-        """
-        for node in brickdata:
-            if node not in list(self.cleands):
-                self.cleands[node] = []
-            self.cleands[node] += brickdata[node]
-
-    def remove_val_from_cleands(self, node: str, brick_dir: str):
-        """
-        remove a specific brick_dir from the node list.
-        Args:
-            node (str)
-            brick_dir (str)
-        """
-        if len(self.cleands[node]) == 1:
-            del self.cleands[node]
-        else:
-            self.cleands[node].remove(brick_dir)
-
-    def get_cleands_data(self, node: list = None) -> dict:
-        """
-        Method to obtain the cleands values pertaining to a node
-        or all nodes.
-        Arg:
-            node (list) : Can be None or list of nodes.
-        Returns:
-            A dictionary of bricks to be cleaned for a node.
-        """
-        if node is None:
-            return copy.deepcopy(self.cleands)
-        ret_val = {}
-        for n in node:
-            if n not in self.cleands.keys():
-                raise Exception(f"No data for node {n}")
-            ret_val[n] = self.cleands[n]
-        return ret_val
 
     def get_volume_nodes(self, volname: str):
         """

--- a/docs/BP/Ops/brick_ops.md
+++ b/docs/BP/Ops/brick_ops.md
@@ -99,17 +99,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			self.form_brick_cmd(self.server_list, self.brick_root, self.vol_name, mul_factor, True)
 
-6) **cleanup_brick_dirs**<br>
-		Function for clearing out all the directory paths present in the cleands data structure.
-
-		Args:
-			None
-		Returns:
-			None
-		Example:
-			self.cleanup_brick_dirs()
-
-7) **are_bricks_offline**<br>
+6) **are_bricks_offline**<br>
 		This function checks if the given list of bricks are offline.
 
 		Args:
@@ -122,7 +112,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			redant.are_bricks_offline(self.vol_name, bricks_list, self.server_list[0])
 
-8) **check_if_bricks_list_changed**<br>
+7) **check_if_bricks_list_changed**<br>
 		Function checks if the bricks list changed. Basically, compares the bricks list with the bricks attained from volume info.
 
  		Args:
@@ -135,7 +125,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			redant.check_if_bricks_list_changed(bricks_list, self.vol_name, self.server_list[0])
 
-9) **get_all_bricks**<br>
+8) **get_all_bricks**<br>
 		Function to get the list of all the bricks of the specified volume.
 
 		Args:
@@ -146,7 +136,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			self.get_all_bricks(self.vol_name, self.server_list[0])
 
-10) **get_online_bricks_list**<br>
+9) **get_online_bricks_list**<br>
 		Function to get the list of all bricks which are online.
 
 		Args:
@@ -157,7 +147,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			online_list = self.get_online_bricks_list(self.vol_name, self.server_list[2])
 
-11) **get_offline_bricks_list**<br>
+10) **get_offline_bricks_list**<br>
 		Function to get the list of all bricks which are offline.
 
 		Args:
@@ -168,7 +158,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			offline_list = self.get_offline_bricks_list(self.vol_name, self.server_list[2])
 
-12) **bring_bricks_offline**<br>
+11) **bring_bricks_offline**<br>
 		Function to bring the given seet of bricks offline.
 
 		Args:
@@ -180,7 +170,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			self.bring_bricks_offline(self.volname, self.brick_list[2:4])
 
-13) **bring_bricks_online**<br>
+12) **bring_bricks_online**<br>
 		Function to bring the given seet of bricks online.
 
 		Args:
@@ -192,7 +182,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			self.bring_bricks_offline(self.volname, self.brick_list[2:4])
 
-14) **wait_for_bricks_to_go_offline**<br>
+13) **wait_for_bricks_to_go_offline**<br>
 		Function to wait till a given set of bricks go offline
 
 		Args:
@@ -204,7 +194,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			self.wait_for_bricks_to_go_offline(self.vol_name, self.brick_list, timeout)
 
-15) **wait_for_bricks_to_come_online**<br>
+14) **wait_for_bricks_to_come_online**<br>
 		Function to wait till a given set of bricks come online
 
 		Args:
@@ -217,7 +207,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			self.wait_for_bricks_to_come_online(self.volname, self.server_list, self.brick_list, timeout)
 
-16) **replace_brick_from_volume**<br>
+15) **replace_brick_from_volume**<br>
 		Function to replace a faulty brick from a volume.
 
 		Args:
@@ -241,7 +231,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 											 brick_to_replace,
 											 new_brick_to_replace)
 
-17) **are_bricks_online**<br>
+16) **are_bricks_online**<br>
 		Function to check if the given list of bricks are online.
 
 		Args:
@@ -256,7 +246,7 @@ Remove brick does the opposite of add_brick operation and that is it removes exi
 		Example:
 			redant.are_bricks_online(self.vol_name, bricks_list, self.server_list[0])
 
-18) **get_brick_processes_count**<br>
+17) **get_brick_processes_count**<br>
 		This function helps in getting the brick process count for a given node.
 
         Args:

--- a/tests/nd_parent_test.py
+++ b/tests/nd_parent_test.py
@@ -97,5 +97,4 @@ class NdParentTest(metaclass=abc.ABCMeta):
                 tb = traceback.format_exc()
                 self.redant.logger.error(e)
                 self.redant.logger.error(tb)
-        self.redant.cleanup_brick_dirs()
         self.redant.deconstruct_connection()

--- a/tests/vol_destroy_test.py
+++ b/tests/vol_destroy_test.py
@@ -31,4 +31,3 @@ class VolDestroy(LazyParentTest):
         """
         volume_nodes = self.redant.es.get_volume_nodes(self.vol_name)
         self.redant.cleanup_volume(self.vol_name, volume_nodes[0])
-        redant.cleanup_brick_dirs()


### PR DESCRIPTION
Removed the cleands structure from the framework and let the deleting of
the bricks are handled when all the TCs are completed or if the volume
is cleaned-up.

Fixes: #765

Signed-off-by: nik-redhat <nladha@redhat.com>