### PR TITLE
Core: Update to allow directories in excluded list

### DIFF
--- a/core/parsing/params_handler.py
+++ b/core/parsing/params_handler.py
@@ -170,7 +170,7 @@ class ParamsHandler:
         """
         ret = self.config_hashmap.get("excluded_tests", [])
         for paths in ret:
-            if not os.path.isfile(paths):
+            if not os.path.isfile(paths) and not os.path.isdir(paths):
                 return ([], False)
 
         return (ret, True)

--- a/core/test_list_builder.py
+++ b/core/test_list_builder.py
@@ -62,12 +62,16 @@ class TestListBuilder:
         global valid_vol_types
         # Obtaining list of paths to the TCs under given directory.
         if not single_tc:
-            for root, _, files in os.walk(path, onerror=path_error_handler):
-                for tfile in files:
-                    if tfile.endswith(".py") and tfile.startswith("test"):
-                        test_case_path = os.path.join(root, tfile)
-                        if test_case_path not in excluded_tests:
-                            cls.tests_path_list.append(test_case_path)
+            if path not in excluded_tests:
+                for root, _, files in os.walk(path,
+                                              onerror=path_error_handler):
+                    if root not in excluded_tests:
+                        for tfile in files:
+                            if tfile.endswith(".py") and \
+                               tfile.startswith("test"):
+                                test_case_path = os.path.join(root, tfile)
+                                if test_case_path not in excluded_tests:
+                                    cls.tests_path_list.append(test_case_path)
 
         elif path not in excluded_tests:
             cls.tests_path_list.append(path)


### PR DESCRIPTION
### Description:

Updated the code to allow directories to be added to the exclude list as well.

**NOTE:**
If the directory is marked as excluded, the user can still run the tests within that directory individually. It is because of the way os.walk works, it doesn't segregate the root folder for the exact TC path.

Signed-off-by: nik-redhat <nladha@redhat.com>



<!--
Thank you for contributing to Redant! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. If logging then check the logging.md file in common/
4. Remember to check the linting issues beforehand as well to prevent your checks from failing.
5. Remember to sign-off your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
